### PR TITLE
updated Gentoo Ebuild

### DIFF
--- a/netdata-9999.ebuild
+++ b/netdata-9999.ebuild
@@ -1,47 +1,92 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
-inherit autotools git-2 user
+inherit linux-info systemd user
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="git://github.com/firehol/${PN}.git"
+	EGIT_BRANCH="master"
+	inherit git-r3 autotools
+	SRC_URI=""
+	KEYWORDS=""
+else
+	SRC_URI="http://firehol.org/download/${PN}/releases/v${PV}/${P}.tar.xz"
+fi
+
 
 DESCRIPTION="Linux real time system monitoring, over the web!"
 HOMEPAGE="https://github.com/firehol/netdata"
-EGIT_REPO_URI="https://github.com/firehol/netdata"
 
-LICENSE="GPL-2+"
+LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS=""
-IUSE="nfacct +zlib"
+KEYWORDS="~amd64 ~x86"
+IUSE="+zlib nfacct nodejs"
 
-RDEPEND="zlib? ( sys-libs/zlib )
+# most unconditional dependencies are for plugins.d/charts.d.plugin:
+RDEPEND=">=app-shells/bash-4
+	sys-apps/sed
+	sys-apps/grep
+	virtual/awk
+	net-misc/curl
+	net-misc/wget
+	
+	zlib? ( sys-libs/zlib )
+	
 	nfacct? (
 		net-firewall/nfacct
 		net-libs/libmnl
+	)
+
+	nodejs? (
+		net-libs/nodejs
 	)"
+
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
+# check for Kernel-Samepage-Merging (CONFIG_KSM)
+CONFIG_CHECK="
+	~KSM
+"
+
 pkg_setup() {
-	enewgroup netdata
-	enewuser netdata -1 -1 / netdata
+	linux-info_pkg_setup
+
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 / ${PN}
+}
+
+src_unpack() {
+	if [[ ${PV} == "9999" ]] ; then
+		git-r3_src_unpack
+	fi
+	default
 }
 
 src_prepare() {
-	eautoreconf
+	if [[ ${PV} == "9999" ]] ; then
+		eautoreconf
+	fi
+	default
 }
 
 src_configure() {
 	econf \
-		--localstatedir="${EROOT}var" \
+		--localstatedir=/var \
 		$(use_enable nfacct plugin-nfacct) \
 		$(use_with zlib) \
-		--with-user=netdata
+		--with-user=${PN} \
+		|| die "configure failed"
 }
 
 src_install() {
 	default
-	fowners netdata /var/log/netdata
-	rm -fr "${ED}/var/cache/netdata"
+
+	fowners ${PN} /var/log/netdata
+
+	newinitd system/netdata-openrc ${PN}
+	systemd_newunit system/netdata-systemd ${PN}.service
 }


### PR DESCRIPTION
+ made "hybrid" ebuild, which switches between
  release and live builds, just symlink the
  file like `netdata-1.0.0.ebuild -> netdata-9999.ebuild`
+ `USE=nodejs` to pull (any) nodejs version
* add more runtime dependencies (mostly needed
  by `plugins.d/charts.d.plugin`)
+ checks for (but only warns) `CONFIG_KSM` enabled Kernel
+ installs Open-RC and systemd startup scripts
* EAPI 5 -> 6