### PR TITLE
Change Anti-DDoS Protection wording

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -993,8 +993,8 @@ var submenuData = {
 	},
 
 	'netfilter.synproxy': {
-		title: 'Anti-DDoS Protection',
-		info: 'Anti-DDoS Protection performance monitoring read from <code>/proc/net/stat/synproxy</code>. <a href="https://github.com/firehol/firehol/wiki/Working-with-SYNPROXY" target="_blank">SYNPROXY</a> is a TCP SYN packets proxy. It is used to protect any TCP server (like a web server) from SYN floods and similar DDoS attacks. It is a netfilter module, in the Linux kernel (since version 3.12). It is optimized to handle millions of packets per second utilizing all CPUs available without any concurrency locking between the connections. It can be used for any kind of TCP traffic (even encrypted), since it does not interfere with the content itself.'
+		title: 'DDoS Protection',
+		info: 'DDoS Protection performance monitoring read from <code>/proc/net/stat/synproxy</code>. <a href="https://github.com/firehol/firehol/wiki/Working-with-SYNPROXY" target="_blank">SYNPROXY</a> is a TCP SYN packets proxy. It is used to protect any TCP server (like a web server) from SYN floods and similar DDoS attacks. It is a netfilter module, in the Linux kernel (since version 3.12). It is optimized to handle millions of packets per second utilizing all CPUs available without any concurrency locking between the connections. It can be used for any kind of TCP traffic (even encrypted), since it does not interfere with the content itself.'
 	}
 };
 


### PR DESCRIPTION
Minor nit-pick: 'Anti-DDoS Protection' is a double negation. I think it's more correct to either call it 'Anti-DDoS' or 'DDoS Protection'.