### PR TITLE
Prototype: monitor disk space usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This is what it currently monitors (most with zero configuration):
 
 - **RAM, swap and kernel memory usage** (including KSM and kernel memory deduper)
 
-- **Disks** (per disk: I/O, operations, backlog, utilization, etc)
+- **Disks** (per disk: I/O, operations, backlog, utilization, space, etc)
 
    ![sda](https://cloud.githubusercontent.com/assets/2662304/14093195/c882bbf4-f554-11e5-8863-1788d643d2c0.gif)
 

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -220,136 +220,251 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		for(s = disk; *s ;s++) if(*s == '/') *s = '_';
 
 		struct disk *d = get_disk(major, minor);
+
+		/*
 		if(d->partition_id == -1)
 			def_enabled = enable_new_disks;
 		else
 			def_enabled = 0;
+		*/
 
-		char *mount_point = d->mount_point;
-		char *family = d->mount_point;
-		if(!family) family = disk;
-
-/*
+		// Enable real disks by default.
+		// To fine out if it is a harddrive we use
+		// Linux Assigned Names and Numbers Authority (http://www.lanana.org/)
 		switch(major) {
-			case 9: // MDs
-			case 43: // network block
-			case 144: // nfs
-			case 145: // nfs
-			case 146: // nfs
-			case 199: // veritas
-			case 201: // veritas
-			case 251: // dm
-			case 253: // virtio
-				def_enabled = enable_new_disks;
+			case 8: // SCSI disk devices (0-15)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
-			case 48: // RAID
-			case 49: // RAID
-			case 50: // RAID
-			case 51: // RAID
-			case 52: // RAID
-			case 53: // RAID
-			case 54: // RAID
-			case 55: // RAID
-			case 112: // RAID
-			case 136: // RAID
-			case 137: // RAID
-			case 138: // RAID
-			case 139: // RAID
-			case 140: // RAID
-			case 141: // RAID
-			case 142: // RAID
-			case 143: // RAID
-			case 179: // MMC
-			case 180: // USB
-				if(minor % 8) def_enabled = 0; // partitions
-				else def_enabled = enable_new_disks;
+			case 21: // Acorn MFM hard drive interface
+				if(!(minor % 64)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
-			case 8: // scsi disks
-			case 65: // scsi disks
-			case 66: // scsi disks
-			case 67: // scsi disks
-			case 68: // scsi disks
-			case 69: // scsi disks
-			case 70: // scsi disks
-			case 71: // scsi disks
-			case 72: // scsi disks
-			case 73: // scsi disks
-			case 74: // scsi disks
-			case 75: // scsi disks
-			case 76: // scsi disks
-			case 77: // scsi disks
-			case 78: // scsi disks
-			case 79: // scsi disks
-			case 80: // i2o
-			case 81: // i2o
-			case 82: // i2o
-			case 83: // i2o
-			case 84: // i2o
-			case 85: // i2o
-			case 86: // i2o
-			case 87: // i2o
-			case 101: // hyperdisk
-			case 102: // compressed
-			case 104: // scsi
-			case 105: // scsi
-			case 106: // scsi
-			case 107: // scsi
-			case 108: // scsi
-			case 109: // scsi
-			case 110: // scsi
-			case 111: // scsi
-			case 114: // bios raid
-			case 116: // ram board
-			case 128: // scsi
-			case 129: // scsi
-			case 130: // scsi
-			case 131: // scsi
-			case 132: // scsi
-			case 133: // scsi
-			case 134: // scsi
-			case 135: // scsi
-			case 153: // raid
-			case 202: // xen
-			case 254: // virtio3
-			case 256: // flash
-			case 257: // flash
-			case 259: // nvme0n1 issue #119
-				if(minor % 16) def_enabled = 0; // partitions
-				else def_enabled = enable_new_disks;
+			case 28: // ACSI disk (68k/Atari)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
-			case 160: // raid
-			case 161: // raid
-				if(minor % 32) def_enabled = 0; // partitions
-				else def_enabled = enable_new_disks;
+			case 36: // MCA ESDI hard disk
+				if(!(minor % 64)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
-			case 3: // ide
-			case 13: // 8bit ide
-			case 22: // ide
-			case 33: // ide
-			case 34: // ide
-			case 56: // ide
-			case 57: // ide
-			case 88: // ide
-			case 89: // ide
-			case 90: // ide
-			case 91: // ide
-				if(minor % 64) def_enabled = 0; // partitions
-				else def_enabled = enable_new_disks;
+			case 48: // Mylex DAC960 PCI RAID controller; first controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
-			case 252: // zram
-				def_enabled = 0;
+			case 49: // Mylex DAC960 PCI RAID controller; second controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
 				break;
-
+			case 50: // Mylex DAC960 PCI RAID controller; third controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 51: // Mylex DAC960 PCI RAID controller; fourth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 52: // Mylex DAC960 PCI RAID controller; fifth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 53: // Mylex DAC960 PCI RAID controller; sixth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 54: // Mylex DAC960 PCI RAID controller; seventh controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 55: // Mylex DAC960 PCI RAID controller; eigth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 65: // SCSI disk devices (16-31)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 66: // SCSI disk devices (32-47)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 67: // SCSI disk devices (48-63)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 68: // SCSI disk devices (64-79)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 69: // SCSI disk devices (80-95)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 70: // SCSI disk devices (96-111)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 71: // SCSI disk devices (112-127)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 80: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 81: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 82: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 83: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 84: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 85: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 86: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 87: // I2O hard disk
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 128: // SCSI disk devices (128-143)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 129: // SCSI disk devices (144-159)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 130: // SCSI disk devices (160-175)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 131: // SCSI disk devices (176-191)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 132: // SCSI disk devices (192-207)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 133: // SCSI disk devices (208-223)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 134: // SCSI disk devices (224-239)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 135: // SCSI disk devices (240-255)
+				if(!(minor % 16)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 136: // Mylex DAC960 PCI RAID controller; nineth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 137: // Mylex DAC960 PCI RAID controller; tenth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 138: // Mylex DAC960 PCI RAID controller; eleventh controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 139: // Mylex DAC960 PCI RAID controller; twelfth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 140: // Mylex DAC960 PCI RAID controller; thirteenth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 141: // Mylex DAC960 PCI RAID controller; fourteenth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 142: // Mylex DAC960 PCI RAID controller; fifteenth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 143: // Mylex DAC960 PCI RAID controller; sixteenth controller
+				if(!(minor % 8)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 160: // Carmel 8-port SATA Disks on First Controller
+				if(!(minor % 32)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
+			case 161: // Carmel 8-port SATA Disks on Second Controller
+				if(!(minor % 32)) {
+					def_enabled = enable_new_disks;
+				}
+				break;
 			default:
 				def_enabled = 0;
 				break;
 		}
-*/
+
+		char *mount_point = d->mount_point;
+		char *family = d->mount_point;
+		if(!family) family = disk;
 
 		int ddo_io = do_io, ddo_ops = do_ops, ddo_mops = do_mops, ddo_iotime = do_iotime, ddo_qops = do_qops, ddo_util = do_util, ddo_backlog = do_backlog, ddo_space = do_space;
 

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -136,7 +136,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	static procfile *ff = NULL;
 	static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";
 	static int enable_autodetection;
-	static int enable_physical_disks, enable_virtual_disks, enable_partitions, enable_mountpoints, enable_space_metrics;
+	static int enable_physical_disks, enable_virtual_disks, enable_partitions, enable_mountpoints, enable_virtual_mountpoints, enable_space_metrics;
 	static int do_io, do_ops, do_mops, do_iotime, do_qops, do_util, do_backlog, do_space, do_inodes;
 	static struct statvfs buff_statvfs;
 	static struct stat buff_stat;
@@ -147,6 +147,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	enable_virtual_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for virtual disks", CONFIG_ONDEMAND_NO);
 	enable_partitions = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for partitions", CONFIG_ONDEMAND_NO);
 	enable_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted filesystems", CONFIG_ONDEMAND_NO);
+	enable_virtual_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted virtual disks", CONFIG_ONDEMAND_ONDEMAND);
 	enable_space_metrics = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space metrics for mounted filesystems", CONFIG_ONDEMAND_ONDEMAND);
 
 	do_io 	   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "bandwidth for all disks", CONFIG_ONDEMAND_ONDEMAND);
@@ -267,6 +268,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 				def_performance = enable_virtual_disks;
 			} else if(enable_partitions && (d->type == DISK_TYPE_PARTITION)) {
 				def_performance = enable_partitions;
+			} else if(enable_virtual_mountpoints && (d->type == DISK_TYPE_CONTAINER) && (d->mount_point != NULL)) {
+				def_performance = enable_virtual_mountpoints;
 			} else if(enable_mountpoints && (d->mount_point != NULL)) {
 				def_performance = enable_mountpoints;
 			}

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -1,13 +1,15 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <dirent.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 
 #include "common.h"
 #include "log.h"
@@ -20,17 +22,20 @@
 
 #define RRD_TYPE_DISK "disk"
 
+#define DISK_TYPE_PHYSICAL  1
+#define DISK_TYPE_PARTITION 2
+#define DISK_TYPE_CONTAINER 3
+
 struct disk {
 	unsigned long major;
 	unsigned long minor;
-	int partition_id;       // -1 = this is not a partition
+	int type;
 	char *mount_point;
-	char *family;
 	struct disk *next;
 } *disk_root = NULL;
 
 struct disk *get_disk(unsigned long major, unsigned long minor) {
-	static char path_find_block_device_partition[FILENAME_MAX + 1] = "";
+	static char path_find_block_device[FILENAME_MAX + 1] = "";
 	static struct mountinfo *mountinfo_root = NULL;
 	struct disk *d;
 
@@ -46,10 +51,10 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	if(likely(d))
 		return d;
 
-	if(unlikely(!path_find_block_device_partition[0])) {
-		char filename[FILENAME_MAX + 1];
-		snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/dev/block/%lu:%lu/partition");
-		snprintfz(path_find_block_device_partition, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get block device partition", filename));
+	if(unlikely(!path_find_block_device[0])) {
+		char dirname[FILENAME_MAX + 1];
+		snprintfz(dirname, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/dev/block/%lu:%lu/%s");
+		snprintfz(path_find_block_device, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get block device infos", dirname));
 	}
 
 	// not found
@@ -59,7 +64,7 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 
 	d->major = major;
 	d->minor = minor;
-	d->partition_id = -1;
+	d->type = DISK_TYPE_PHYSICAL; // Default type. Changed later if not correct.
 	d->next = NULL;
 
 	// append it to the list
@@ -71,21 +76,36 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 		last->next = d;
 	}
 
+	// ------------------------------------------------------------------------
+	// find the type of the device
+
 	// find if it is a partition
-	// by reading /sys/dev/block/MAJOR:MINOR/partition
+	// by checking if /sys/dev/block/MAJOR:MINOR/partition is readable.
 	char buffer[FILENAME_MAX + 1];
-	snprintfz(buffer, FILENAME_MAX, path_find_block_device_partition, major, minor);
-
-	int fd = open(buffer, O_RDONLY, 0666);
-	if(likely(fd != -1)) {
-		// we opened it
-		int bytes = read(fd, buffer, FILENAME_MAX);
-		close(fd);
-
-		if(bytes > 0)
-			d->partition_id = strtoul(buffer, NULL, 10);
+	snprintfz(buffer, FILENAME_MAX, path_find_block_device, major, minor, "partition");
+	if(access(buffer, R_OK) == 0) {
+		d->type = DISK_TYPE_PARTITION;
+	} else {
+		// find if it is a container
+		// by checking if /sys/dev/block/MAJOR:MINOR/slaves has entries
+		int is_container = 0;
+		snprintfz(buffer, FILENAME_MAX, path_find_block_device, major, minor, "slaves/");
+		DIR *dirp = opendir(buffer);	
+		if (dirp != NULL) {
+		struct dirent *dp;
+			while(dp = readdir(dirp)) {
+				// . and .. are also files in empty folders.
+				if(strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
+					continue;
+				}
+				d->type = DISK_TYPE_CONTAINER;
+				// Stop the loop after we found one file.
+				break;
+			}
+			if(closedir(dirp) == -1)
+				error("Unable to close dir %s", buffer);
+		}
 	}
-	// if the /partition file does not exist, it is a disk, not a partition
 
 	// ------------------------------------------------------------------------
 	// check if we can find its mount point
@@ -117,6 +137,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";
 	static int enable_new_disks = -1;
 	static int do_io = -1, do_ops = -1, do_mops = -1, do_iotime = -1, do_qops = -1, do_util = -1, do_backlog = -1, do_space = -1;
+	static struct statvfs buff_statvfs;
 
 	if(enable_new_disks == -1)	enable_new_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "enable new disks detected at runtime", CONFIG_ONDEMAND_ONDEMAND);
 
@@ -144,12 +165,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 
 	ff = procfile_readall(ff);
 	if(!ff) return 0; // we return 0, so that we will retry to open it next time
-
-	struct statvfs * buff_statvfs;
-	if ( !(buff_statvfs = (struct statvfs *)
-				malloc(sizeof(struct statvfs)))) {
-		error("Failed to allocate memory to buffer.");
-	}
 
 	uint32_t lines = procfile_lines(ff), l;
 	uint32_t words;
@@ -221,16 +236,17 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 
 		struct disk *d = get_disk(major, minor);
 
-		/*
-		if(d->partition_id == -1)
+		// Enable statistics for physical disks and mount points by default.
+		if( (d->type == DISK_TYPE_PHYSICAL) || (d->mount_point != NULL) ) {
 			def_enabled = enable_new_disks;
-		else
-			def_enabled = 0;
-		*/
+		}
 
-		// Enable real disks by default.
+		/*
+		// Enable physical disks by default.
 		// To fine out if it is a harddrive we use
 		// Linux Assigned Names and Numbers Authority (http://www.lanana.org/)
+		// We can't do that because proprietary disk drivers do not stick to
+		// the standard. To detect re
 		switch(major) {
 			case 8: // SCSI disk devices (0-15)
 				if(!(minor % 16)) {
@@ -461,6 +477,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 				def_enabled = 0;
 				break;
 		}
+		*/
 
 		char *mount_point = d->mount_point;
 		char *family = d->mount_point;
@@ -651,35 +668,33 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		// --------------------------------------------------------------------
 
 		if(ddo_space) {
-			if(mount_point) {
-				st = rrdset_find_bytype("disk_space", disk);
-				if(!st) {
-					st = rrdset_create("disk_space", disk, NULL, family, "disk.space", "Disk Space Usage", "Megabyte", 2023, update_every, RRDSET_TYPE_AREA);
-					st->isdetail = 1;
-
-					rrddim_add(st, "avail", NULL, 1, 1048576, RRDDIM_ABSOLUTE);
-					rrddim_add(st, "reserved for root", NULL, 1, 1048576, RRDDIM_ABSOLUTE);
-					rrddim_add(st, "used" , NULL, 1, 1045576, RRDDIM_ABSOLUTE);
-				}
-				else rrdset_next_usec(st, dt);
-
-
-
-				if (statvfs(family, buff_statvfs) < 0) {
-					error("Faild checking disk space usage of %s", family);
-				} else {
-					space_avail = buff_statvfs->f_bavail * buff_statvfs->f_bsize;
-					space_avail_root = (buff_statvfs->f_bfree - buff_statvfs->f_bavail) * buff_statvfs->f_bsize;
-					space_used = (buff_statvfs->f_blocks - buff_statvfs->f_bfree) * buff_statvfs->f_bsize;
-				}
-
-				rrddim_set(st, "avail", space_avail);
-				rrddim_set(st, "reserved for root", space_avail_root);
-				rrddim_set(st, "used", space_used);
-				rrdset_done(st);
-			} else {
+			if(!mount_point) {
 				if(ddo_space != CONFIG_ONDEMAND_ONDEMAND) {
 					error("Cannot find space usage for disk %s. It does not have a mount point.", family);
+				}
+			} else {
+				if (statvfs(family, &buff_statvfs) < 0) {
+					error("Failed checking disk space usage of %s", family);
+				} else {
+					space_avail = buff_statvfs.f_bavail * buff_statvfs.f_bsize;
+					space_avail_root = (buff_statvfs.f_bfree - buff_statvfs.f_bavail) * buff_statvfs.f_bsize;
+					space_used = (buff_statvfs.f_blocks - buff_statvfs.f_bfree) * buff_statvfs.f_bsize;
+
+					st = rrdset_find_bytype("disk_space", disk);
+					if(!st) {
+						st = rrdset_create("disk_space", disk, NULL, family, "disk.space", "Disk Space Usage", "GB", 2023, update_every, RRDSET_TYPE_STACKED);
+						st->isdetail = 1;
+
+						rrddim_add(st, "avail", NULL, 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
+						rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
+						rrddim_add(st, "used" , NULL, 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
+					}
+					else rrdset_next_usec(st, dt);
+
+					rrddim_set(st, "avail", space_avail);
+					rrddim_set(st, "reserved_for_root", space_avail_root);
+					rrddim_set(st, "used", space_used);
+					rrdset_done(st);
 				}
 			}
 		}
@@ -736,7 +751,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 			}
 		}
 	}
-	free(buff_statvfs);
 
 	return 0;
 }

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -89,12 +89,11 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	} else {
 		// find if it is a container
 		// by checking if /sys/dev/block/MAJOR:MINOR/slaves has entries
-		int is_container = 0;
 		snprintfz(buffer, FILENAME_MAX, path_find_block_device, major, minor, "slaves/");
 		DIR *dirp = opendir(buffer);	
 		if (dirp != NULL) {
 		struct dirent *dp;
-			while(dp = readdir(dirp)) {
+			while( (dp = readdir(dirp)) ) {
 				// . and .. are also files in empty folders.
 				if(strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
 					continue;

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <fcntl.h>
 
 #include "common.h"
@@ -23,6 +24,7 @@ struct disk {
 	unsigned long major;
 	unsigned long minor;
 	int partition_id;       // -1 = this is not a partition
+	char *mount_point;
 	char *family;
 	struct disk *next;
 } *disk_root = NULL;
@@ -102,10 +104,10 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	}
 
 	if(mi)
-		d->family = strdup(mi->mount_point);
+		d->mount_point = strdup(mi->mount_point);
 		// no need to check for NULL
 	else
-		d->family = NULL;
+		d->mount_point = NULL;
 
 	return d;
 }
@@ -114,7 +116,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	static procfile *ff = NULL;
 	static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";
 	static int enable_new_disks = -1;
-	static int do_io = -1, do_ops = -1, do_mops = -1, do_iotime = -1, do_qops = -1, do_util = -1, do_backlog = -1;
+	static int do_io = -1, do_ops = -1, do_mops = -1, do_iotime = -1, do_qops = -1, do_util = -1, do_backlog = -1, do_space = -1;
 
 	if(enable_new_disks == -1)	enable_new_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "enable new disks detected at runtime", CONFIG_ONDEMAND_ONDEMAND);
 
@@ -125,6 +127,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	if(do_qops == -1)	do_qops 	= config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "queued operations for all disks", CONFIG_ONDEMAND_ONDEMAND);
 	if(do_util == -1)	do_util 	= config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "utilization percentage for all disks", CONFIG_ONDEMAND_ONDEMAND);
 	if(do_backlog == -1)do_backlog 	= config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "backlog for all disks", CONFIG_ONDEMAND_ONDEMAND);
+	if(do_space == -1)  do_space 	= config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
 
 	if(!ff) {
 		char filename[FILENAME_MAX + 1];
@@ -142,6 +145,12 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	ff = procfile_readall(ff);
 	if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
+	struct statvfs * buff_statvfs;
+	if ( !(buff_statvfs = (struct statvfs *)
+				malloc(sizeof(struct statvfs)))) {
+		error("Failed to allocate memory to buffer.");
+	}
+
 	uint32_t lines = procfile_lines(ff), l;
 	uint32_t words;
 
@@ -150,7 +159,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		unsigned long long 	major = 0, minor = 0,
 							reads = 0,  mreads = 0,  readsectors = 0,  readms = 0,
 							writes = 0, mwrites = 0, writesectors = 0, writems = 0,
-							queued_ios = 0, busy_ms = 0, backlog_ms = 0;
+							queued_ios = 0, busy_ms = 0, backlog_ms = 0,
+							space_avail = 0, space_avail_root = 0, space_used = 0;
 
 		unsigned long long 	last_reads = 0,  last_readsectors = 0,  last_readms = 0,
 							last_writes = 0, last_writesectors = 0, last_writems = 0,
@@ -215,7 +225,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		else
 			def_enabled = 0;
 
-		char *family = d->family;
+		char *mount_point = d->mount_point;
+		char *family = d->mount_point;
 		if(!family) family = disk;
 
 /*
@@ -340,7 +351,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		}
 */
 
-		int ddo_io = do_io, ddo_ops = do_ops, ddo_mops = do_mops, ddo_iotime = do_iotime, ddo_qops = do_qops, ddo_util = do_util, ddo_backlog = do_backlog;
+		int ddo_io = do_io, ddo_ops = do_ops, ddo_mops = do_mops, ddo_iotime = do_iotime, ddo_qops = do_qops, ddo_util = do_util, ddo_backlog = do_backlog, ddo_space = do_space;
 
 		// check which charts are enabled for this disk
 		{
@@ -358,6 +369,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 			ddo_qops 	= config_get_boolean_ondemand(var_name, "queued operations", ddo_qops);
 			ddo_util 	= config_get_boolean_ondemand(var_name, "utilization percentage", ddo_util);
 			ddo_backlog = config_get_boolean_ondemand(var_name, "backlog", ddo_backlog);
+			ddo_space   = config_get_boolean_ondemand(var_name, "space", ddo_space);
 
 			// by default, do not add charts that do not have values
 			if(ddo_io == CONFIG_ONDEMAND_ONDEMAND && !reads && !writes) ddo_io = 0;
@@ -522,6 +534,42 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		}
 
 		// --------------------------------------------------------------------
+
+		if(ddo_space) {
+			if(mount_point) {
+				st = rrdset_find_bytype("disk_space", disk);
+				if(!st) {
+					st = rrdset_create("disk_space", disk, NULL, family, "disk.space", "Disk Space Usage", "Megabyte", 2023, update_every, RRDSET_TYPE_AREA);
+					st->isdetail = 1;
+
+					rrddim_add(st, "avail", NULL, 1, 1048576, RRDDIM_ABSOLUTE);
+					rrddim_add(st, "reserved for root", NULL, 1, 1048576, RRDDIM_ABSOLUTE);
+					rrddim_add(st, "used" , NULL, 1, 1045576, RRDDIM_ABSOLUTE);
+				}
+				else rrdset_next_usec(st, dt);
+
+
+
+				if (statvfs(family, buff_statvfs) < 0) {
+					error("Faild checking disk space usage of %s", family);
+				} else {
+					space_avail = buff_statvfs->f_bavail * buff_statvfs->f_bsize;
+					space_avail_root = (buff_statvfs->f_bfree - buff_statvfs->f_bavail) * buff_statvfs->f_bsize;
+					space_used = (buff_statvfs->f_blocks - buff_statvfs->f_bfree) * buff_statvfs->f_bsize;
+				}
+
+				rrddim_set(st, "avail", space_avail);
+				rrddim_set(st, "reserved for root", space_avail_root);
+				rrddim_set(st, "used", space_used);
+				rrdset_done(st);
+			} else {
+				if(ddo_space != CONFIG_ONDEMAND_ONDEMAND) {
+					error("Cannot find space usage for disk %s. It does not have a mount point.", family);
+				}
+			}
+		}
+
+		// --------------------------------------------------------------------
 		// calculate differential charts
 		// only if this is not the first time we run
 
@@ -573,6 +621,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 			}
 		}
 	}
+	free(buff_statvfs);
 
 	return 0;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1192,7 +1192,7 @@ var menuData = {
 
 	'disk': {
 		title: 'Disks',
-		info: undefined
+		info: 'Charts with performance information for all the system disks. Special care has been given to present disk performance metrics in a way compatible with <code>iostat -x</code>. netdata by default prevents rendering performance charts for individual partitions. Partitions can still be enabled by altering the relative settings in the netdata configuration file.'
 	},
 
 	'sensors': {
@@ -1435,18 +1435,29 @@ var chartData = {
 		colors: '#FF5588',
 		heads: [
 			gaugeChart('Utilization', '12%', '', '#FF5588')
-		]
+		],
+		info: 'Disk Utilization measures the amount of time the disk was busy with something. This is not related to its performance. 100% means that the Linux kernel always had an outstanding operation on the disk. Keep in mind that depending on the underlying technology of the disk, 100% here may or may not be an indication of congestion.'
 	},
 
 	'disk.backlog': {
-		colors: '#0099CC'
+		colors: '#0099CC',
+		info: 'Backlog is an indication of the duration of pending disk operations. On every I/O event the Linux kernel is multiplying the time spent doing I/O since the last update of this field with the number of pending operations. While not accurate, this metric can provide an indication of the expected completion time of the operations in progress.'
 	},
 
 	'disk.io': {
 		heads: [
 			gaugeChart('Read', '12%', 'reads'),
 			gaugeChart('Write', '12%', 'writes')
-		]
+		],
+		info: 'Amount of data transferred to and from disk.'
+	},
+
+	'disk.ops': {
+		info: 'Completed disk I/O operations. Keep in mind the number of operations requested might be higher, since the Linux kernel is able to merge adjacent to each other (see merged operations chart).'
+	},
+
+	'disk.qops': {
+		info: 'I/O operations currently in progress. This metric is a snapshot - it is not an average over the last interval.'
 	},
 
 	'netfilter.sockets': {
@@ -1463,20 +1474,32 @@ var chartData = {
 	},
 
 	'disk.iotime': {
-		height: 0.5
+		height: 0.5,
+		info: 'The sum of the duration of all completed I/O operations. This number can exceed the interval if the disk is able to execute I/O operations in parallel.'
 	},
 	'disk.mops': {
-		height: 0.5
+		height: 0.5,
+		info: 'The number of merged disk operations. The Linux kernel is able to merge adjacent I/O operations, for example two 4KB reads can become one 8KB read before given to disk.'
 	},
 	'disk.svctm': {
-		height: 0.5
+		height: 0.5,
+		info: 'The average service time for completed I/O operations. This metric is calculated using the total busy time of the disk and the number of completed operations. If the disk is able to execute multiple parallel operations the reporting average service time will be misleading.'
 	},
 	'disk.avgsz': {
-		height: 0.5
+		height: 0.5,
+		info: 'The average I/O operation size.'
 	},
 	'disk.await': {
-		height: 0.5
+		height: 0.5,
+		info: 'The average time for I/O requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.'
 	},
+
+	'disk.space': {
+		info: 'Disk space utilization. reserved for root is automatically reserved by the system to prevent the root user from getting out of space.'
+	}
+	'disk.inodes': {
+		'inodes (or index nodes) are filesystem objects (e.g. files and directories). On many types of file system implementations, the maximum number of inodes is fixed at filesystem creation, limiting the maximum number of files the filesystem can hold. It is possible for a device to run out of inodes. When this happens, new files cannot be created on the device, even though there may be free space available.'
+	}
 
 	'apache.connections': {
 		colors: NETDATA.colors[4],

--- a/web/index.html
+++ b/web/index.html
@@ -1192,7 +1192,7 @@ var menuData = {
 
 	'disk': {
 		title: 'Disks',
-		info: 'Charts with performance information for all the system disks. Special care has been given to present disk performance metrics in a way compatible with <code>iostat -x</code>. netdata by default prevents rendering performance charts for individual partitions. Partitions can still be enabled by altering the relative settings in the netdata configuration file.'
+		info: 'Charts with performance information for all the system disks. Special care has been given to present disk performance metrics in a way compatible with <code>iostat -x</code>. netdata by default prevents rendering performance charts for individual partitions and unmounted virtual disks. Disabled charts can still be enabled by altering the relative settings in the netdata configuration file.'
 	},
 
 	'sensors': {


### PR DESCRIPTION
This is just a prototype for disccussing some questions at this point.
 
This will fix issues #249 and #74 when implemented properly.

**Questions**
1. Should we realy implement this at proc_diskstats.c? This does not get it's values from proc. I implemented it there because the file system data is already there and it produces a graph in this section.
2. Shall we use statvfs (only mounted filesystems) or statfs (every filesystem)? If we use statfs we have to query mountinfo

**TODO**
- [x] Only add charts for filesystems where disk space is avaiable
- [x] Do not allocate and free buffer statvfs all the time
- [ ] Add this feature to the wiki
- [x] Make unit more readable (TB, GB, MB depending on filesystem size) 
- [x] Do not display disk metrics for containers, only for disks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/firehol/netdata/338)
<!-- Reviewable:end -->
