### PR TITLE
Update README.md to include release URL (#131)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ MAINTAINERCLEANFILES= \
 EXTRA_DIST = \
 	.gitignore \
 	autogen.sh \
-	README.md \
+	README \
 	LICENSE.md \
 	autogen.sh \
 	netdata-9999.ebuild \
@@ -36,6 +36,15 @@ SUBDIRS = \
 	src \
 	web \
 	$(NULL)
+
+if GIT_TREE
+
+all-local: README
+
+README: README.md
+	sed -e '/^## Features$$/p' -e '/^## Git/,/^## Features$$/d' $< > $@
+
+endif
 
 dist_noinst_DATA = netdata.spec
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ---
 
+## Git sources
+
+You are looking at a version of the sources extracted directly from git.
+If you want a version of the source package where `configure` and any
+documentation has been built for you, please get an official
+[netdata package download](https://firehol.org/download/netdata/).
+The `unsigned/master` folder tracks the head of the git tree and
+released packages are also available.
+
 ## Features
 
 **netdata** is a highly optimized Linux daemon providing **real-time performance monitoring for Linux systems, Applications, SNMP devices, over the web**!

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed 's/^_//')"
 
 AC_INIT([netdata], VERSION_NUMBER[]VERSION_SUFFIX)
 
+AM_CONDITIONAL([GIT_TREE], [test -f README.md])
+
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then
 AC_MSG_NOTICE(***************** MAINTAINER MODE *****************)


### PR DESCRIPTION
Make it clear the user has got a git version that does not include
the configure script. Also has the advantage of publishing the location
when browsing the repository.

Remove the as part of the build, so that someone who gets a source
package with ./configure already does not get confused.