### PR TITLE
do not skip creation of the version.txt file

### DIFF
--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -99,6 +99,8 @@ version.txt:
 			rm -f v.tmp; \
 			false; \
 		fi; \
+	else \
+		echo > version.txt; \
 	fi
 
 .PHONY: version.txt


### PR DESCRIPTION
This probably for @philwhineray - patch 2d24458219f9c307c4b6310abf0d53d79e98de0d breaks building in a clean autobuild environment, such as sbuild.

It's probably slightly unusual, but the situation looks like this -
* git installed on the host machine, and is used to check out the source. So there is a .git directory;
* sbuild used to build a clean debian package, which builds within a minimal chroot;
* git is not installed in the chroot, but .git directory exists;
* build install fails because version.txt does not exist.

One fix would be to make the packaging have a build-depend on git being installed, but that's just messy for people who build from releases. So probably better to just create an artificial version.txt so that make install doesn't error. Alternative might be for the Debian packaging to just touch web/version.txt in case it can't be created, but that feels a little messy. But there may be another cleaner way!

I think this is most likely to hit auto build systems which check out from git and then build in a chroot. Debian is affected with sbuild; don't know about other autobuild systems.

Of course, it might be better to put something more useful in version.txt rather than just create an empty file, but I don't know what that might be :)

(09d80f67354c9d992e84f7a564b4b1874eeb82fd is related, but still doesn't fix this particular issue)