### PR TITLE
older browsers compatibility fix; online help restored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ set(APPS_PLUGIN_SOURCE_FILES
 	src/log.h
         config.h)
 
+include_directories(AFTER .)
+
 add_definitions(-DHAVE_CONFIG_H -DNETDATA_INTERNAL_CHECKS=1 -DCACHE_DIR="/tmp" -DCONFIG_DIR="/tmp" -DLOG_DIR="/tmp" -DPLUGINS_DIR="/tmp" -DWEB_DIR="/tmp")
 
 add_executable(netdata ${NETDATA_SOURCE_FILES})

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -19,8 +19,28 @@
 // var netdataServer = "http://yourhost:19999"; // set your NetData server
 
 //(function(window, document, undefined) {
+
+	// ------------------------------------------------------------------------
+	// compatibility fixes
+
 	// fix IE issue with console
-	if(!window.console){ window.console = {log: function(){} }; }
+	if(!window.console) { window.console = { log: function(){} }; }
+
+	// if string.endsWith is not defined, define it
+	if(typeof String.prototype.endsWith !== 'function') {
+		String.prototype.endsWith = function(s) {
+			if(s.length > this.length) return false;
+			return this.slice(-s.length) === s;
+		};
+	}
+
+	// if string.startsWith is not defined, define it
+	if(typeof String.prototype.startsWith !== 'function') {
+		String.prototype.startsWith = function(s) {
+			if(s.length > this.length) return false;
+			return this.slice(s.length) === s;
+		};
+	}
 
 	// global namespace
 	var NETDATA = window.NETDATA || {};
@@ -53,7 +73,11 @@
 		NETDATA.serverDefault = netdataServer;
 	else {
 		var s = NETDATA._scriptSource();
-		NETDATA.serverDefault = s.replace(/\/dashboard.js(\?.*)*$/g, "");
+		if(s) NETDATA.serverDefault = s.replace(/\/dashboard.js(\?.*)*$/g, "");
+		else {
+			console.log('WARNING: Cannot detect the URL of the netdata server.');
+			NETDATA.serverDefault = null;
+		}
 	}
 
 	if(NETDATA.serverDefault === null)
@@ -80,7 +104,7 @@
 	NETDATA.google_js    		= 'https://www.google.com/jsapi';
 
 	NETDATA.themes = {
-		default: {
+		white: {
 			bootstrap_css: NETDATA.serverDefault + 'css/bootstrap.min.css',
 			dashboard_css: NETDATA.serverDefault + 'dashboard.css',
 			background: '#FFFFFF',
@@ -124,7 +148,7 @@
 	if(typeof netdataTheme !== 'undefined' && typeof NETDATA.themes[netdataTheme] !== 'undefined')
 		NETDATA.themes.current = NETDATA.themes[netdataTheme];
 	else
-		NETDATA.themes.current = NETDATA.themes.default;
+		NETDATA.themes.current = NETDATA.themes.white;
 
 	NETDATA.colors = NETDATA.themes.current.colors;
 
@@ -5407,7 +5431,7 @@
 
 	NETDATA._loadjQuery(function() {
 		NETDATA.loadRequiredJs(0, function() {
-			if(typeof $().emulateTransitionEnd == 'function') {
+			if(typeof $().emulateTransitionEnd !== 'function') {
 				// bootstrap is not available
 				NETDATA.options.current.show_help = false;
 			}

--- a/web/index.html
+++ b/web/index.html
@@ -330,7 +330,7 @@
 	</script>
 
 	<!-- load the dashboard manager - it will do the rest -->
-	<script type="text/javascript" src="dashboard.js?v32"></script>
+	<script type="text/javascript" src="dashboard.js?v33"></script>
 </head>
 
 <body data-spy="scroll" data-target="#sidebar">
@@ -1841,12 +1841,15 @@ function finalizePage() {
 	// the Dom elements are initially zero-sized
 	NETDATA.parseDom();
 
-	var before = 0, after = 0;
+	var before = 0, after = 0, nowelcome = 0;
 	after = getUrlParameter('force_after_ms');
 	before = getUrlParameter('force_before_ms');
+	nowelcome = (getUrlParameter('nowelcome') === true)?true:false;
 
-	if(before > 0 && after > 0)
+	if(before > 0 && after > 0) {
+		nowelcome = true;
 		NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], after, before);
+	}
 
 	// let it run (update the charts)
 	NETDATA.unpause();
@@ -1939,11 +1942,11 @@ function finalizePage() {
 	// this has to be the last
 	// it reloads the page
 	$('#netdata_theme_control').change(function() {
-		if(setTheme($(this).prop('checked')?'slate':'default'))
+		if(setTheme($(this).prop('checked')?'slate':'white'))
 			location.reload();
 	});
 
-	if(isdemo()) {
+	if(!nowelcome && isdemo()) {
 		setTimeout(function() {
 			$('#welcomeModal').modal();
 		}, 1000);


### PR DESCRIPTION
1. Using browserstack.com I found the dashboard was not visible for most mobile browsers. This was caused by the use of `string.startsWith()` and `string.endsWith()` introduced with #278. This bug is present in the current v1.1.0 release.

2. Fixed a bug introduced with #290 due to #286 that resulted in online help being always disabled. This bug is not present ins the current v1.1.0 release.