### PR TITLE
add --enable-sse option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
  - clang
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq automake make libcap2-bin zlib1g-dev uuid-dev
+ - sudo apt-get install -qq automake make libcap2-bin zlib1g-dev uuid-dev autoconf-archive
 script:
    # default build
  - ./autogen.sh && ./configure && make -j4

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,18 @@ if test "${enable_pedantic}" = "yes"; then
 	CFLAGS="${CFLAGS} -pedantic -Wall -Wextra -Wno-long-long"
 fi
 
+
+# Check for SSE/SSE2 flags if compile supports
+AC_ARG_ENABLE([sse],
+AS_HELP_STRING([--enable-sse=yes|no], [enable SSE/SS2 optimizations [default=no]]),
+[case "${enableval}" in
+yes)
+	opt="-msse2 -mfpmath=sse"
+	AX_CHECK_COMPILE_FLAG($opt, [CFLAGS="$CFLAGS $opt"], []) ;;
+no) ;;
+*)  AC_MSG_ERROR([bad value ${enableval} for --enable-sse]) ;;
+esac])
+
 AC_DEFINE_UNQUOTED([NETDATA_USER], ["${with_user}"], [use this user to drop privileged])
 
 AC_SUBST([varlibdir], ["\$(localstatedir)/lib/netdata"])


### PR DESCRIPTION
add --enable-sse option. #263

adds the starting ground, by default the option is not enabled.

my x86-64 compiler was able to compile with the flags although i'm sure those are not needed on x86-64 target.