### PR TITLE
cgroup plugin fixes

### DIFF
--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -33,12 +33,47 @@ struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *ro
 	uint32_t filesystem_hash = simple_hash(filesystem), mount_source_hash = simple_hash(mount_source);
 
 	for(mi = root; mi ; mi = mi->next)
-		if(mi->filesystem_hash == filesystem_hash && mi->mount_source_hash == mount_source_hash
-				&& !strcmp(mi->filesystem, filesystem) && !strcmp(mi->mount_source, mount_source))
+		if(mi->filesystem
+		   		&& mi->mount_source
+				&& mi->filesystem_hash == filesystem_hash
+		   		&& mi->mount_source_hash == mount_source_hash
+				&& !strcmp(mi->filesystem, filesystem)
+		   		&& !strcmp(mi->mount_source, mount_source))
 			return mi;
 
 	return NULL;
 }
+
+struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options) {
+	struct mountinfo *mi;
+	uint32_t filesystem_hash = simple_hash(filesystem);
+
+	size_t solen = strlen(super_options);
+
+	for(mi = root; mi ; mi = mi->next)
+		if(mi->filesystem
+		   		&& mi->super_options
+				&& mi->filesystem_hash == filesystem_hash
+		   		&& !strcmp(mi->filesystem, filesystem)) {
+
+			// super_options is a comma separated list
+			char *s = mi->super_options, *e;
+			while(*s) {
+				e = ++s;
+				while(*e && *e != ',') e++;
+
+				size_t len = e - s;
+				if(len == solen && !strncmp(s, super_options, len))
+					return mi;
+
+				if(*e == ',') s = ++e;
+				else s = e;
+			}
+		}
+
+	return NULL;
+}
+
 
 // free a linked list of mountinfo structures
 void mountinfo_free(struct mountinfo *mi) {

--- a/src/proc_self_mountinfo.h
+++ b/src/proc_self_mountinfo.h
@@ -34,6 +34,7 @@ struct mountinfo {
 
 extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor);
 extern struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *root, const char *filesystem, const char *mount_source);
+extern struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options);
 
 extern void mountinfo_free(struct mountinfo *mi);
 extern struct mountinfo *mountinfo_read();

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -47,18 +47,21 @@ void read_cgroup_plugin_configuration() {
 	struct mountinfo *mi, *root = mountinfo_read();
 
 	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
+	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
 	if(!mi) s = "/sys/fs/cgroup/cpuacct";
 	else s = mi->mount_point;
 	snprintf(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);
 	cgroup_cpuacct_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuacct", filename);
 
 	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "blkio");
+	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
 	if(!mi) s = "/sys/fs/cgroup/blkio";
 	else s = mi->mount_point;
 	snprintf(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);
 	cgroup_blkio_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/blkio", filename);
 
 	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "memory");
+	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
 	if(!mi) s = "/sys/fs/cgroup/memory";
 	else s = mi->mount_point;
 	snprintf(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -838,7 +838,6 @@ void cleanup_all_cgroups() {
 				cg = cgroup_root;
 			else
 				cg = last->next;
-			
 		}
 		else {
 			last = cg;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -960,7 +960,7 @@ void update_cgroup_charts(int update_every) {
 		if(cg->id[0] == '\0')
 			strcpy(type, "cgroup_host");
 		else if(cg->id[0] == '/')
-			snprintf(type, RRD_ID_LENGTH_MAX, "cgroup_%s", "host");
+			snprintf(type, RRD_ID_LENGTH_MAX, "cgroup_%s", cg->chart_id);
 		else
 			snprintf(type, RRD_ID_LENGTH_MAX, "cgroup_%s", cg->chart_id);
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -822,9 +822,9 @@ void mark_all_cgroups_as_not_available() {
 }
 
 void cleanup_all_cgroups() {
-	struct cgroup *cg, *last;
+	struct cgroup *cg = cgroup_root, *last = NULL;
 
-	for(cg = cgroup_root, last = NULL; cg ; last = cg) {
+	for(; cg ;) {
 		if(!cg->available) {
 
 			if(!last)
@@ -838,10 +838,12 @@ void cleanup_all_cgroups() {
 				cg = cgroup_root;
 			else
 				cg = last->next;
-
-			continue;
+			
 		}
-		cg = cg->next;
+		else {
+			last = cg;
+			cg = cg->next;
+		}
 	}
 }
 


### PR DESCRIPTION
1. disable system.slice, user.slice and systemd cgroups by default #329 
2. now the plugin allows configuring options to prevent it from descending into specific sub-cgroups
3. fixed copy-paste typos (wrong option names)
4. support for getting cgroup mount points for newer kernels that show cgroup type in super options of mountinfo.

~~This commit logs an `info()` line every time a cgroup is added and every time is removed. There are `FIXME` tags. These logs should be converted to `debug()` calls once we are sure it works properly.~~

cc: #308 #329