### PR TITLE
Let systemd handle killing the processes

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -9,7 +9,8 @@ User=root
 Group=root
 PIDFile=@localstatedir_POST@/run/netdata.pid
 ExecStart=@sbindir_POST@/netdata -pidfile @localstatedir_POST@/run/netdata.pid
-ExecStop=/bin/kill -SIGTERM $MAINPID
+KillMode=mixed
+KillSignal=SIGTERM
 TimeoutStopSec=30
 
 [Install]


### PR DESCRIPTION
By setting `KillMode` to `mixed`, systemd will send `KillSignal` to the main process. It will then wait `TimeoutStopSec` and then send `SIGKILL` to all remaining processes in the cgroup. This appears to be the desired behavior.