### PR TITLE
Add Dockerfile to run as a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:sid
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install zlib1g-dev gcc make git autoconf autogen automake pkg-config  
+
+RUN git clone https://github.com/firehol/netdata.git netdata.git --depth=1 && \
+   cd netdata.git && \
+   ./netdata-installer.sh
+
+EXPOSE 19999
+
+ENTRYPOINT ["/usr/sbin/netdata", "-nd"]


### PR DESCRIPTION
Hello there!

I hope PRs are welcomed :).

I found very fancy your monitoring application as well as an interactive web UI. I think it would be cool if you can run your application within a container. Therefore I decided to make this PR to be able to run your monitoring tool as a Docker container in my cluster.

As an example, you could run `netdata` as a container by simply:

`docker run -it --privileged --pid=host --net=host -p 19999:19999 hectorj2f/netdata`