### PR TITLE
Add virtio to whitelist in diskstats plugin

### DIFF
--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -195,6 +195,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 			case 135: // scsi
 			case 153: // raid
 			case 202: // xen
+			case 253: // virtio
 			case 256: // flash
 			case 257: // flash
 				if(minor % 16) def_enabled = 0; // partitions


### PR DESCRIPTION
Hi,

I noticed that when testing netdata vda devices default to not being monitored. I had a look, and Xen equivalent devices *do* get monitored, so I think this is just a case of adding a new major number to make KVM and Xen guest support equivalent.