### PR TITLE
Fixed PIDFile usage in systemd unit file

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -8,7 +8,7 @@ WorkingDirectory=/tmp
 User=root
 Group=root
 PIDFile=@localstatedir_POST@/run/netdata/netdata.pid
-ExecStart=@sbindir_POST@/netdata -pidfile $PIDFile
+ExecStart=@sbindir_POST@/netdata -pidfile @localstatedir_POST@/run/netdata/netdata.pid
 ExecStop=/bin/kill -SIGTERM $MAINPID
 TimeoutStopSec=30
 


### PR DESCRIPTION
Currently unit file for systemd is broken.
The problem was raised in #188, but was not fixed.
The reason to this is that systemd does not replace `$PIDFile` variable at all, so the execution line is:
`/usr/bin/netdata -pidfile`. Which result in `Cannot understand option '-pidfile'` error.

This pull request fixes the problem.

FYI the program itself fails to create a PID file, when a path to it is: `/var/run/netdata/netdata.pid`. It is probably because of the missing `netdata` folder inside `/var/run/`. Having the path as `/var/run/netdata.pid` works. Anyway this is out of this pull request scope. Just FYI.

_More about `PIDFile` option can be found at_ [https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile=](https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile=)