### PR TITLE
mountinfo: disks now get their menu point on the menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ apps.plugin-profiler.sh
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
+
+.jetbrains*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,6 +52,7 @@ netdata_SOURCES = \
 	proc_net_stat_conntrack.c \
 	proc_net_stat_synproxy.c \
 	proc_stat.c \
+	proc_self_mountinfo.c proc_self_mountinfo.h \
 	proc_sys_kernel_random_entropy_avail.c \
 	proc_vmstat.c \
 	sys_kernel_mm_ksm.c \

--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -1,0 +1,170 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "common.h"
+#include "log.h"
+#include "appconfig.h"
+
+#include "proc_self_mountinfo.h"
+
+// find the mount info with the given major:minor
+// in the supplied linked list of mountinfo structures
+struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor) {
+	struct mountinfo *mi;
+
+	for(mi = root; mi ; mi = mi->next)
+		if(mi->major == major && mi->minor == minor)
+			return mi;
+
+	return NULL;
+}
+
+// free a linked list of mountinfo structures
+void mountinfo_free(struct mountinfo *mi) {
+	if(unlikely(!mi))
+		return;
+
+	if(likely(mi->next))
+		mountinfo_free(mi->next);
+
+	free(mi->root);
+	free(mi->mount_point);
+	free(mi->mount_options);
+
+	if(mi->optional_fields_count) {
+		int i;
+		for(i = 0; i < mi->optional_fields_count ; i++)
+			free(mi->optional_fields[i]);
+	}
+	free(mi->optional_fields);
+
+	free(mi->filesystem);
+	free(mi->mount_source);
+	free(mi->super_options);
+	free(mi);
+}
+
+// read the whole mountinfo into a linked list
+struct mountinfo *mountinfo_read() {
+	procfile *ff = NULL;
+
+	char filename[FILENAME_MAX + 1];
+	snprintf(filename, FILENAME_MAX, "%s/proc/self/mountinfo", global_host_prefix);
+	ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
+	if(!ff) {
+		snprintf(filename, FILENAME_MAX, "%s/proc/1/mountinfo", global_host_prefix);
+		ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
+		if(!ff) return NULL;
+	}
+
+	ff = procfile_readall(ff);
+	if(!ff) return NULL;
+
+	struct mountinfo *root = NULL, *last = NULL, *mi = NULL;
+
+	unsigned long l, lines = procfile_lines(ff);
+	error("MOUNTINFO: file has %u lines", lines);
+	for(l = 0; l < lines ;l++) {
+		if(procfile_linewords(ff, l) < 5)
+			continue;
+
+		mi = malloc(sizeof(struct mountinfo));
+		if(unlikely(!mi)) fatal("Cannot allocate memory for mountinfo");
+
+		if(unlikely(!root))
+			root = last = mi;
+		else
+			last->next = mi;
+
+		last = mi;
+		mi->next = NULL;
+
+		unsigned long w = 0;
+		mi->id = strtoul(procfile_lineword(ff, l, w), NULL, 10); w++;
+		mi->parentid = strtoul(procfile_lineword(ff, l, w), NULL, 10); w++;
+
+		char *major = procfile_lineword(ff, l, w), *minor; w++;
+		for(minor = major; *minor && *minor != ':' ;minor++) ;
+		*minor = '\0';
+		minor++;
+
+		mi->major = strtoul(major, NULL, 10);
+		mi->minor = strtoul(minor, NULL, 10);
+
+		mi->root = strdup(procfile_lineword(ff, l, w)); w++;
+		if(unlikely(!mi->root)) fatal("Cannot allocate memory");
+
+		mi->mount_point = strdup(procfile_lineword(ff, l, w)); w++;
+		if(unlikely(!mi->mount_point)) fatal("Cannot allocate memory");
+
+		mi->mount_options = strdup(procfile_lineword(ff, l, w)); w++;
+		if(unlikely(!mi->mount_options)) fatal("Cannot allocate memory");
+
+		// count the optional fields
+		unsigned long wo = w;
+		mi->optional_fields_count = 0;
+		char *s = procfile_lineword(ff, l, w);
+		while(*s && *s != '-') {
+			w++;
+			s = procfile_lineword(ff, l, w);
+			mi->optional_fields_count++;
+		}
+
+		if(unlikely(mi->optional_fields_count)) {
+			// we have some optional fields
+			// read them into a new array of pointers;
+
+			mi->optional_fields = malloc(mi->optional_fields_count * sizeof(char *));
+			if(unlikely(!mi->optional_fields))
+				fatal("Cannot allocate memory for %d mountinfo optional fields", mi->optional_fields_count);
+
+			int i;
+			for(i = 0; i < mi->optional_fields_count ; i++) {
+				mi->optional_fields[wo] = strdup(procfile_lineword(ff, l, w));
+				if(!mi->optional_fields[wo]) fatal("Cannot allocate memory");
+				wo++;
+			}
+		}
+		else
+			mi->optional_fields = NULL;
+
+		if(likely(*s == '-')) {
+			mi->filesystem = strdup(procfile_lineword(ff, l, w)); w++;
+			if(!mi->filesystem) fatal("Cannot allocate memory");
+
+			mi->mount_source = strdup(procfile_lineword(ff, l, w)); w++;
+			if(!mi->mount_source) fatal("Cannot allocate memory");
+
+			mi->super_options = strdup(procfile_lineword(ff, l, w)); w++;
+			if(!mi->super_options) fatal("Cannot allocate memory");
+		}
+		else {
+			mi->filesystem = NULL;
+			mi->mount_source = NULL;
+			mi->super_options = NULL;
+		}
+
+		//info("MOUNTINFO: %u %u %u:%u root '%s', mount point '%s', mount options '%s', filesystem '%s', mount source '%s', super options '%s'",
+		//     mi->id,
+		//     mi->parentid,
+		//     mi->major,
+		//     mi->minor,
+		//     mi->root,
+		//     mi->mount_point,
+		//     mi->mount_options,
+		//     mi->filesystem,
+		//     mi->mount_source,
+		//     mi->super_options
+		//);
+	}
+
+	procfile_close(ff);
+	return root;
+}

--- a/src/proc_self_mountinfo.h
+++ b/src/proc_self_mountinfo.h
@@ -1,0 +1,30 @@
+#include "procfile.h"
+
+#ifndef NETDATA_PROC_SELF_MOUNTINFO_H
+#define NETDATA_PROC_SELF_MOUNTINFO_H 1
+
+struct mountinfo {
+	long id;                // mount ID: unique identifier of the mount (may be reused after umount(2)).
+	long parentid;          // parent ID: ID of parent mount (or of self for the top of the mount tree).
+	unsigned long major;    // major:minor: value of st_dev for files on filesystem (see stat(2)).
+	unsigned long minor;
+
+	char *root;             // root: root of the mount within the filesystem.
+	char *mount_point;      // mount point: mount point relative to the process's root.
+	char *mount_options;    // mount options: per-mount options.
+
+	int optional_fields_count;
+	char **optional_fields; // optional fields: zero or more fields of the form "tag[:value]".
+
+	char *filesystem;       // filesystem type: name of filesystem in the form "type[.subtype]".
+	char *mount_source;     // mount source: filesystem-specific information or "none".
+	char *super_options;    // super options: per-superblock options.
+
+	struct mountinfo *next;
+};
+
+extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor);
+extern void mountinfo_free(struct mountinfo *mi);
+extern struct mountinfo *mountinfo_read();
+
+#endif /* NETDATA_PROC_SELF_MOUNTINFO_H */

--- a/src/proc_self_mountinfo.h
+++ b/src/proc_self_mountinfo.h
@@ -10,20 +10,30 @@ struct mountinfo {
 	unsigned long minor;
 
 	char *root;             // root: root of the mount within the filesystem.
+	uint32_t root_hash;
+
 	char *mount_point;      // mount point: mount point relative to the process's root.
+	uint32_t mount_point_hash;
+
 	char *mount_options;    // mount options: per-mount options.
 
 	int optional_fields_count;
 	char **optional_fields; // optional fields: zero or more fields of the form "tag[:value]".
 
 	char *filesystem;       // filesystem type: name of filesystem in the form "type[.subtype]".
+	uint32_t filesystem_hash;
+
 	char *mount_source;     // mount source: filesystem-specific information or "none".
+	uint32_t mount_source_hash;
+
 	char *super_options;    // super options: per-superblock options.
 
 	struct mountinfo *next;
 };
 
 extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor);
+extern struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *root, const char *filesystem, const char *mount_source);
+
 extern void mountinfo_free(struct mountinfo *mi);
 extern struct mountinfo *mountinfo_read();
 

--- a/web/index.html
+++ b/web/index.html
@@ -1442,11 +1442,11 @@ function enrichChartData(chart) {
 
 function name2id(s) {
 	return s
-		.replace(' ', '_')
-		.replace('(', '_')
-		.replace(')', '_')
-		.replace('.', '_')
-		.replace('/', '_');
+		.replace(/ /g, '_')
+		.replace(/\(/g, '_')
+		.replace(/\)/g, '_')
+		.replace(/\./g, '_')
+		.replace(/\//g, '_');
 }
 
 function headMain(charts, duration) {
@@ -1601,7 +1601,7 @@ function renderPage(menus, data) {
 
 		// generate an entry at the main menu
 
-		sidebar += '<li class=""><a href="#' + menu + '">' + menus[menu].title + '</a><ul class="nav">';
+		sidebar += '<li class=""><a href="#' + name2id(menu) + '">' + menus[menu].title + '</a><ul class="nav">';
 		html += '<div role="section"><div role="sectionhead"><h1 id="' + menu + '" role="heading">' + menus[menu].title + '</h1></div><div id="' + menu + '" role="document">';
 
 		if(menus[menu].info !== null)


### PR DESCRIPTION
- [x] fixes #295 (show mount points on the dashboard, instead of disk names)
- [x] cgroup mount points are now read dynamically #308 #115 #91 
- [x] the installer adds the `netdata` user to the `docker` group (only when running as root and the `docker` group exists) - the uninstaller will also instruct the user to remove it.