### PR TITLE
add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+compiler:
+ - gcc
+ - clang
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq automake make
+script: ./autogen.sh && ./configure && make -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ compiler:
  - clang
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq automake make
+ - sudo apt-get install -qq automake make zlib1g-dev
 script: ./autogen.sh && ./configure && make -j4


### PR DESCRIPTION
seems current master (1188686) is broken:

```
make[2]: Entering directory '/home/users/glen/rpm/packages/netdata/netdata/netdata-1.0.1_master/src'
gcc     -g -O2 -pthread   -o netdata appconfig.o avl.o common.o daemon.o dictionary.o global_statistics.o log.o main.o plugin_checks.o plugin_idlejitter.o plugin_nfacct.o plugin_proc.o plugin_tc.o plugins_d.o popen.o proc_diskstats.o proc_interrupts.o proc_softirqs.o proc_loadavg.o proc_meminfo.o proc_net_dev.o proc_net_ip_vs_stats.o proc_net_netstat.o proc_net_rpc_nfsd.o proc_net_snmp.o proc_net_snmp6.o proc_net_stat_conntrack.o proc_stat.o proc_sys_kernel_random_entropy_avail.o proc_vmstat.o sys_kernel_mm_ksm.o procfile.o rrd.o rrd2json.o storage_number.o unit_test.o url.o web_buffer.o web_client.o web_server.o -lm  -lz  
plugin_proc.o: In function `proc_main':
/home/users/glen/rpm/packages/netdata/netdata/netdata-1.0.1_master/src/plugin_proc.c:202: undefined reference to `do_proc_net_stat_synproxy'
```

so decided to add travis integration to catch such compile errors sooner

currently the file is based on https://github.com/glensc/nagios-snmp-plugins/blob/master/.travis.yml, can be extended to do more