### PR TITLE
Change squid polling to use squidclient

### DIFF
--- a/charts.d/squid.chart.sh
+++ b/charts.d/squid.chart.sh
@@ -9,14 +9,7 @@ squid_priority=60000
 
 squid_get_stats_internal() {
 	local host="$1" port="$2" url="$3"
-
-	nc -w $squid_timeout $host $port <<EOF
-GET $url HTTP/1.0
-Host: $host:$port
-Accept: */*
-User-Agent: netdata (charts.d/squid.chart.sh)
-
-EOF
+	squidclient -h $host -p $port $url
 }
 
 squid_get_stats() {
@@ -47,8 +40,8 @@ squid_autodetect() {
 }
 
 squid_check() {
-	require_cmd nc    || return 1
-	require_cmd sed   || return 1
+	require_cmd squidclient || return 1
+	require_cmd sed || return 1
 	require_cmd egrep || return 1
 
 	if [ -z "$squid_host" -o -z "$squid_port" -o -z "$squid_url" ]


### PR DESCRIPTION
Use squidclient instead of manually aggregating data from netcat. This
should allow for a more supported and robust operation.

FWIW, I couldn't get the squid chart to work while using netcat. Perhaps I was doing something wrong, but I think this is a good change to have at any case. I think it would also allow SSL support in the future with a few additional parameters.