### PR TITLE
build: move warning to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,3 +155,6 @@ AC_CONFIG_FILES([
 	web/Makefile
 ])
 AC_OUTPUT
+
+test "${with_math}" != "yes" && AC_MSG_WARN([You are building without math. math allows accurate calculations. It should be enabled.])
+test "${with_zlib}" != "yes" && AC_MSG_WARN([You are building without zlib. zlib allows netdata to trasnfer a lot less data with web clients. It should be enabled.])

--- a/src/storage_number.c
+++ b/src/storage_number.c
@@ -3,8 +3,6 @@
 #endif
 #ifdef STORAGE_WITH_MATH
 #include <math.h>
-#else
-#warning "You are building without math. math allows accurate calculations. It should be enabled."
 #endif
 
 #include "common.h"

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -229,8 +229,6 @@ void web_client_reset(struct web_client *w)
 
 #ifdef NETDATA_WITH_ZLIB
 	if(likely(w->zoutput)) sent = (long)w->zstream.total_out;
-#else
-#warning "You are building without zlib. zlib allows netdata to trasnfer a lot less data with web clients. It should be enabled."
 #endif
 
 	long size = (w->mode == WEB_CLIENT_MODE_FILECOPY)?w->data->rbytes:w->data->bytes;


### PR DESCRIPTION
all customization/warning/interaction should be at autoconf level

compile time is too late.

Note: maybe these should not be optional at all.