### PR TITLE
use try-restart in logrotate sample

### DIFF
--- a/system/netdata.logrotate.in
+++ b/system/netdata.logrotate.in
@@ -14,8 +14,6 @@
 	copytruncate
 	#
 	#postrotate
-	#	if service netdata status > /dev/null ; then \
-	#		service netdata restart > /dev/null; \
-	#	fi;
+	#	/sbin/service netdata try-restart >/dev/null
 	#endscript
 }


### PR DESCRIPTION
now that #440 is merged, can use try-restart action

[LSB 3.1](http://refspecs.linuxfoundation.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html):
> restart the service if the service is already running

it should even work for systemd systems which proxy calls from `/sbin/service` to [systemctl](https://www.freedesktop.org/software/systemd/man/systemctl.html#try-restart%20PATTERN...)