### PR TITLE
Add cjdns app group

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -54,6 +54,7 @@ nms: snmpd vnstatd smokeping zabbix_agentd monit munin-node mon openhpid
 ppp: ppp pppd pptpd pptpctrl
 inetd: inetd xinetd
 openvpn: openvpn
+cjdns: cjdroute
 cron: cron atd
 ha: corosync hs_logd ha_logd stonithd
 ipvs: ipvs_syncmaster ipvs_syncbackup


### PR DESCRIPTION
cjdns is a crypto networking software.

I will understand if you are not willing to pull-in this change, cjdns isn't the most popular software ever.