### PR TITLE
Add httpd to apache process group

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -49,7 +49,7 @@ compile: cc1 cc1plus as gcc* ld make automake autoconf git
 rsync: rsync
 media: mplayer vlc xine mediatomb omxplayer* kodi* xbmc* mediacenter eventlircd
 squid: squid* c-icap
-apache: apache*
+apache: apache* httpd
 mysql: mysql*
 asterisk: asterisk
 opensips: opensips* stund


### PR DESCRIPTION
The default Apache distribution, as well as Red Hat/CentOS packages, use 'httpd' instead of 'apache' or 'apache2' for the daemon executable filename. This PR adds httpd to apps_groups.conf to correctly categorize httpd as Apache on such systems.