### PR TITLE
Signals: Fix uninitialized sa->sa_flag in sigaction.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -414,6 +414,7 @@ int main(int argc, char **argv)
 		sigaddset(&sa.sa_mask, SIGINT);
 		sigaddset(&sa.sa_mask, SIGTERM);
 		sa.sa_handler = sig_handler;
+		sa.sa_flags = 0;
 		if(sigaction(SIGHUP, &sa, NULL) == -1) {
 			error("Failed to change signal handler for SIGHUP");
 		}

--- a/src/popen.c
+++ b/src/popen.c
@@ -126,6 +126,7 @@ FILE *mypopen(const char *command, pid_t *pidptr)
 		struct sigaction sa;
 		sigemptyset(&sa.sa_mask);
 		sa.sa_handler = SIG_DFL;
+		sa.sa_flags = 0;
 		if(sigaction(SIGPIPE, &sa, NULL) == -1) {
 			error("Failed to change signal handler for SIGTERM");
 		}


### PR DESCRIPTION
This is quite strange. I thought initializing sigacton would set it's sa_flag to 0.

Thank you for the hint!