### PR TITLE
CORS and dashboard fixes

### DIFF
--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1428,17 +1428,22 @@ void web_client_process(struct web_client *w) {
 		"HTTP/1.1 %d %s\r\n"
 		"Connection: %s\r\n"
 		"Server: NetData Embedded HTTP Server\r\n"
-		"Content-Type: %s\r\n"
 		"Access-Control-Allow-Origin: *\r\n"
-		"Access-Control-Allow-Methods: GET, OPTIONS\r\n"
-		"Access-Control-Allow-Headers: accept, x-requested-with\r\n"
-		"Access-Control-Max-Age: 86400\r\n"
+		"Content-Type: %s\r\n"
 		"Date: %s\r\n"
 		, code, code_msg
 		, w->keepalive?"keep-alive":"close"
 		, content_type_string
 		, date
 		);
+
+	if(w->mode == WEB_CLIENT_MODE_OPTIONS) {
+		buffer_strcat(w->response.header_output,
+			"Access-Control-Allow-Methods: GET, OPTIONS\r\n"
+			"Access-Control-Allow-Headers: accept, x-requested-with\r\n"
+			"Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
+			);
+	}
 
 	if(buffer_strlen(w->response.header))
 		buffer_strcat(w->response.header_output, buffer_tostring(w->response.header));
@@ -1449,7 +1454,7 @@ void web_client_process(struct web_client *w) {
 			"Cache-Control: no-cache\r\n"
 			, date);
 	}
-	else {
+	else if(w->mode != WEB_CLIENT_MODE_OPTIONS) {
 		char edate[100];
 		time_t et = w->response.data->date + (86400 * 14);
 		struct tm etmbuf, *etm = gmtime_r(&et, &etmbuf);

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -4,18 +4,19 @@
 MAINTAINERCLEANFILES= $(srcdir)/Makefile.in
 
 dist_web_DATA = \
-	robots.txt \
-	index.html \
 	demo.html \
 	demo2.html \
-	tv.html \
+	demosites.html \
 	dashboard.html \
 	dashboard.js \
 	dashboard.css \
 	dashboard.slate.css \
 	favicon.ico \
+	index.html \
 	netdata-swagger.yaml \
 	netdata-swagger.json \
+	robots.txt \
+	tv.html \
 	version.txt \
 	$(NULL)
 

--- a/web/demosites.html
+++ b/web/demosites.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<title>NetData TV Dashboard</title>
+	<title>NetData Demo Sites Dashboard</title>
 
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta charset="utf-8">
@@ -78,25 +78,23 @@
 
 <div style="width: 100%; text-align: center; display: inline-block;">
 
-	<b>PLEASE RESPECT OUR DEMO SITE RESOURCES - DON'T PUT THIS AS-IS ON TV - CLOSE IT WHEN YOU DON'T NEED IT !</b>
-	
-
-	<div style="width: 100%; height: 24vh; text-align: center; display: inline-block;">
+	<div style="width: 100%; height: 16vh; text-align: center; display: inline-block;">
 		<div style="width: 100%; height: 15px; text-align: center; display: inline-block;">
 			<b>CPU On both servers</b>
 		</div>
 		<div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
 			<br/>
 			<div data-netdata="system.cpu"
-					data-host="http://netdata.firehol.org"
-					data-title="CPU usage of netdata.firehol.org"
+					data-host="//netdata.firehol.org"
+					data-title="CPU usage of EU Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
 					data-after="-300"
 					></div>
 			<div data-netdata="system.cpu"
-					data-title="CPU usage of your netdata server"
+					data-host="//netdata2.firehol.org"
+					data-title="CPU usage of US Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
@@ -106,21 +104,22 @@
 	</div>
 
 
-	<div style="width: 100%; height: 24vh; text-align: center; display: inline-block;">
+	<div style="width: 100%; height: 16vh; text-align: center; display: inline-block;">
 		<div style="width: 100%; height: 15px; text-align: center; display: inline-block;">
 			<b>Disk I/O on both servers</b>
 		</div>
 		<div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
-			<div data-netdata="system.io"
-					data-host="http://netdata.firehol.org"
-					data-title="I/O on netdata.firehol.org"
+			<div data-netdata="tc.world_in"
+					data-host="//netdata.firehol.org"
+					data-title="I/O on EU Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
 					data-after="-300"
 					></div>
-			<div data-netdata="system.io"
-					data-title="I/O on your netdata server"
+			<div data-netdata="tc.world_in"
+					data-host="//netdata2.firehol.org"
+					data-title="I/O on US Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
@@ -129,26 +128,70 @@
 		</div>
 	</div>
 
-
-	<div style="width: 100%; height: 24vh; text-align: center; display: inline-block;">
-		<div style="width: 100%; height: 15px; text-align: center; display: inline-block;">
-			<b>IPv4 traffic on both servers</b>
-		</div>
+	<div style="width: 100%; height: 16vh; text-align: center; display: inline-block;">
 		<div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
-			<div data-netdata="system.ipv4"
-					data-host="http://netdata.firehol.org"
-					data-title="IPv4 traffic on netdata.firehol.org"
+			<div data-netdata="tc.world_out"
+					data-host="//netdata.firehol.org"
+					data-title="I/O on EU Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
 					data-after="-300"
 					></div>
-			<div data-netdata="system.ipv4"
-					data-title="IPv4 traffic on your netdata server"
+			<div data-netdata="tc.world_out"
+					data-host="//netdata2.firehol.org"
+					data-title="I/O on US Server"
 					data-chart-library="dygraph"
 					data-width="49%"
 					data-height="100%"
 					data-after="-300"
+					></div>
+		</div>
+	</div>
+
+	<div style="width: 100%; height: 12vh; text-align: center; display: inline-block;">
+		<div style="width: 100%; height: 15px; text-align: center; display: inline-block;">
+			<b>NGINX performance on both servers</b>
+		</div>
+		<div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
+			<div data-netdata="nginx.connections"
+					data-host="//netdata.firehol.org"
+					data-title="NGINX Connections on EU Server"
+					data-chart-library="dygraph"
+					data-width="49%"
+					data-height="100%"
+					data-after="-300"
+					></div>
+			<div data-netdata="nginx.connections"
+					data-host="//netdata2.firehol.org"
+					data-title="NGINX Connections on US Server"
+					data-chart-library="dygraph"
+					data-width="49%"
+					data-height="100%"
+					data-after="-300"
+					></div>
+		</div>
+	</div>
+
+	<div style="width: 100%; height: 12vh; text-align: center; display: inline-block;">
+		<div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
+			<div data-netdata="nginx.requests"
+					data-host="//netdata.firehol.org"
+					data-title="NGINX Requests on EU Server"
+					data-chart-library="dygraph"
+					data-width="49%"
+					data-height="100%"
+					data-after="-300"
+					data-colors="#5555FF"
+					></div>
+			<div data-netdata="nginx.requests"
+					data-host="//netdata2.firehol.org"
+					data-title="NGINX Requests on US Server"
+					data-chart-library="dygraph"
+					data-width="49%"
+					data-height="100%"
+					data-after="-300"
+					data-colors="#5555FF"
 					></div>
 		</div>
 	</div>
@@ -159,63 +202,65 @@
 		</div>
 		<div style="width: 100%; max-height: calc(100% - 15px); text-align: center; display: inline-block;">
 			<div style="width: 49%; height:100%; align: center; display: inline-block;">
-				netdata.firehol.org
+				EU Server
 				<br/>
-				<div data-netdata="netdata.requests"
-						data-host="http://netdata.firehol.org"
-						data-title="Chart Refreshes/s"
-						data-chart-library="gauge"
-						data-width="20%"
+				<div data-netdata="netdata.net"
+						data-dimensions="out"
+						data-host="//netdata.firehol.org"
+						data-title="Chart Data Traffic"
+						data-chart-library="easypiechart"
+						data-width="16%"
+						data-height="100%"
+						data-after="-300"
+						data-points="300"
+						></div>
+				<div data-netdata="netdata.net"
+						data-dimensions="in"
+						data-host="//netdata.firehol.org"
+						data-title="Requests Traffic"
+						data-chart-library="easypiechart"
+						data-width="16%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
 						></div>
 				<div data-netdata="netdata.clients"
-						data-host="http://netdata.firehol.org"
+						data-host="//netdata.firehol.org"
 						data-title="Sockets"
 						data-chart-library="gauge"
-						data-width="20%"
+						data-width="22%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
 						data-colors="#AA5500"
 						></div>
-				<div data-netdata="netdata.net"
-						data-dimensions="in"
-						data-host="http://netdata.firehol.org"
-						data-title="Requests Traffic"
-						data-chart-library="easypiechart"
-						data-width="15%"
-						data-height="100%"
-						data-after="-300"
-						data-points="300"
-						></div>
-				<div data-netdata="netdata.net"
-						data-dimensions="out"
-						data-host="http://netdata.firehol.org"
-						data-title="Chart Data Traffic"
-						data-chart-library="easypiechart"
-						data-width="15%"
+				<div data-netdata="netdata.requests"
+						data-host="//netdata.firehol.org"
+						data-title="Chart Refreshes/s"
+						data-chart-library="gauge"
+						data-width="22%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
 						></div>
 			</div>
 			<div style="width: 49%; height:100%; align: center; display: inline-block;">
-				your netdata server
+				US Server
 				<br/>
 				<div data-netdata="netdata.requests"
+						data-host="//netdata2.firehol.org"
 						data-title="Chart Refreshes/s"
 						data-chart-library="gauge"
-						data-width="20%"
+						data-width="22%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
 						></div>
 				<div data-netdata="netdata.clients"
+						data-host="//netdata2.firehol.org"
 						data-title="Sockets"
 						data-chart-library="gauge"
-						data-width="20%"
+						data-width="22%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
@@ -223,18 +268,20 @@
 						></div>
 				<div data-netdata="netdata.net"
 						data-dimensions="in"
+						data-host="//netdata2.firehol.org"
 						data-title="Requests Traffic"
 						data-chart-library="easypiechart"
-						data-width="15%"
+						data-width="16%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"
 						></div>
 				<div data-netdata="netdata.net"
 						data-dimensions="out"
+						data-host="//netdata2.firehol.org"
 						data-title="Chart Data Traffic"
 						data-chart-library="easypiechart"
-						data-width="15%"
+						data-width="16%"
 						data-height="100%"
 						data-after="-300"
 						data-points="300"

--- a/web/index.html
+++ b/web/index.html
@@ -330,7 +330,7 @@
 	</script>
 
 	<!-- load the dashboard manager - it will do the rest -->
-	<script type="text/javascript" src="dashboard.js?v33"></script>
+	<script type="text/javascript" src="dashboard.js?v34"></script>
 </head>
 
 <body data-spy="scroll" data-target="#sidebar">
@@ -345,6 +345,20 @@
 				</button>
 				<a href="/" class="navbar-brand" id="hostname">netdata</a>
 			</div>
+			<nav id="demosites_nav" class="collapse navbar-collapse navbar-left" role="navigation">
+				<ul class="nav navbar-nav">
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown" id="current_view">demo sites <strong class="caret"></strong></a>
+						<ul class="dropdown-menu scrollable-menu inpagemenu" role="menu">
+							<li id="demo_eu"><a href="//netdata.firehol.org?nowelcome">EU - London (DigitalOcean.com)</a></li>
+							<li id="demo_us"><a href="//netdata2.firehol.org?nowelcome">US - Atlanta (CDN77.com)</a></li>
+							<li role="separator" class="divider"></li>
+							<li id="demo_tv"><a href="tv.html">TV Dashboard for 2 servers</a></li>
+							<li id="demosites"><a href="demosites.html">Dashboard for monitoring netdata demo sites</a></li>
+						</ul>
+					</li>
+				</ul>
+			</nav>
 			<nav class="collapse navbar-collapse navbar-right" role="navigation">
 				<ul class="nav navbar-nav">
 					<li><a href="#" class="btn" data-toggle="modal" data-target="#optionsModal"><i class="fa fa-cog"></i> settings</a></li>
@@ -783,8 +797,19 @@ function isdemo() {
 	this_is_demo = false;
 
 	try {
-		if(typeof document.location.hostname === 'string')
-			this_is_demo = document.location.hostname.endsWith('.firehol.org');
+		if(typeof document.location.hostname === 'string') {
+			if(document.location.hostname === 'netdata.firehol.org') {
+				document.getElementById("demo_eu").className = "active";
+				this_is_demo = true;
+			}
+			else if(document.location.hostname === 'netdata2.firehol.org') {
+				document.getElementById("demo_us").className = "active";
+				this_is_demo = true;
+			}
+		}
+
+		if(!this_is_demo)
+			document.getElementById("demosites_nav").style.visibility = "hidden";
 	}
 	catch(error) {
 		;


### PR DESCRIPTION

1. When the dashboard is not hosted on netdata, the browsers are making OPTIONS requests to check cross origin site scripting. With this update, the netdata dashboards allow the browsers to cache the CORS response from the servers. Prior to this, the browsers would have to execute 2 requests for every chart refresh (one OPTIONS, one GET). Now the OPTIONS is cached.

2. The parallel refresher of the dashboard had an issue when a slow server (a server with latency, or firewalling that does not reply at all), would make the whole dashboard, every chart, refresh slowly. With this commit, each chart is independent of the others. So, a slow chart will not affect the refresh frequency of the others.

3. The response header of the internal web server, now responds with the full CORS headers only on OPTIONS requests. This saves some bandwidth on chart refreshes.

4. When netdata dashboards is viewed on the demo sites, a menu appears at the top left corner, allowing the user to select another demo site.

5. Added a new demo dashboard `/demosites.html`