### PR TITLE
more registry fixes

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -1174,10 +1174,14 @@ int registry_person_url_callback_verify_machine_exists(void *entry, void *machin
 	PERSON_URL *pu = (PERSON_URL *)entry;
 	MACHINE *m = (MACHINE *)machine;
 
-	if(pu->machine == m)
+	if(pu->machine == m) {
+		info("registry_person_url_callback_verify_machine_exists('%s', '%s'): no", pu->machine->guid, m->guid);
 		return 1;
-	else
+	}
+	else {
+		info("registry_person_url_callback_verify_machine_exists('%s', '%s'): yes", pu->machine->guid, m->guid);
 		return 0;
+	}
 }
 
 // the main method for switching user identity
@@ -1648,7 +1652,7 @@ int registry_init(void) {
 	registry.save_registry_every_entries = config_get_number("registry", "registry save db every new entries", 1000000);
 	registry.persons_expiration = config_get_number("registry", "registry expire idle persons days", 365) * 86400;
 	registry.registry_domain = config_get("registry", "registry domain", "");
-	registry.registry_to_announce = config_get("registry", "registry to announce", "//registry.my-netdata.io");
+	registry.registry_to_announce = config_get("registry", "registry to announce", "https://registry.my-netdata.io");
 	registry.hostname = config_get("registry", "registry hostname", config_get("global", "hostname", hostname));
 
 	registry.max_url_length = config_get_number("registry", "max URL length", 1024);

--- a/src/registry.c
+++ b/src/registry.c
@@ -340,8 +340,7 @@ static inline URL *registry_url_allocate_nolock(const char *url, size_t urllen) 
 
 	// a simple strcpy() should do the job
 	// but I prefer to be safe, since the caller specified urllen
-	strncpy(u->url, url, urllen);
-	u->url[urllen] = '\0';
+	strncpyz(u->url, url, urllen);
 
 	u->len = urllen;
 	u->links = 0;
@@ -424,8 +423,7 @@ static inline MACHINE *registry_machine_allocate(const char *machine_guid, time_
 	MACHINE *m = malloc(sizeof(MACHINE));
 	if(!m) fatal("Registry: cannot allocate memory for new machine '%s'", machine_guid);
 
-	strncpy(m->guid, machine_guid, 36);
-	m->guid[36] = '\0';
+	strncpyz(m->guid, machine_guid, 36);
 
 	debug(D_REGISTRY, "Registry: registry_machine_allocate('%s'): creating dictionary of urls", machine_guid);
 	m->urls = dictionary_create(DICTIONARY_FLAGS);
@@ -488,8 +486,7 @@ static inline PERSON_URL *registry_person_url_allocate(PERSON *p, MACHINE *m, UR
 
 	// a simple strcpy() should do the job
 	// but I prefer to be safe, since the caller specified urllen
-	strncpy(pu->name, name, namelen);
-	pu->name[namelen] = '\0';
+	strncpyz(pu->name, name, namelen);
 
 	pu->machine = m;
 	pu->first_t = pu->last_t = when;
@@ -552,10 +549,8 @@ static inline PERSON *registry_person_allocate(const char *person_guid, time_t w
 				info("Registry: generated person guid '%s' found in the registry. Retrying...", p->guid);
 		}
 	}
-	else {
-		strncpy(p->guid, person_guid, 36);
-		p->guid[36] = '\0';
-	}
+	else
+		strncpyz(p->guid, person_guid, 36);
 
 	debug(D_REGISTRY, "Registry: registry_person_allocate('%s'): creating dictionary of urls", p->guid);
 	p->urls = dictionary_create(DICTIONARY_FLAGS);
@@ -1022,12 +1017,10 @@ static inline void registry_set_person_cookie(struct web_client *w, PERSON *p) {
 	struct tm etmbuf, *etm = gmtime_r(&et, &etmbuf);
 	strftime(edate, sizeof(edate), "%a, %d %b %Y %H:%M:%S %Z", etm);
 
-	if(registry.registry_domain && registry.registry_domain[0])
-		snprintf(w->cookie, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s", p->guid, registry.registry_domain, edate);
-	else
-		snprintf(w->cookie, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", p->guid, edate);
+	snprintfz(w->cookie1, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", p->guid, edate);
 
-	w->cookie[COOKIE_MAX] = '\0';
+	if(registry.registry_domain && registry.registry_domain[0])
+		snprintfz(w->cookie2, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s", p->guid, registry.registry_domain, edate);
 }
 
 static inline void registry_json_header(struct web_client *w, const char *action, const char *status) {
@@ -1399,8 +1392,8 @@ int registry_save(void) {
 	char tmp_filename[FILENAME_MAX + 1];
 	char old_filename[FILENAME_MAX + 1];
 
-	snprintf(old_filename, FILENAME_MAX, "%s.old", registry.db_filename);
-	snprintf(tmp_filename, FILENAME_MAX, "%s.tmp", registry.db_filename);
+	snprintfz(old_filename, FILENAME_MAX, "%s.old", registry.db_filename);
+	snprintfz(tmp_filename, FILENAME_MAX, "%s.tmp", registry.db_filename);
 
 	debug(D_REGISTRY, "Registry: Creating file '%s'", tmp_filename);
 	FILE *fp = fopen(tmp_filename, "w");
@@ -1643,14 +1636,14 @@ int registry_init(void) {
 	}
 
 	// filenames
-	snprintf(filename, FILENAME_MAX, "%s/netdata.public.unique.id", registry.pathname);
+	snprintfz(filename, FILENAME_MAX, "%s/netdata.public.unique.id", registry.pathname);
 	registry.machine_guid_filename = config_get("registry", "netdata unique id file", filename);
 	registry_get_this_machine_guid();
 
-	snprintf(filename, FILENAME_MAX, "%s/registry.db", registry.pathname);
+	snprintfz(filename, FILENAME_MAX, "%s/registry.db", registry.pathname);
 	registry.db_filename = config_get("registry", "registry db file", filename);
 
-	snprintf(filename, FILENAME_MAX, "%s/registry-log.db", registry.pathname);
+	snprintfz(filename, FILENAME_MAX, "%s/registry-log.db", registry.pathname);
 	registry.log_filename = config_get("registry", "registry log file", filename);
 
 	// configuration options
@@ -1883,7 +1876,7 @@ int test1(int argc, char **argv) {
 		uuid_unparse(uuid, machines_guids[m]);
 
 		char buf[FILENAME_MAX + 1];
-		snprintf(buf, FILENAME_MAX, "http://%u.netdata.rocks/", m+1);
+		snprintfz(buf, FILENAME_MAX, "http://%u.netdata.rocks/", m+1);
 		machines_urls[m] = strdup(buf);
 
 		// fprintf(stderr, "\tmachine %u: '%s', url: '%s'\n", m + 1, machines_guids[m], machines_urls[m]);
@@ -1970,7 +1963,7 @@ int test1(int argc, char **argv) {
 			char *url = machines_urls[tm];
 			char buf[FILENAME_MAX + 1];
 			if (random() % 10000 == 1234) {
-				snprintf(buf, FILENAME_MAX, "http://random.%ld.netdata.rocks/", random());
+				snprintfz(buf, FILENAME_MAX, "http://random.%ld.netdata.rocks/", random());
 				url = buf;
 			}
 			else if (random() % 1000 == 123)

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -175,7 +175,8 @@ void web_client_reset(struct web_client *w)
 	}
 
 	w->last_url[0] = '\0';
-	w->cookie[0] = '\0';
+	w->cookie1[0] = '\0';
+	w->cookie2[0] = '\0';
 	w->origin[0] = '*';
 	w->origin[1] = '\0';
 
@@ -801,6 +802,9 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 
 	debug(D_WEB_CLIENT, "%llu: API v1 registry with URL '%s'", w->id, url);
 
+	// FIXME
+	// The browser may send multiple cookies with our id
+	
 	char *cookie = strstr(w->response.data->buffer, " " NETDATA_REGISTRY_COOKIE_NAME "=");
 	if(cookie)
 		strncpyz(person_guid, &cookie[sizeof(NETDATA_REGISTRY_COOKIE_NAME) + 1], 36);
@@ -1655,10 +1659,16 @@ void web_client_process(struct web_client *w) {
 		, date
 		);
 
-	if(w->cookie[0]) {
+	if(w->cookie1[0]) {
 		buffer_sprintf(w->response.header_output,
 		   "Set-Cookie: %s\r\n",
-		   w->cookie);
+		   w->cookie1);
+	}
+
+	if(w->cookie2[0]) {
+		buffer_sprintf(w->response.header_output,
+		   "Set-Cookie: %s\r\n",
+		   w->cookie2);
 	}
 
 	if(w->mode == WEB_CLIENT_MODE_OPTIONS) {

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -61,7 +61,8 @@ struct web_client {
 
 	struct timeval tv_in, tv_ready;
 
-	char cookie[COOKIE_MAX+1];
+	char cookie1[COOKIE_MAX+1];
+	char cookie2[COOKIE_MAX+1];
 	char origin[ORIGIN_MAX+1];
 
 	int mode;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -646,4 +646,4 @@ So, to avoid flashing the charts, we destroy and re-create the charts on each up
 	<!-- <script> netdataServer = "http://box:19999"; </script> -->
 
 	<!-- load the dashboard manager - it will do the rest -->
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -3392,7 +3392,7 @@
 		NETDATA.parseDom(NETDATA.chartRefresher);
 
 		// Registry initialization
-		setTimeout(NETDATA.registry.init, 1000);
+		setTimeout(NETDATA.registry.init, 3000);
 	};
 
 	// ----------------------------------------------------------------------------------------------------------------

--- a/web/demo.html
+++ b/web/demo.html
@@ -11,7 +11,7 @@
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 	<meta name="author" content="costa@tsaousis.gr">
 
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>
 </head>
 <body>
 

--- a/web/demo2.html
+++ b/web/demo2.html
@@ -12,7 +12,7 @@
 	<meta name="author" content="costa@tsaousis.gr">
 
 	<script>var netdataTheme = 'slate';</script>
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>
 </head>
 <body>
 

--- a/web/demosites.html
+++ b/web/demosites.html
@@ -42,7 +42,7 @@
 		and that you have chown it to be owned by netdata:netdata
 	-->
 	<!-- <script type="text/javascript" src="http://my.server:19999/dashboard.js"></script> -->
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>
 
 	<script>
 	// --- OPTIONS FOR THE CHARTS --

--- a/web/index.html
+++ b/web/index.html
@@ -425,7 +425,7 @@
 	</script>
 
 	<!-- load the dashboard manager - it will do the rest -->
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>
 </head>
 
 <body data-spy="scroll" data-target="#sidebar">
@@ -439,10 +439,12 @@
 							<div class="row">
 								<div class="col-sm-6" style="width: 85%; padding-right: 0;">
 									<ul id="mynetdata_servers" class="multi-column-dropdown">
+										<li><a href="#" onclck="return false;" style="color: #999;">loading...</a></li>
 									</ul>
 								</div>
 								<div class="col-sm-3 hidden-xs" style="width: 15%; padding-left: 0;">
 									<ul id="mynetdata_actions1" class="multi-column-dropdown">
+									<li style="color: #999;">&nbsp;</li>
 									</ul>
 								</div>
 							</div>
@@ -476,6 +478,7 @@
 					<li class="dropdown hidden-sm hidden-md hidden-lg">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" id="current_view">my-netdata <strong class="caret"></strong></a>
 						<ul id="mynetdata_servers2" class="dropdown-menu scrollable-menu inpagemenu" role="menu">
+							<li><a href="#" onclck="return false;" style="color: #999;">loading...</a></li>
 						</ul>
 					</li>
 				</ul>

--- a/web/tv.html
+++ b/web/tv.html
@@ -40,7 +40,7 @@
 		and that you have chown it to be owned by netdata:netdata
 	-->
 	<!-- <script type="text/javascript" src="http://my.server:19999/dashboard.js"></script> -->
-	<script type="text/javascript" src="dashboard.js?v36"></script>
+	<script type="text/javascript" src="dashboard.js?v37"></script>
 
 	<script>
 	// Set options for TV operation


### PR DESCRIPTION
- [x] default registry is now HTTPS
- [x] loading the my-netdata menu is delayed 3 seconds to prevent it slow down the page initialization
- [x] registry used snprintfz() and strncpyz()
- [x] when a domain cookie is configurated at the registry, the registry send both the host and the domain cookie to the browser (to avoid a split brain situation where the browser has 2 cookies, one for the host and one for the domain
- [x] work-around for impersonate not working under conditions. It seems dictionary_get_all() does not return the right value - still investigating...