### PR TITLE
Fixing Dial-graphs misaligned in Safari/OS X

### DIFF
--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -10,14 +10,19 @@ body {
 	margin-left: 55px;
 }
 
-netdata-chart-row {
-	width: 100%;
-	text-align: center;
-	display: flex;
-	align-items: baseline;
-	justify-content: center;
+.netdata-chart-row {
+        width: 100%;
+        text-align: center;
+        display: flex;
+        display: -webkit-flex;
+        display: -moz-flex;
+        align-items: baseline;
+        -moz-align-items: baseline;
+        -webkit-align-items: baseline;
+        justify-content: center;
+        -webkit-justify-content: center;
+        -moz-justify-content: center;
 }
-
 
 .netdata-container {
 	display: inline-block;

--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -10,11 +10,17 @@ body {
 	margin-left: 55px;
 }
 
+netdata-chart-row {
+	width: 100%;
+	text-align: center;
+	display: flex;
+	align-items: baseline;
+	justify-content: center;
+}
+
+
 .netdata-container {
-	display: -webkit-flex; /* Safari */
-	-webkit-flex-wrap: wrap; /* Safari 6.1+ */
 	display: inline-block;
-	flex-wrap: wrap;
 	overflow: hidden;
 
 	/* required for child elements to have absolute position */
@@ -31,10 +37,7 @@ body {
 }
 
 .netdata-container-with-legend {
-	display: -webkit-flex; /* Safari */
-	-webkit-flex-wrap: wrap; /* Safari 6.1+ */
 	display: inline-block;
-	flex-wrap: wrap;
 	overflow: hidden;
 
 	/* fix minimum scrollbar issue in firefox */

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -24,9 +24,9 @@ body {
 	display: flex;
 	display: -webkit-flex;
 	display: -moz-flex;
-	align-items: baseline;
-	-moz-align-items: baseline;
-	-webkit-align-items: baseline;
+	align-items: flex-end;
+	-moz-align-items: flex-end;
+	-webkit-align-items: flex-end;
 	justify-content: center;
 	-moz--webkit-justify-content: center;
 	-moz-justify-content: center;

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -18,11 +18,16 @@ body {
 	margin-left: 55px;
 }
 
+.netdata-chart-row {
+	width: 100%;
+	text-align: center;
+	display: flex;
+	align-items: baseline;
+	justify-content: center;
+}
+
 .netdata-container {
-	display: -webkit-flex; /* Safari */
-	-webkit-flex-wrap: wrap; /* Safari 6.1+ */
 	display: inline-block;
-	flex-wrap: wrap;
 	overflow: hidden;
 
 	/* required for child elements to have absolute position */
@@ -39,10 +44,7 @@ body {
 }
 
 .netdata-container-with-legend {
-	display: -webkit-flex; /* Safari */
-	-webkit-flex-wrap: wrap; /* Safari 6.1+ */
 	display: inline-block;
-	flex-wrap: wrap;
 	overflow: hidden;
 
 	/* fix minimum scrollbar issue in firefox */

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -22,8 +22,14 @@ body {
 	width: 100%;
 	text-align: center;
 	display: flex;
+	display: -webkit-flex;
+	display: -moz-flex;
 	align-items: baseline;
+	-moz-align-items: baseline;
+	-webkit-align-items: baseline;
 	justify-content: center;
+	-moz--webkit-justify-content: center;
+	-moz-justify-content: center;
 }
 
 .netdata-container {

--- a/web/index.html
+++ b/web/index.html
@@ -1610,7 +1610,7 @@ function renderPage(menus, data) {
 		// console.log(' >> ' + menu + ' (' + menus[menu].priority + '): ' + menus[menu].title);
 
 		var shtml = '';
-		var mhead = '<div style="width: 100%; text-align: center;">' + mainhead;
+		var mhead = '<div class="netdata-chart-row">' + mainhead;
 		mainhead = '';
 
 		// sort the submenus of this menu
@@ -1626,7 +1626,7 @@ function renderPage(menus, data) {
 			if(menus[menu].submenus[submenu].info !== null)
 				shtml += '<div class="chart-message netdata-chart-alignment" role="document">' + menus[menu].submenus[submenu].info + '</div>';
 
-			var head = '<div style="width: 100%; text-align: center;">';
+			var head = '<div class="netdata-chart-row">';
 			var chtml = '';
 
 			// console.log('    \------- ' + submenu + ' (' + menus[menu].submenus[submenu].priority + '): ' + menus[menu].submenus[submenu].title);


### PR DESCRIPTION
This fixes the misalignment described in #159.

I have tested the pull request on
* Safari 9.1 (OS X)
* Chromium 50.0.2661.75 and (Linux)
* Mozilla Firefox 45.02. (Linux )

I made this fix in two commits because I do not know if we want to support old browsers.
I also want to admit that this might destroy layout for very old browsers.

Fore more information look at [w3schools](http://www.w3schools.com/css/css3_flexbox.asp)