### PR TITLE
optimizations

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -242,8 +242,8 @@ int config_get_boolean(const char *section, const char *name, int value)
 	s = config_get(section, name, s);
 	if(!s) return value;
 
-	if(!strcmp(s, "yes")) return 1;
-	else return 0;
+	if(!strcmp(s, "yes") || !strcmp(s, "auto") || !strcmp(s, "on demand")) return 1;
+	return 0;
 }
 
 int config_get_boolean_ondemand(const char *section, const char *name, int value)
@@ -251,7 +251,7 @@ int config_get_boolean_ondemand(const char *section, const char *name, int value
 	char *s;
 
 	if(value == CONFIG_ONDEMAND_ONDEMAND)
-		s = "on demand";
+		s = "auto";
 
 	else if(value == CONFIG_ONDEMAND_NO)
 		s = "no";
@@ -266,7 +266,7 @@ int config_get_boolean_ondemand(const char *section, const char *name, int value
 		return CONFIG_ONDEMAND_YES;
 	else if(!strcmp(s, "no"))
 		return CONFIG_ONDEMAND_NO;
-	else if(!strcmp(s, "on demand"))
+	else if(!strcmp(s, "auto") || !strcmp(s, "on demand"))
 		return CONFIG_ONDEMAND_ONDEMAND;
 
 	return value;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -46,15 +46,15 @@ static int name_value_compare(void* a, void* b) {
 	else return strcmp(((NAME_VALUE *)a)->name, ((NAME_VALUE *)b)->name);
 }
 
-#define dictionary_name_value_index_add_nolock(dict, nv) do { (dict)->inserts++; avl_insert(&((dict)->values_index), (avl *)(nv)); } while(0)
-#define dictionary_name_value_index_del_nolock(dict, nv) do { (dict)->deletes++; avl_remove(&(dict->values_index), (avl *)(nv)); } while(0)
+#define dictionary_name_value_index_add_nolock(dict, nv) do { NETDATA_DICTIONARY_STATS_INSERTS_PLUS1(dict); avl_insert(&((dict)->values_index), (avl *)(nv)); } while(0)
+#define dictionary_name_value_index_del_nolock(dict, nv) do { NETDATA_DICTIONARY_STATS_DELETES_PLUS1(dict); avl_remove(&(dict->values_index), (avl *)(nv)); } while(0)
 
 static inline NAME_VALUE *dictionary_name_value_index_find_nolock(DICTIONARY *dict, const char *name, uint32_t hash) {
 	NAME_VALUE tmp;
 	tmp.hash = (hash)?hash:simple_hash(name);
 	tmp.name = (char *)name;
 
-	dict->searches++;
+	NETDATA_DICTIONARY_STATS_SEARCHES_PLUS1(dict);
 	return (NAME_VALUE *)avl_search(&(dict->values_index), (avl *) &tmp);
 }
 
@@ -89,7 +89,7 @@ static NAME_VALUE *dictionary_name_value_create_nolock(DICTIONARY *dict, const c
 
 	// index it
 	dictionary_name_value_index_add_nolock(dict, nv);
-	dict->entries++;
+	NETDATA_DICTIONARY_STATS_ENTRIES_PLUS1(dict);
 
 	return nv;
 }
@@ -99,7 +99,7 @@ static void dictionary_name_value_destroy_nolock(DICTIONARY *dict, NAME_VALUE *n
 
 	dictionary_name_value_index_del_nolock(dict, nv);
 
-	dict->entries--;
+	NETDATA_DICTIONARY_STATS_ENTRIES_MINUS1(dict);
 
 	if(!(dict->flags & DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE)) {
 		debug(D_REGISTRY, "Dictionary freeing value of '%s'", nv->name);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -21,13 +21,29 @@ typedef struct dictionary {
 
 	uint8_t flags;
 
+#ifdef NETDATA_DICTIONARY_WITH_STATISTICS
 	unsigned long long inserts;
 	unsigned long long deletes;
 	unsigned long long searches;
 	unsigned long long entries;
+#endif /* NETDATA_DICTIONARY_WITH_STATISTICS */
 
 	pthread_rwlock_t rwlock;
 } DICTIONARY;
+
+#ifdef NETDATA_DICTIONARY_WITH_STATISTICS
+#define NETDATA_DICTIONARY_STATS_INSERTS_PLUS1(dict) (dict)->inserts++
+#define NETDATA_DICTIONARY_STATS_DELETES_PLUS1(dict) (dict)->deletes++
+#define NETDATA_DICTIONARY_STATS_SEARCHES_PLUS1(dict) (dict)->searches++
+#define NETDATA_DICTIONARY_STATS_ENTRIES_PLUS1(dict) (dict)->entries++
+#define NETDATA_DICTIONARY_STATS_ENTRIES_MINUS1(dict) (dict)->entries--
+#else /* NETDATA_DICTIONARY_WITH_STATISTICS */
+#define NETDATA_DICTIONARY_STATS_INSERTS_PLUS1(dict)
+#define NETDATA_DICTIONARY_STATS_DELETES_PLUS1(dict)
+#define NETDATA_DICTIONARY_STATS_SEARCHES_PLUS1(dict)
+#define NETDATA_DICTIONARY_STATS_ENTRIES_PLUS1(dict)
+#define NETDATA_DICTIONARY_STATS_ENTRIES_MINUS1(dict)
+#endif /* NETDATA_DICTIONARY_WITH_STATISTICS */
 
 #define DICTIONARY_FLAG_DEFAULT					0x00000000
 #define DICTIONARY_FLAG_SINGLE_THREADED			0x00000001

--- a/src/global_statistics.c
+++ b/src/global_statistics.c
@@ -5,7 +5,7 @@
 
 #include "global_statistics.h"
 
-struct global_statistics global_statistics = { 0ULL, 0ULL, 0ULL, 0ULL };
+struct global_statistics global_statistics = { 0, 0ULL, 0ULL, 0ULL, 0ULL};
 
 pthread_mutex_t global_statistics_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/global_statistics.h
+++ b/src/global_statistics.h
@@ -5,11 +5,11 @@
 // global statistics
 
 struct global_statistics {
-	unsigned long long connected_clients;
-	unsigned long long web_requests;
-	unsigned long long bytes_received;
-	unsigned long long bytes_sent;
-
+	unsigned long volatile connected_clients;
+	unsigned long long volatile web_requests;
+	unsigned long long volatile web_usec;
+	unsigned long long volatile bytes_received;
+	unsigned long long volatile bytes_sent;
 };
 
 extern struct global_statistics global_statistics;

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -598,7 +598,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		// only if this is not the first time we run
 
 		if(dt) {
-			if(d->do_iotime && d->do_ops) {
+			if( (d->do_iotime == CONFIG_ONDEMAND_YES || (d->do_iotime == CONFIG_ONDEMAND_ONDEMAND && (readms || writems))) &&
+				(d->do_ops    == CONFIG_ONDEMAND_YES || (d->do_ops    == CONFIG_ONDEMAND_ONDEMAND && (reads || writes)))) {
 				st = rrdset_find_bytype("disk_await", disk);
 				if(!st) {
 					st = rrdset_create("disk_await", disk, NULL, family, "disk.await", "Average Completed I/O Operation Time", "ms per operation", 2005, update_every, RRDSET_TYPE_LINE);
@@ -614,7 +615,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 				rrdset_done(st);
 			}
 
-			if(d->do_io && d->do_ops) {
+			if( (d->do_io  == CONFIG_ONDEMAND_YES || (d->do_io  == CONFIG_ONDEMAND_ONDEMAND && (readsectors || writesectors))) &&
+				(d->do_ops == CONFIG_ONDEMAND_YES || (d->do_ops == CONFIG_ONDEMAND_ONDEMAND && (reads || writes)))) {
 				st = rrdset_find_bytype("disk_avgsz", disk);
 				if(!st) {
 					st = rrdset_create("disk_avgsz", disk, NULL, family, "disk.avgsz", "Average Completed I/O Operation Bandwidth", "kilobytes per operation", 2006, update_every, RRDSET_TYPE_AREA);
@@ -630,7 +632,8 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 				rrdset_done(st);
 			}
 
-			if(d->do_util && d->do_ops) {
+			if( (d->do_util == CONFIG_ONDEMAND_YES || (d->do_util == CONFIG_ONDEMAND_ONDEMAND && busy_ms)) &&
+				(d->do_ops  == CONFIG_ONDEMAND_YES || (d->do_ops  == CONFIG_ONDEMAND_ONDEMAND && (reads || writes)))) {
 				st = rrdset_find_bytype("disk_svctm", disk);
 				if(!st) {
 					st = rrdset_create("disk_svctm", disk, NULL, family, "disk.svctm", "Average Service Time", "ms per operation", 2007, update_every, RRDSET_TYPE_LINE);

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -27,17 +27,35 @@
 #define DISK_TYPE_PARTITION 2
 #define DISK_TYPE_CONTAINER 3
 
-struct disk {
+static struct disk {
+	char *disk;				// the name of the disk (sda, sdb, etc)
 	unsigned long major;
 	unsigned long minor;
+	int sector_size;
 	int type;
 	char *mount_point;
+
+	// disk options caching
+	int configured;
+	int do_io;
+	int do_ops;
+	int do_mops;
+	int do_iotime;
+	int do_qops;
+	int do_util;
+	int do_backlog;
+	int do_space;
+	int do_inodes;
+
 	struct disk *next;
 } *disk_root = NULL;
 
-struct disk *get_disk(unsigned long major, unsigned long minor) {
+static struct mountinfo *disk_mountinfo_root = NULL;
+
+static struct disk *get_disk(unsigned long major, unsigned long minor, char *disk) {
+	static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";
+	static char path_to_get_hw_sector_size_partitions[FILENAME_MAX + 1] = "";
 	static char path_find_block_device[FILENAME_MAX + 1] = "";
-	static struct mountinfo *mountinfo_root = NULL;
 	struct disk *d;
 
 	// search for it in our RAM list.
@@ -52,20 +70,17 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	if(likely(d))
 		return d;
 
-	if(unlikely(!path_find_block_device[0])) {
-		char dirname[FILENAME_MAX + 1];
-		snprintfz(dirname, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/dev/block/%lu:%lu/%s");
-		snprintfz(path_find_block_device, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get block device infos", dirname));
-	}
-
 	// not found
 	// create a new disk structure
 	d = (struct disk *)malloc(sizeof(struct disk));
 	if(!d) fatal("Cannot allocate memory for struct disk in proc_diskstats.");
 
+	d->disk = strdup(disk);
 	d->major = major;
 	d->minor = minor;
 	d->type = DISK_TYPE_PHYSICAL; // Default type. Changed later if not correct.
+	d->configured = 0;
+	d->sector_size = 512; // the default, will be changed below
 	d->next = NULL;
 
 	// append it to the list
@@ -80,9 +95,16 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	// ------------------------------------------------------------------------
 	// find the type of the device
 
+	char buffer[FILENAME_MAX + 1];
+
+	// get the default path for finding info about the block device
+	if(unlikely(!path_find_block_device[0])) {
+		snprintfz(buffer, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/dev/block/%lu:%lu/%s");
+		snprintfz(path_find_block_device, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get block device infos", buffer));
+	}
+
 	// find if it is a partition
 	// by checking if /sys/dev/block/MAJOR:MINOR/partition is readable.
-	char buffer[FILENAME_MAX + 1];
 	snprintfz(buffer, FILENAME_MAX, path_find_block_device, major, minor, "partition");
 	if(access(buffer, R_OK) == 0) {
 		d->type = DISK_TYPE_PARTITION;
@@ -92,13 +114,15 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 		snprintfz(buffer, FILENAME_MAX, path_find_block_device, major, minor, "slaves/");
 		DIR *dirp = opendir(buffer);	
 		if (dirp != NULL) {
-		struct dirent *dp;
+			struct dirent *dp;
 			while( (dp = readdir(dirp)) ) {
 				// . and .. are also files in empty folders.
 				if(strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
 					continue;
 				}
+
 				d->type = DISK_TYPE_CONTAINER;
+
 				// Stop the loop after we found one file.
 				break;
 			}
@@ -110,17 +134,17 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	// ------------------------------------------------------------------------
 	// check if we can find its mount point
 
-	// mountinfo_find() can be called with NULL mountinfo_root
-	struct mountinfo *mi = mountinfo_find(mountinfo_root, d->major, d->minor);
+	// mountinfo_find() can be called with NULL disk_mountinfo_root
+	struct mountinfo *mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor);
 	if(unlikely(!mi)) {
-		// mountinfo_free() can be called with NULL mountinfo_root
-		mountinfo_free(mountinfo_root);
+		// mountinfo_free() can be called with NULL disk_mountinfo_root
+		mountinfo_free(disk_mountinfo_root);
 
 		// re-read mountinfo in case something changed
-		mountinfo_root = mountinfo_read();
+		disk_mountinfo_root = mountinfo_read();
 
 		// search again for this disk
-		mi = mountinfo_find(mountinfo_root, d->major, d->minor);
+		mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor);
 	}
 
 	if(mi)
@@ -129,36 +153,106 @@ struct disk *get_disk(unsigned long major, unsigned long minor) {
 	else
 		d->mount_point = NULL;
 
+	// ------------------------------------------------------------------------
+	// find the disk sector size
+
+	if(!path_to_get_hw_sector_size[0]) {
+		snprintfz(buffer, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/block/%s/queue/hw_sector_size");
+		snprintfz(path_to_get_hw_sector_size, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get h/w sector size", buffer));
+	}
+	if(!path_to_get_hw_sector_size_partitions[0]) {
+		snprintfz(buffer, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/dev/block/%lu:%lu/subsystem/%s/../queue/hw_sector_size");
+		snprintfz(path_to_get_hw_sector_size_partitions, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get h/w sector size for partitions", buffer));
+	}
+
+	{
+		char tf[FILENAME_MAX + 1], *t;
+		strncpyz(tf, d->disk, FILENAME_MAX);
+
+		// replace all / with !
+		for(t = tf; *t ;t++)
+			if(*t == '/') *t = '!';
+
+		if(d->type == DISK_TYPE_PARTITION)
+			snprintfz(buffer, FILENAME_MAX, path_to_get_hw_sector_size_partitions, d->major, d->minor, tf);
+		else
+			snprintfz(buffer, FILENAME_MAX, path_to_get_hw_sector_size, tf);
+
+		FILE *fpss = fopen(buffer, "r");
+		if(fpss) {
+			char buffer2[1024 + 1];
+			char *tmp = fgets(buffer2, 1024, fpss);
+
+			if(tmp) {
+				d->sector_size = atoi(tmp);
+				if(d->sector_size <= 0) {
+					error("Invalid sector size %d for device %s in %s. Assuming 512.", d->sector_size, d->disk, buffer);
+					d->sector_size = 512;
+				}
+			}
+			else error("Cannot read data for sector size for device %s from %s. Assuming 512.", d->disk, buffer);
+
+			fclose(fpss);
+		}
+		else error("Cannot read sector size for device %s from %s. Assuming 512.", d->disk, buffer);
+	}
+
 	return d;
+}
+
+static inline int select_positive_option(int option1, int option2) {
+	if(option1 == CONFIG_ONDEMAND_YES || option2 == CONFIG_ONDEMAND_YES)
+		return CONFIG_ONDEMAND_YES;
+	else if(option1 == CONFIG_ONDEMAND_ONDEMAND || option2 == CONFIG_ONDEMAND_ONDEMAND)
+		return CONFIG_ONDEMAND_ONDEMAND;
+
+	return CONFIG_ONDEMAND_NO;
 }
 
 int do_proc_diskstats(int update_every, unsigned long long dt) {
 	static procfile *ff = NULL;
-	static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";
-	static int enable_autodetection;
-	static int enable_physical_disks, enable_virtual_disks, enable_partitions, enable_mountpoints, enable_virtual_mountpoints, enable_space_metrics;
-	static int do_io, do_ops, do_mops, do_iotime, do_qops, do_util, do_backlog, do_space, do_inodes;
 	static struct statvfs buff_statvfs;
 	static struct stat buff_stat;
+	static int 	global_enable_new_disks_detected_at_runtime = CONFIG_ONDEMAND_YES,
+				global_enable_performance_for_physical_disks = CONFIG_ONDEMAND_ONDEMAND,
+				global_enable_performance_for_virtual_disks = CONFIG_ONDEMAND_NO,
+				global_enable_performance_for_partitions = CONFIG_ONDEMAND_NO,
+				global_enable_performance_for_mountpoints = CONFIG_ONDEMAND_NO,
+				global_enable_performance_for_virtual_mountpoints = CONFIG_ONDEMAND_ONDEMAND,
+				global_enable_space_for_mountpoints = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_io = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_ops = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_mops = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_iotime = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_qops = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_util = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_backlog = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_space = CONFIG_ONDEMAND_ONDEMAND,
+				global_do_inodes = CONFIG_ONDEMAND_ONDEMAND,
+				globals_initialized = 0;
 
-	enable_autodetection = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "enable new disks detected at runtime", CONFIG_ONDEMAND_ONDEMAND);
+	if(unlikely(!globals_initialized)) {
+		global_enable_new_disks_detected_at_runtime = config_get_boolean("plugin:proc:/proc/diskstats", "enable new disks detected at runtime", global_enable_new_disks_detected_at_runtime);
 
-	enable_physical_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for physical disks", CONFIG_ONDEMAND_ONDEMAND);
-	enable_virtual_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for virtual disks", CONFIG_ONDEMAND_NO);
-	enable_partitions = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for partitions", CONFIG_ONDEMAND_NO);
-	enable_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted filesystems", CONFIG_ONDEMAND_NO);
-	enable_virtual_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted virtual disks", CONFIG_ONDEMAND_ONDEMAND);
-	enable_space_metrics = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space metrics for mounted filesystems", CONFIG_ONDEMAND_ONDEMAND);
+		global_enable_performance_for_physical_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for physical disks", global_enable_performance_for_physical_disks);
+		global_enable_performance_for_virtual_disks = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for virtual disks", global_enable_performance_for_virtual_disks);
+		global_enable_performance_for_partitions = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for partitions", global_enable_performance_for_partitions);
+		global_enable_performance_for_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted filesystems", global_enable_performance_for_mountpoints);
+		global_enable_performance_for_virtual_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted virtual disks", global_enable_performance_for_virtual_mountpoints);
+		global_enable_space_for_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space metrics for mounted filesystems", global_enable_space_for_mountpoints);
 
-	do_io 	   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "bandwidth for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_ops 	   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "operations for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_mops    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "merged operations for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_iotime  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "i/o time for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_qops    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "queued operations for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_util    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "utilization percentage for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_backlog = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "backlog for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_space   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
-	do_inodes  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "inodes usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
+		global_do_io 	  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "bandwidth for all disks", global_do_io);
+		global_do_ops 	  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "operations for all disks", global_do_ops);
+		global_do_mops    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "merged operations for all disks", global_do_mops);
+		global_do_iotime  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "i/o time for all disks", global_do_iotime);
+		global_do_qops    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "queued operations for all disks", global_do_qops);
+		global_do_util    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "utilization percentage for all disks", global_do_util);
+		global_do_backlog = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "backlog for all disks", global_do_backlog);
+		global_do_space   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space usage for all disks", global_do_space);
+		global_do_inodes  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "inodes usage for all disks", global_do_inodes);
+
+		globals_initialized = 1;
+	}
 
 	if(!ff) {
 		char filename[FILENAME_MAX + 1];
@@ -166,12 +260,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		ff = procfile_open(config_get("plugin:proc:/proc/diskstats", "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
 	}
 	if(!ff) return 1;
-
-	if(!path_to_get_hw_sector_size[0]) {
-		char filename[FILENAME_MAX + 1];
-		snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, "/sys/block/%s/queue/hw_sector_size");
-		snprintfz(path_to_get_hw_sector_size, FILENAME_MAX, "%s", config_get("plugin:proc:/proc/diskstats", "path to get h/w sector size", filename));
-	}
 
 	ff = procfile_readall(ff);
 	if(!ff) return 0; // we return 0, so that we will retry to open it next time
@@ -182,6 +270,7 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 	for(l = 0; l < lines ;l++) {
 		// --------------------------------------------------------------------------
 		// Read parameters
+
 		char *disk;
 		unsigned long long 	major = 0, minor = 0,
 							reads = 0,  mreads = 0,  readsectors = 0,  readms = 0,
@@ -241,331 +330,390 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
 		// I/O completion time and the backlog that may be accumulating.
 		backlog_ms 		= strtoull(procfile_lineword(ff, l, 13), NULL, 10);	// rq_ticks
 
+
 		// --------------------------------------------------------------------------
 		// remove slashes from disk names
 		char *s;
-		for(s = disk; *s ;s++) if(*s == '/') *s = '_';
-		struct disk *d = get_disk(major, minor);
-		// Find mount point and family
-		char *mount_point = d->mount_point;
+		for(s = disk; *s ;s++)
+			if(*s == '/') *s = '_';
+
+		// --------------------------------------------------------------------------
+		// get a disk structure for the disk
+
+		struct disk *d = get_disk(major, minor, disk);
+
+
+		// --------------------------------------------------------------------------
+		// Set its family based on mount point
+
 		char *family = d->mount_point;
 		if(!family) family = disk;
 
+
 		// --------------------------------------------------------------------------
-		// Check if device is enabled by autodetection or config
-		int def_enable = -1;
-		char var_name[4096 + 1];
-		snprintfz(var_name, 4096, "plugin:proc:/proc/diskstats:%s", disk);
+		// Check the configuration for the device
 
-		if(def_enable == -1) def_enable = config_get_boolean_ondemand(var_name, "enable", CONFIG_ONDEMAND_ONDEMAND);
-		if(def_enable == CONFIG_ONDEMAND_NO) continue;
+		if(unlikely(!d->configured)) {
+			char var_name[4096 + 1];
+			snprintfz(var_name, 4096, "plugin:proc:/proc/diskstats:%s", disk);
 
-		int def_performance = CONFIG_ONDEMAND_NO, def_space = CONFIG_ONDEMAND_NO;
-		if(enable_autodetection)  {
-			if(enable_physical_disks && (d->type == DISK_TYPE_PHYSICAL)) {
-				def_performance = enable_physical_disks;
-			} else if(enable_virtual_disks && (d->type == DISK_TYPE_CONTAINER)) {
-				def_performance = enable_virtual_disks;
-			} else if(enable_partitions && (d->type == DISK_TYPE_PARTITION)) {
-				def_performance = enable_partitions;
-			} else if(enable_virtual_mountpoints && (d->type == DISK_TYPE_CONTAINER) && (d->mount_point != NULL)) {
-				def_performance = enable_virtual_mountpoints;
-			} else if(enable_mountpoints && (d->mount_point != NULL)) {
-				def_performance = enable_mountpoints;
+			int def_enable = config_get_boolean_ondemand(var_name, "enable", global_enable_new_disks_detected_at_runtime);
+			if(def_enable == CONFIG_ONDEMAND_NO) {
+				// the user does not want any metrics for this disk
+				d->do_io = CONFIG_ONDEMAND_NO;
+				d->do_ops = CONFIG_ONDEMAND_NO;
+				d->do_mops = CONFIG_ONDEMAND_NO;
+				d->do_iotime = CONFIG_ONDEMAND_NO;
+				d->do_qops = CONFIG_ONDEMAND_NO;
+				d->do_util = CONFIG_ONDEMAND_NO;
+				d->do_backlog = CONFIG_ONDEMAND_NO;
+				d->do_space = CONFIG_ONDEMAND_NO;
+				d->do_inodes = CONFIG_ONDEMAND_NO;
+			}
+			else {
+				// this disk is enabled
+				// check its direct settings
+
+				int def_performance = CONFIG_ONDEMAND_ONDEMAND;
+				int def_space = (d->mount_point)?CONFIG_ONDEMAND_ONDEMAND:CONFIG_ONDEMAND_NO;
+
+				// since this is 'on demand' we can figure the performance settings
+				// based on the type of disk
+
+				switch(d->type) {
+					case DISK_TYPE_PHYSICAL:
+						def_performance = global_enable_performance_for_physical_disks;
+						break;
+
+					case DISK_TYPE_PARTITION:
+						def_performance = global_enable_performance_for_partitions;
+						break;
+
+					case DISK_TYPE_CONTAINER:
+						def_performance = global_enable_performance_for_virtual_disks;
+
+						if(d->mount_point)
+							def_performance = select_positive_option(def_performance, global_enable_performance_for_virtual_mountpoints);
+
+						break;
+				}
+
+				if(d->mount_point)
+					def_performance = select_positive_option(def_performance, global_enable_performance_for_mountpoints);
+
+				// ------------------------------------------------------------
+				// now we have def_performance and def_space
+				// to work further
+
+				// def_performance
+				// check the user configuration (this will also show our 'on demand' decision)
+				def_performance = config_get_boolean_ondemand(var_name, "enable performance metrics", def_performance);
+
+				int ddo_io = CONFIG_ONDEMAND_NO,
+					ddo_ops = CONFIG_ONDEMAND_NO,
+					ddo_mops = CONFIG_ONDEMAND_NO,
+					ddo_iotime = CONFIG_ONDEMAND_NO,
+					ddo_qops = CONFIG_ONDEMAND_NO,
+					ddo_util = CONFIG_ONDEMAND_NO,
+					ddo_backlog = CONFIG_ONDEMAND_NO;
+
+				// we enable individual performance charts only when def_performance is not disabled
+				if(def_performance != CONFIG_ONDEMAND_NO) {
+					ddo_io = global_do_io,
+					ddo_ops = global_do_ops,
+					ddo_mops = global_do_mops,
+					ddo_iotime = global_do_iotime,
+					ddo_qops = global_do_qops,
+					ddo_util = global_do_util,
+					ddo_backlog = global_do_backlog;
+				}
+
+				d->do_io      = config_get_boolean_ondemand(var_name, "bandwidth", ddo_io);
+				d->do_ops     = config_get_boolean_ondemand(var_name, "operations", ddo_ops);
+				d->do_mops    = config_get_boolean_ondemand(var_name, "merged operations", ddo_mops);
+				d->do_iotime  = config_get_boolean_ondemand(var_name, "i/o time", ddo_iotime);
+				d->do_qops    = config_get_boolean_ondemand(var_name, "queued operations", ddo_qops);
+				d->do_util    = config_get_boolean_ondemand(var_name, "utilization percentage", ddo_util);
+				d->do_backlog = config_get_boolean_ondemand(var_name, "backlog", ddo_backlog);
+
+				// def_space
+				if(d->mount_point) {
+					// check the user configuration (this will also show our 'on demand' decision)
+					def_space = config_get_boolean_ondemand(var_name, "enable space metrics", def_space);
+
+					int ddo_space = def_space,
+						ddo_inodes = def_space;
+
+					d->do_space = config_get_boolean_ondemand(var_name, "space usage", ddo_space);
+					d->do_inodes = config_get_boolean_ondemand(var_name, "inodes usage", ddo_inodes);
+				}
+				else {
+					// don't show settings for this disk
+					d->do_space = CONFIG_ONDEMAND_NO;
+					d->do_inodes = CONFIG_ONDEMAND_NO;
+				}
 			}
 
-			if(enable_space_metrics && (d->mount_point != NULL)) {
-				def_space = enable_space_metrics;
-			}
+			d->configured = 1;
 		}
 
 		RRDSET *st;
 
 		// --------------------------------------------------------------------------
 		// Do performance metrics
-		def_performance = config_get_boolean_ondemand(var_name, "enable performance metrics", def_performance);
-		if( (def_performance == CONFIG_ONDEMAND_YES) || (def_performance == CONFIG_ONDEMAND_ONDEMAND && reads && writes) ) {
-			int ddo_io = do_io, ddo_ops = do_ops, ddo_mops = do_mops, ddo_iotime = do_iotime, ddo_qops = do_qops, ddo_util = do_util, ddo_backlog = do_backlog;
 
-			ddo_io 		= config_get_boolean_ondemand(var_name, "bandwidth", ddo_io);
-			ddo_ops 	= config_get_boolean_ondemand(var_name, "operations", ddo_ops);
-			ddo_mops 	= config_get_boolean_ondemand(var_name, "merged operations", ddo_mops);
-			ddo_iotime 	= config_get_boolean_ondemand(var_name, "i/o time", ddo_iotime);
-			ddo_qops 	= config_get_boolean_ondemand(var_name, "queued operations", ddo_qops);
-			ddo_util 	= config_get_boolean_ondemand(var_name, "utilization percentage", ddo_util);
-			ddo_backlog = config_get_boolean_ondemand(var_name, "backlog", ddo_backlog);
+		if(d->do_io == CONFIG_ONDEMAND_YES || (d->do_io == CONFIG_ONDEMAND_ONDEMAND && (readsectors || writesectors))) {
+			d->do_io = CONFIG_ONDEMAND_YES;
 
-			// by default, do not add charts that do not have values
-			if(ddo_io == CONFIG_ONDEMAND_ONDEMAND && !reads && !writes) ddo_io = 0;
-			if(ddo_mops == CONFIG_ONDEMAND_ONDEMAND && mreads == 0 && mwrites == 0) ddo_mops = 0;
-			if(ddo_iotime == CONFIG_ONDEMAND_ONDEMAND && readms == 0 && writems == 0) ddo_iotime = 0;
-			if(ddo_util == CONFIG_ONDEMAND_ONDEMAND && busy_ms == 0) ddo_util = 0;
-			if(ddo_backlog == CONFIG_ONDEMAND_ONDEMAND && backlog_ms == 0) ddo_backlog = 0;
-			if(ddo_qops == CONFIG_ONDEMAND_ONDEMAND && backlog_ms == 0) ddo_qops = 0;
+			st = rrdset_find_bytype(RRD_TYPE_DISK, disk);
+			if(!st) {
+				st = rrdset_create(RRD_TYPE_DISK, disk, NULL, family, "disk.io", "Disk I/O Bandwidth", "kilobytes/s", 2000, update_every, RRDSET_TYPE_AREA);
 
-			// for absolute values, we need to switch the setting to 'yes'
-			// to allow it refresh from now on
-			if(ddo_qops == CONFIG_ONDEMAND_ONDEMAND) config_set(var_name, "queued operations", "yes");
-
-			// --------------------------------------------------------------------
-			int sector_size = 512;
-			if(ddo_io) {
-				st = rrdset_find_bytype(RRD_TYPE_DISK, disk);
-				if(!st) {
-					char tf[FILENAME_MAX + 1], *t;
-					char ssfilename[FILENAME_MAX + 1];
-
-					strncpyz(tf, disk, FILENAME_MAX);
-
-					// replace all / with !
-					while((t = strchr(tf, '/'))) *t = '!';
-
-					snprintfz(ssfilename, FILENAME_MAX, path_to_get_hw_sector_size, tf);
-					FILE *fpss = fopen(ssfilename, "r");
-					if(fpss) {
-						char ssbuffer[1025];
-						char *tmp = fgets(ssbuffer, 1024, fpss);
-
-						if(tmp) {
-							sector_size = atoi(tmp);
-							if(sector_size <= 0) {
-								error("Invalid sector size %d for device %s in %s. Assuming 512.", sector_size, disk, ssfilename);
-								sector_size = 512;
-							}
-						}
-						else error("Cannot read data for sector size for device %s from %s. Assuming 512.", disk, ssfilename);
-
-						fclose(fpss);
-					}
-					else error("Cannot read sector size for device %s from %s. Assuming 512.", disk, ssfilename);
-
-					st = rrdset_create(RRD_TYPE_DISK, disk, NULL, family, "disk.io", "Disk I/O Bandwidth", "kilobytes/s", 2000, update_every, RRDSET_TYPE_AREA);
-
-					rrddim_add(st, "reads", NULL, sector_size, 1024, RRDDIM_INCREMENTAL);
-					rrddim_add(st, "writes", NULL, sector_size * -1, 1024, RRDDIM_INCREMENTAL);
-				}
-				else rrdset_next_usec(st, dt);
-
-				last_readsectors  = rrddim_set(st, "reads", readsectors);
-				last_writesectors = rrddim_set(st, "writes", writesectors);
-				rrdset_done(st);
+				rrddim_add(st, "reads", NULL, d->sector_size, 1024, RRDDIM_INCREMENTAL);
+				rrddim_add(st, "writes", NULL, d->sector_size * -1, 1024, RRDDIM_INCREMENTAL);
 			}
+			else rrdset_next_usec(st, dt);
 
-			// --------------------------------------------------------------------
-			if(ddo_ops) {
-				st = rrdset_find_bytype("disk_ops", disk);
+			last_readsectors  = rrddim_set(st, "reads", readsectors);
+			last_writesectors = rrddim_set(st, "writes", writesectors);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_ops == CONFIG_ONDEMAND_YES || (d->do_ops == CONFIG_ONDEMAND_ONDEMAND && (reads || writes))) {
+			d->do_ops = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_ops", disk);
+			if(!st) {
+				st = rrdset_create("disk_ops", disk, NULL, family, "disk.ops", "Disk Completed I/O Operations", "operations/s", 2001, update_every, RRDSET_TYPE_LINE);
+				st->isdetail = 1;
+
+				rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
+				rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
+			}
+			else rrdset_next_usec(st, dt);
+
+			last_reads  = rrddim_set(st, "reads", reads);
+			last_writes = rrddim_set(st, "writes", writes);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_qops == CONFIG_ONDEMAND_YES || (d->do_qops == CONFIG_ONDEMAND_ONDEMAND && queued_ios)) {
+			d->do_qops = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_qops", disk);
+			if(!st) {
+				st = rrdset_create("disk_qops", disk, NULL, family, "disk.qops", "Disk Current I/O Operations", "operations", 2002, update_every, RRDSET_TYPE_LINE);
+				st->isdetail = 1;
+
+				rrddim_add(st, "operations", NULL, 1, 1, RRDDIM_ABSOLUTE);
+			}
+			else rrdset_next_usec(st, dt);
+
+			rrddim_set(st, "operations", queued_ios);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_backlog == CONFIG_ONDEMAND_YES || (d->do_backlog == CONFIG_ONDEMAND_ONDEMAND && backlog_ms)) {
+			d->do_backlog = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_backlog", disk);
+			if(!st) {
+				st = rrdset_create("disk_backlog", disk, NULL, family, "disk.backlog", "Disk Backlog", "backlog (ms)", 2003, update_every, RRDSET_TYPE_AREA);
+				st->isdetail = 1;
+
+				rrddim_add(st, "backlog", NULL, 1, 10, RRDDIM_INCREMENTAL);
+			}
+			else rrdset_next_usec(st, dt);
+
+			rrddim_set(st, "backlog", backlog_ms);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_util == CONFIG_ONDEMAND_YES || (d->do_util == CONFIG_ONDEMAND_ONDEMAND && busy_ms)) {
+			d->do_util = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_util", disk);
+			if(!st) {
+				st = rrdset_create("disk_util", disk, NULL, family, "disk.util", "Disk Utilization Time", "% of time working", 2004, update_every, RRDSET_TYPE_AREA);
+				st->isdetail = 1;
+
+				rrddim_add(st, "utilization", NULL, 1, 10, RRDDIM_INCREMENTAL);
+			}
+			else rrdset_next_usec(st, dt);
+
+			last_busy_ms = rrddim_set(st, "utilization", busy_ms);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_mops == CONFIG_ONDEMAND_YES || (d->do_mops == CONFIG_ONDEMAND_ONDEMAND && (mreads || mwrites))) {
+			d->do_mops = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_mops", disk);
+			if(!st) {
+				st = rrdset_create("disk_mops", disk, NULL, family, "disk.mops", "Disk Merged Operations", "merged operations/s", 2021, update_every, RRDSET_TYPE_LINE);
+				st->isdetail = 1;
+
+				rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
+				rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
+			}
+			else rrdset_next_usec(st, dt);
+
+			rrddim_set(st, "reads", mreads);
+			rrddim_set(st, "writes", mwrites);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+
+		if(d->do_iotime == CONFIG_ONDEMAND_YES || (d->do_iotime == CONFIG_ONDEMAND_ONDEMAND && (readms || writems))) {
+			d->do_iotime = CONFIG_ONDEMAND_YES;
+
+			st = rrdset_find_bytype("disk_iotime", disk);
+			if(!st) {
+				st = rrdset_create("disk_iotime", disk, NULL, family, "disk.iotime", "Disk Total I/O Time", "milliseconds/s", 2022, update_every, RRDSET_TYPE_LINE);
+				st->isdetail = 1;
+
+				rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
+				rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
+			}
+			else rrdset_next_usec(st, dt);
+
+			last_readms  = rrddim_set(st, "reads", readms);
+			last_writems = rrddim_set(st, "writes", writems);
+			rrdset_done(st);
+		}
+
+		// --------------------------------------------------------------------
+		// calculate differential charts
+		// only if this is not the first time we run
+
+		if(dt) {
+			if(d->do_iotime && d->do_ops) {
+				st = rrdset_find_bytype("disk_await", disk);
 				if(!st) {
-					st = rrdset_create("disk_ops", disk, NULL, family, "disk.ops", "Disk Completed I/O Operations", "operations/s", 2001, update_every, RRDSET_TYPE_LINE);
+					st = rrdset_create("disk_await", disk, NULL, family, "disk.await", "Average Completed I/O Operation Time", "ms per operation", 2005, update_every, RRDSET_TYPE_LINE);
 					st->isdetail = 1;
 
-					rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
-					rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
+					rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_ABSOLUTE);
+					rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_ABSOLUTE);
 				}
 				else rrdset_next_usec(st, dt);
 
-				last_reads  = rrddim_set(st, "reads", reads);
-				last_writes = rrddim_set(st, "writes", writes);
+				rrddim_set(st, "reads", (reads - last_reads) ? (readms - last_readms) / (reads - last_reads) : 0);
+				rrddim_set(st, "writes", (writes - last_writes) ? (writems - last_writems) / (writes - last_writes) : 0);
 				rrdset_done(st);
 			}
 
-			// --------------------------------------------------------------------
-			if(ddo_qops) {
-				st = rrdset_find_bytype("disk_qops", disk);
+			if(d->do_io && d->do_ops) {
+				st = rrdset_find_bytype("disk_avgsz", disk);
 				if(!st) {
-					st = rrdset_create("disk_qops", disk, NULL, family, "disk.qops", "Disk Current I/O Operations", "operations", 2002, update_every, RRDSET_TYPE_LINE);
+					st = rrdset_create("disk_avgsz", disk, NULL, family, "disk.avgsz", "Average Completed I/O Operation Bandwidth", "kilobytes per operation", 2006, update_every, RRDSET_TYPE_AREA);
 					st->isdetail = 1;
 
-					rrddim_add(st, "operations", NULL, 1, 1, RRDDIM_ABSOLUTE);
+					rrddim_add(st, "reads", NULL, d->sector_size, 1024, RRDDIM_ABSOLUTE);
+					rrddim_add(st, "writes", NULL, d->sector_size * -1, 1024, RRDDIM_ABSOLUTE);
 				}
 				else rrdset_next_usec(st, dt);
 
-				rrddim_set(st, "operations", queued_ios);
+				rrddim_set(st, "reads", (reads - last_reads) ? (readsectors - last_readsectors) / (reads - last_reads) : 0);
+				rrddim_set(st, "writes", (writes - last_writes) ? (writesectors - last_writesectors) / (writes - last_writes) : 0);
 				rrdset_done(st);
 			}
 
-			// --------------------------------------------------------------------
-			if(ddo_backlog) {
-				st = rrdset_find_bytype("disk_backlog", disk);
+			if(d->do_util && d->do_ops) {
+				st = rrdset_find_bytype("disk_svctm", disk);
 				if(!st) {
-					st = rrdset_create("disk_backlog", disk, NULL, family, "disk.backlog", "Disk Backlog", "backlog (ms)", 2003, update_every, RRDSET_TYPE_AREA);
+					st = rrdset_create("disk_svctm", disk, NULL, family, "disk.svctm", "Average Service Time", "ms per operation", 2007, update_every, RRDSET_TYPE_LINE);
 					st->isdetail = 1;
 
-					rrddim_add(st, "backlog", NULL, 1, 10, RRDDIM_INCREMENTAL);
+					rrddim_add(st, "svctm", NULL, 1, 1, RRDDIM_ABSOLUTE);
 				}
 				else rrdset_next_usec(st, dt);
 
-				rrddim_set(st, "backlog", backlog_ms);
+				rrddim_set(st, "svctm", ((reads - last_reads) + (writes - last_writes)) ? (busy_ms - last_busy_ms) / ((reads - last_reads) + (writes - last_writes)) : 0);
 				rrdset_done(st);
-			}
-
-			// --------------------------------------------------------------------
-			if(ddo_util) {
-				st = rrdset_find_bytype("disk_util", disk);
-				if(!st) {
-					st = rrdset_create("disk_util", disk, NULL, family, "disk.util", "Disk Utilization Time", "% of time working", 2004, update_every, RRDSET_TYPE_AREA);
-					st->isdetail = 1;
-
-					rrddim_add(st, "utilization", NULL, 1, 10, RRDDIM_INCREMENTAL);
-				}
-				else rrdset_next_usec(st, dt);
-
-				last_busy_ms = rrddim_set(st, "utilization", busy_ms);
-				rrdset_done(st);
-			}
-
-			// --------------------------------------------------------------------
-			if(ddo_mops) {
-				st = rrdset_find_bytype("disk_mops", disk);
-				if(!st) {
-					st = rrdset_create("disk_mops", disk, NULL, family, "disk.mops", "Disk Merged Operations", "merged operations/s", 2021, update_every, RRDSET_TYPE_LINE);
-					st->isdetail = 1;
-
-					rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
-					rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
-				}
-				else rrdset_next_usec(st, dt);
-
-				rrddim_set(st, "reads", mreads);
-				rrddim_set(st, "writes", mwrites);
-				rrdset_done(st);
-			}
-
-			// --------------------------------------------------------------------
-			if(ddo_iotime) {
-				st = rrdset_find_bytype("disk_iotime", disk);
-				if(!st) {
-					st = rrdset_create("disk_iotime", disk, NULL, family, "disk.iotime", "Disk Total I/O Time", "milliseconds/s", 2022, update_every, RRDSET_TYPE_LINE);
-					st->isdetail = 1;
-
-					rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_INCREMENTAL);
-					rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_INCREMENTAL);
-				}
-				else rrdset_next_usec(st, dt);
-
-				last_readms  = rrddim_set(st, "reads", readms);
-				last_writems = rrddim_set(st, "writes", writems);
-				rrdset_done(st);
-			}
-
-			// --------------------------------------------------------------------
-			// calculate differential charts
-			// only if this is not the first time we run
-			if(dt) {
-				if(ddo_iotime && ddo_ops) {
-					st = rrdset_find_bytype("disk_await", disk);
-					if(!st) {
-						st = rrdset_create("disk_await", disk, NULL, family, "disk.await", "Average Completed I/O Operation Time", "ms per operation", 2005, update_every, RRDSET_TYPE_LINE);
-						st->isdetail = 1;
-
-						rrddim_add(st, "reads", NULL, 1, 1, RRDDIM_ABSOLUTE);
-						rrddim_add(st, "writes", NULL, -1, 1, RRDDIM_ABSOLUTE);
-					}
-					else rrdset_next_usec(st, dt);
-
-					rrddim_set(st, "reads", (reads - last_reads) ? (readms - last_readms) / (reads - last_reads) : 0);
-					rrddim_set(st, "writes", (writes - last_writes) ? (writems - last_writems) / (writes - last_writes) : 0);
-					rrdset_done(st);
-				}
-
-				if(ddo_io && ddo_ops) {
-					st = rrdset_find_bytype("disk_avgsz", disk);
-					if(!st) {
-						st = rrdset_create("disk_avgsz", disk, NULL, family, "disk.avgsz", "Average Completed I/O Operation Bandwidth", "kilobytes per operation", 2006, update_every, RRDSET_TYPE_AREA);
-						st->isdetail = 1;
-
-						rrddim_add(st, "reads", NULL, sector_size, 1024, RRDDIM_ABSOLUTE);
-						rrddim_add(st, "writes", NULL, -sector_size, 1024, RRDDIM_ABSOLUTE);
-					}
-					else rrdset_next_usec(st, dt);
-
-					rrddim_set(st, "reads", (reads - last_reads) ? (readsectors - last_readsectors) / (reads - last_reads) : 0);
-					rrddim_set(st, "writes", (writes - last_writes) ? (writesectors - last_writesectors) / (writes - last_writes) : 0);
-					rrdset_done(st);
-				}
-
-				if(ddo_util && ddo_ops) {
-					st = rrdset_find_bytype("disk_svctm", disk);
-					if(!st) {
-						st = rrdset_create("disk_svctm", disk, NULL, family, "disk.svctm", "Average Service Time", "ms per operation", 2007, update_every, RRDSET_TYPE_LINE);
-						st->isdetail = 1;
-
-						rrddim_add(st, "svctm", NULL, 1, 1, RRDDIM_ABSOLUTE);
-					}
-					else rrdset_next_usec(st, dt);
-
-					rrddim_set(st, "svctm", ((reads - last_reads) + (writes - last_writes)) ? (busy_ms - last_busy_ms) / ((reads - last_reads) + (writes - last_writes)) : 0);
-					rrdset_done(st);
-				}
 			}
 		}
 
 		// --------------------------------------------------------------------------
-		// Do space metrics
-		def_space = config_get_boolean_ondemand(var_name, "enable space metrics", def_space);		
-		if(def_space != CONFIG_ONDEMAND_NO) {
-			int ddo_space = do_space, ddo_inodes = do_inodes;
+		// space metrics
 
-			ddo_space = config_get_boolean_ondemand(var_name, "space", ddo_space);
-			ddo_inodes = config_get_boolean_ondemand(var_name, "inodes", ddo_space);
-			if(mount_point && (ddo_space || ddo_inodes) ) {
-				// collect space metrics using statvfs
-				if (statvfs(mount_point, &buff_statvfs) < 0) {
-					error("Failed checking disk space usage of %s", family);
-				} else {
-					// verify we collected the metrics for the right disk.
-					// if not the mountpoint has changed.
-					if(stat(mount_point, &buff_stat) == -1) {
-						error("Failed to call stat for %s", family);
-					} else {
-						if(major(buff_stat.st_dev) == major && minor(buff_stat.st_dev) == minor)
-						{
-							if(ddo_space) {
-								space_avail = buff_statvfs.f_bavail * buff_statvfs.f_bsize;
-								space_avail_root = (buff_statvfs.f_bfree - buff_statvfs.f_bavail) * buff_statvfs.f_bsize;
-								space_used = (buff_statvfs.f_blocks - buff_statvfs.f_bfree) * buff_statvfs.f_bsize;
+		if(d->mount_point && (d->do_space || d->do_inodes) ) {
+			// collect space metrics using statvfs
 
-								st = rrdset_find_bytype("disk_space", disk);
-								if(!st) {
-									st = rrdset_create("disk_space", disk, NULL, family, "disk.space", "Disk Space Usage", "GB", 2023, update_every, RRDSET_TYPE_STACKED);
-									st->isdetail = 1;
+			if (statvfs(d->mount_point, &buff_statvfs) < 0)
+				error("Failed statvfs() for '%s' (disk '%s')", d->mount_point, d->disk);
+			else {
+				space_avail = buff_statvfs.f_bavail * buff_statvfs.f_bsize;
+				space_avail_root = (buff_statvfs.f_bfree - buff_statvfs.f_bavail) * buff_statvfs.f_bsize;
+				space_used = (buff_statvfs.f_blocks - buff_statvfs.f_bfree) * buff_statvfs.f_bsize;
 
-									rrddim_add(st, "avail", NULL, 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
-									rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
-									rrddim_add(st, "used" , NULL, 1, 1000*1000*1000, RRDDIM_ABSOLUTE);
-								}
-								else rrdset_next_usec(st, dt);
+				inodes_avail = buff_statvfs.f_favail;
+				inodes_avail_root = buff_statvfs.f_ffree - buff_statvfs.f_favail;
+				inodes_used = buff_statvfs.f_files - buff_statvfs.f_ffree;
 
-								rrddim_set(st, "avail", space_avail);
-								rrddim_set(st, "reserved_for_root", space_avail_root);
-								rrddim_set(st, "used", space_used);
-								rrdset_done(st);
+				// verify we collected the metrics for the right disk.
+				// if not the mountpoint has changed.
+
+				if(stat(d->mount_point, &buff_stat) == -1)
+					error("Failed to stat() for '%s' (disk '%s')", d->mount_point, d->disk);
+				else {
+					if(major(buff_stat.st_dev) == major && minor(buff_stat.st_dev) == minor) {
+
+						// --------------------------------------------------------------------------
+
+						if(d->do_space == CONFIG_ONDEMAND_YES || (d->do_space == CONFIG_ONDEMAND_ONDEMAND && (space_avail || space_avail_root || space_used))) {
+							st = rrdset_find_bytype("disk_space", disk);
+							if(!st) {
+								st = rrdset_create("disk_space", disk, NULL, family, "disk.space", "Disk Space Usage", "GB", 2023, update_every, RRDSET_TYPE_STACKED);
+								st->isdetail = 1;
+
+								rrddim_add(st, "avail", NULL, 1, 1024*1024*1024, RRDDIM_ABSOLUTE);
+								rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1024*1024*1024, RRDDIM_ABSOLUTE);
+								rrddim_add(st, "used" , NULL, 1, 1024*1024*1024, RRDDIM_ABSOLUTE);
 							}
-							if(ddo_inodes) {
-								inodes_avail = buff_statvfs.f_favail;
-								inodes_avail_root = buff_statvfs.f_ffree - buff_statvfs.f_favail;
-								inodes_used = buff_statvfs.f_files - buff_statvfs.f_ffree;
+							else rrdset_next_usec(st, dt);
 
-								st = rrdset_find_bytype("disk_inodes", disk);
-								if(!st) {
-									st = rrdset_create("disk_inodes", disk, NULL, family, "disk.inodes", "Disk Inodes Usage", "Inodes", 2024, update_every, RRDSET_TYPE_STACKED);
-									st->isdetail = 1;
+							rrddim_set(st, "avail", space_avail);
+							rrddim_set(st, "reserved_for_root", space_avail_root);
+							rrddim_set(st, "used", space_used);
+							rrdset_done(st);
+						}
 
-									rrddim_add(st, "avail", NULL, 1, 1, RRDDIM_ABSOLUTE);
-									rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1, RRDDIM_ABSOLUTE);
-									rrddim_add(st, "used" , NULL, 1, 1, RRDDIM_ABSOLUTE);
-								}
-								else rrdset_next_usec(st, dt);
+						// --------------------------------------------------------------------------
 
-								rrddim_set(st, "avail", inodes_avail);
-								rrddim_set(st, "reserved_for_root", inodes_avail_root);
-								rrddim_set(st, "used", inodes_used);
-								rrdset_done(st);
+						if(d->do_inodes == CONFIG_ONDEMAND_YES || (d->do_inodes == CONFIG_ONDEMAND_ONDEMAND && (inodes_avail || inodes_avail_root || inodes_used))) {
+							st = rrdset_find_bytype("disk_inodes", disk);
+							if(!st) {
+								st = rrdset_create("disk_inodes", disk, NULL, family, "disk.inodes", "Disk Inodes Usage", "Inodes", 2024, update_every, RRDSET_TYPE_STACKED);
+								st->isdetail = 1;
+
+								rrddim_add(st, "avail", NULL, 1, 1, RRDDIM_ABSOLUTE);
+								rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1, RRDDIM_ABSOLUTE);
+								rrddim_add(st, "used" , NULL, 1, 1, RRDDIM_ABSOLUTE);
 							}
+							else rrdset_next_usec(st, dt);
+
+							rrddim_set(st, "avail", inodes_avail);
+							rrddim_set(st, "reserved_for_root", inodes_avail_root);
+							rrddim_set(st, "used", inodes_used);
+							rrdset_done(st);
 						}
 					}
 				}
 			}
 		}
 	}
+
 	return 0;
 }

--- a/src/url.c
+++ b/src/url.c
@@ -63,31 +63,37 @@ char *url_encode(char *str) {
 /* Returns a url-decoded version of str */
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_decode(char *str) {
-	char *pstr = str,
-		*buf = malloc(strlen(str) + 1),
-		*pbuf = buf;
+	size_t size = strlen(str) + 1;
 
+	char *buf = malloc(size);
 	if(!buf)
-		fatal("Cannot allocate memory.");
+		fatal("Cannot allocate %zu bytes of memory.", size);
 
-	while (*pstr) {
-		if (*pstr == '%') {
-			if (pstr[1] && pstr[2]) {
-				*pbuf++ = from_hex(pstr[1]) << 4 | from_hex(pstr[2]);
-				pstr += 2;
-			}
-		}
-		else if (*pstr == '+')
-			*pbuf++ = ' ';
-
-		else
-			*pbuf++ = *pstr;
-
-		pstr++;
-	}
-
-	*pbuf = '\0';
-
-	return buf;
+	return url_decode_r(buf, str, size);
 }
 
+char *url_decode_r(char *to, char *url, size_t size) {
+	char *s = url,           // source
+		 *d = to,            // destination
+		 *e = &to[size - 1]; // destination end
+
+	while(*s && d < e) {
+		if(unlikely(*s == '%')) {
+			if(likely(s[1] && s[2])) {
+				*d++ = from_hex(s[1]) << 4 | from_hex(s[2]);
+				s += 2;
+			}
+		}
+		else if(unlikely(*s == '+'))
+			*d++ = ' ';
+
+		else
+			*d++ = *s;
+
+		s++;
+	}
+
+	*d = '\0';
+
+	return to;
+}

--- a/src/url.h
+++ b/src/url.h
@@ -19,4 +19,6 @@ extern char *url_encode(char *str);
 /* IMPORTANT: be sure to free() the returned string after use */
 extern char *url_decode(char *str);
 
+extern char *url_decode_r(char *to, char *url, size_t size);
+
 #endif /* NETDATA_URL_H */

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1229,7 +1229,7 @@ static inline char *http_header_parse(struct web_client *w, char *s) {
 	}
 #ifdef NETDATA_WITH_ZLIB
 	else if(!strcasecmp(s, "Accept-Encoding")) {
-		if(web_enable_gzip && strcasestr(v, "gzip")) {
+		if(web_enable_gzip && (strcasestr(v, "gzip") || strcasestr(v, "deflate"))) {
 			w->enable_gzip = 1;
 		}
 	}

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -57,7 +57,8 @@ struct web_client {
 	char client_ip[NI_MAXHOST+1];
 	char client_port[NI_MAXSERV+1];
 
-	char last_url[URL_MAX+1];
+	char decoded_url[URL_MAX + 1];	// we decode the URL in this buffer
+	char last_url[URL_MAX+1];		// we keep a copy of the decoded URL here
 
 	struct timeval tv_in, tv_ready;
 
@@ -68,7 +69,6 @@ struct web_client {
 	int mode;
 	int keepalive;
 	int enable_gzip;
-	char *decoded_url;
 
 	struct sockaddr_storage clientaddr;
 

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -83,6 +83,9 @@ struct web_client {
 	int wait_receive;
 	int wait_send;
 
+	unsigned long stats_received_bytes;
+	unsigned long stats_sent_bytes;
+
 	struct web_client *prev;
 	struct web_client *next;
 };


### PR DESCRIPTION
I did several optimizations to speed up netdata:

- web statistics now use a single lock per web request.
- diskstats cache all the config options for the disks, so that on each data collection iteration there is no configuration options check
- eliminated a malloc()/free() per web request by refactoring the url_decode() function

a few optimizations to lower the memory requirements of netdata:

- registry now uses dictionaries without statistics info (saved 32 bytes per person and machine)

added a new performance chart for netdata:

- Average API response time in ms is now reported in netdata charts

Optimized a bit the code that parses the web request:

- a few array references were converted to pointer operations

Configuration changes

- `on demand` renamed to `auto`. `on demand` still works when parsing the configuration file, but the generated one will have the values as `auto`.

Code cleanup:

- diskstats cleanup a bit the code, renamed the variables, etc.

Bugs fixed:

- netdata was not able to find the hw sector size for partitions. Now it is. This fixes #393
