### PR TITLE
Fixes to netdata.spec.in to build on CentOS/RHEL

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -7,11 +7,13 @@ URL:		http://firehol.org
 Source:		%{name}-@PACKAGE_VERSION@.tar.bz2
 
 BuildRequires:	libmnl-devel
-BuildRequires:	libnetfilter_acct-devel
 BuildRequires:	zlib-devel
 Requires:	libmnl
-Requires:	libnetfilter_acct
 Requires:	zlib
+%if !0%{?rhel}
+Requires:	libnetfilter_acct
+BuildRequires:	libnetfilter_acct-devel
+%endif
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -32,7 +34,9 @@ getent passwd netdata > /dev/null || useradd -r -g netdata -c netdata -s /sbin/n
 %build
 %configure \
 	--docdir="%{_docdir}/%{name}-%{version}" \
+%if !0%{?rhel}
 	--enable-plugin-nfacct \
+%endif
 	--with-zlib \
 	--with-math \
 	--with-user=netdata \
@@ -48,7 +52,11 @@ find "%{buildroot}" -name .keep -exec rm {} \;
 %attr(-, netdata, netdata) %dir %{_localstatedir}/cache/%{name}/
 %attr(-, netdata, netdata) %dir %{_localstatedir}/log/%{name}/
 %config(noreplace) %{_sysconfdir}/%{name}/
+%if 0%{?rhel}
+%{_sbindir}/%{name}
+%else
 %{_bindir}/%{name}
+%endif
 %{_datadir}/%{name}/
 %{_libexecdir}/%{name}/
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -47,18 +47,25 @@ make %{?_smp_mflags}
 rm -rf "%{buildroot}"
 make %{?_smp_mflags} install DESTDIR="%{buildroot}"
 find "%{buildroot}" -name .keep -exec rm {} \;
+touch %{buildroot}/%{_sysconfdir}/netdata/netdata.conf
+%if 0%{?fedora} || 0%{?rhel} >= 7 
+install -m 0644 -D system/netdata-systemd ${RPM_BUILD_ROOT}%{_unitdir}/netdata.service
+%endif
 
 %files
 %attr(-, netdata, netdata) %dir %{_localstatedir}/cache/%{name}/
 %attr(-, netdata, netdata) %dir %{_localstatedir}/log/%{name}/
+%attr(-, netdata, netdata) %{_datadir}/%{name}/
 %config(noreplace) %{_sysconfdir}/%{name}/
 %if 0%{?rhel}
 %{_sbindir}/%{name}
 %else
 %{_bindir}/%{name}
 %endif
-%{_datadir}/%{name}/
 %{_libexecdir}/%{name}/
+%if 0%{?fedora} || 0%{?rhel} >= 7 
+%{_unitdir}/netdata.service
+%endif
 
 %changelog
 * Tue Mar 22 2016 Costa Tsaousis <costa@tsaousis.gr> - 1.0.0-1

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -14,6 +14,9 @@ Requires:	zlib
 Requires:	libnetfilter_acct
 BuildRequires:	libnetfilter_acct-devel
 %endif
+%if 0%{?fedora} || 0%{?rhel} >= 7
+BuildRequires: systemd
+%endif
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -50,6 +53,17 @@ find "%{buildroot}" -name .keep -exec rm {} \;
 touch %{buildroot}/%{_sysconfdir}/netdata/netdata.conf
 %if 0%{?fedora} || 0%{?rhel} >= 7 
 install -m 0644 -D system/netdata-systemd ${RPM_BUILD_ROOT}%{_unitdir}/netdata.service
+%endif
+
+%if 0%{?fedora} || 0%{?rhel} >= 7
+%post
+%systemd_post netdata.service
+
+%preun
+%systemd_preun netdata.service
+
+%postun
+%systemd_postun_with_restart netdata.service
 %endif
 
 %files


### PR DESCRIPTION
Tested on CentOS 6 and 7.

Not sure if the last %if/%else is even necessary, or if the existing spec is broken everywhere currently.  Are there any RPM-based distros where the binary would be built in (/usr)/bin instead of (/usr)/sbin?