### PR TITLE
Replace README info with detection of autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ MAINTAINERCLEANFILES= \
 EXTRA_DIST = \
 	.gitignore \
 	autogen.sh \
-	README \
+	README.md \
 	LICENSE.md \
 	COPYING \
 	autogen.sh \
@@ -36,15 +36,6 @@ SUBDIRS = \
 	system \
 	web \
 	$(NULL)
-
-if GIT_TREE
-
-all-local: README
-
-README: README.md
-	sed -e '/^## Git/,/^$$/{d;p}' $< > $@
-
-endif
 
 dist_noinst_DATA = netdata.spec
 

--- a/README.md
+++ b/README.md
@@ -109,14 +109,3 @@ It should run on any Linux system. We have tested it on:
 ## Documentation
 
 Check the **[netdata wiki](https://github.com/firehol/netdata/wiki)**.
-
-
-## Git sources
-
-You are looking at a version of the sources extracted directly from git.
-If you want a version of the source package where `configure` and any
-documentation has been built for you, please get an official
-[netdata package download](https://firehol.org/download/netdata/).
-The `unsigned/master` folder tracks the head of the git tree and
-released packages are also available.
-

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,6 @@ PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed 's/^_//')"
 
 AC_INIT([netdata], VERSION_NUMBER[]VERSION_SUFFIX)
 
-AM_CONDITIONAL([GIT_TREE], [test -f README.md])
-
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then
 AC_MSG_NOTICE(***************** MAINTAINER MODE *****************)


### PR DESCRIPTION
This will ensure people get informed about the necessary tools and
how to get the package pre-configured without requiring the readme
to be modified when packaged.

In addition, the script will not run autoreconf unilaterally so when
people have an old version it will not attempt to overwrite the
pre-existing configure script.

Should solve #131 and also #93 as well as recent comments on README.md