### PR TITLE
multi-threaded web server using poll(), added single threaded web server (using select())

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -594,9 +594,21 @@ then
 	run service netdata start && running=1
 fi
 
+if [ ${running} -eq 0 -a "${UID}" -eq 0 ]
+then
+	service netdata status >/dev/null 2>&1
+	if [ $? -eq 0 ]
+	then
+		# nice guy, he installed netdata to his system
+		run service netdata stop
+		stop_all_netdata
+		run service netdata start && running=1
+	fi
+fi
+
 if [ ${running} -eq 0 ]
 then
-	# no systemd (or not running as root, or systemd failed)
+	# still not running...
 
 	stop_all_netdata
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -524,60 +524,95 @@ isnetdata() {
 	return 1
 }
 
+stop_netdata_on_pid() {
+	local pid="$1" ret=0 count=0
 
-echo >&2
-echo >&2 "-------------------------------------------------------------------------------"
-echo >&2
-printf >&2 "Stopping a (possibly) running netdata..."
-ret=0
-count=0
-while [ $ret -eq 0 ]
-do
-	if [ $count -gt 30 ]
-		then
-		echo >&2 "Cannot stop the running netdata."
-		exit 1
-	fi
+	isnetdata $pid || return 0
 
-	count=$((count + 1))
+	printf >&2 "Stopping netdata on pid $pid ..."
+	while [ ! -z "$pid" -a $ret -eq 0 ]
+	do
+		if [ $count -gt 45 ]
+			then
+			echo >&2 "Cannot stop the running netdata on pid $pid."
+			return 1
+		fi
 
-	pid=$(cat "${NETDATA_RUN_DIR}/netdata.pid" 2>/dev/null)
-	# backwards compatibility
-	[ -z "${pid}" ] && pid=$(cat /var/run/netdata.pid 2>/dev/null)
-	[ -z "${pid}" ] && pid=$(cat /var/run/netdata/netdata.pid 2>/dev/null)
-	
-	isnetdata $pid || pid=
-	if [ ! -z "${pid}" ]
-		then
+		count=$(( count + 1 ))
+
 		run kill $pid 2>/dev/null
 		ret=$?
-	else
-		run killall netdata 2>/dev/null
-		ret=$?
+
+		test $ret -eq 0 && printf >&2 "." && sleep 2
+	done
+
+	echo >&2
+	if [ $ret -eq 0 ]
+	then
+		echo >&2 "SORRY! CANNOT STOP netdata ON PID $pid !"
+		return 1
 	fi
 
-	test $ret -eq 0 && printf >&2 "." && sleep 2
-done
-echo >&2
-echo >&2
+	echo >&2 "netdata on pid $pid stopped."
+	return 0
+}
 
+stop_all_netdata() {
+	local p
+
+	echo >&2 "Stopping a (possibly) running netdata..."
+
+	for p in $(cat "${NETDATA_RUN_DIR}/netdata.pid" 2>/dev/null) \
+		$(cat /var/run/netdata.pid 2>/dev/null) \
+		$(cat /var/run/netdata/netdata.pid 2>/dev/null) \
+		$(pidof netdata 2>/dev/null)
+	do
+		stop_netdata_on_pid $p
+	done
+}
 
 # -----------------------------------------------------------------------------
-# run netdata
+# check netdata for systemd
 
-echo >&2 "Starting netdata..."
-run ${NETDATA_PREFIX}/usr/sbin/netdata -P ${NETDATA_RUN_DIR}/netdata.pid "${@}"
+running=0
+pidof systemd >/dev/null 2>&1
+if [ $? -eq 0 -a "${UID}" -eq 0 ]
+then
+	# systemd is running on this system
 
-if [ $? -ne 0 ]
+	if [ ! -f /etc/systemd/system/netdata.service ]
 	then
-	echo >&2
-	echo >&2 "SORRY! FAILED TO START NETDATA!"
-	exit 1
-else
-	echo >&2 "OK. NetData Started!"
-fi
-echo >&2
+		echo >&2 "Installing systemd service..."
+		run cp system/netdata.service /etc/systemd/system/netdata.service && \
+			run systemctl daemon-reload && \
+			run systemctl enable netdata
+	else
+		run service netdata stop
+	fi
 
+	stop_all_netdata
+	run service netdata start && running=1
+fi
+
+if [ ${running} -eq 0 ]
+then
+	# no systemd (or not running as root, or systemd failed)
+
+	stop_all_netdata
+
+	echo >&2 "Starting netdata..."
+	run ${NETDATA_PREFIX}/usr/sbin/netdata -P ${NETDATA_RUN_DIR}/netdata.pid "${@}"
+	if [ $? -ne 0 ]
+		then
+		echo >&2
+		echo >&2 "SORRY! FAILED TO START NETDATA!"
+		exit 1
+	else
+		echo >&2 "OK. NetData Started!"
+	fi
+
+	echo >&2
+fi
 
 # -----------------------------------------------------------------------------
 # save a config file, if it is not already there
@@ -633,7 +668,7 @@ ksm_is_available_but_disabled() {
 	-------------------------------------------------------------------------------
 	Memory de-duplication instructions
 
-	I see you have kernel memory de-duper (called Kernel Same-page Merging,
+	You have kernel memory de-duper (called Kernel Same-page Merging,
 	or KSM) available, but it is not currently enabled.
 
 	To enable it run:
@@ -741,7 +776,7 @@ cat >netdata-uninstaller.sh <<-UNINSTALL
 	fi
 
 	echo >&2 "Stopping a possibly running netdata..."
-	killall netdata
+	for p in \$(pidof netdata); do kill \$x; done
 	sleep 2
 
 	deletedir() {
@@ -780,6 +815,12 @@ cat >netdata-uninstaller.sh <<-UNINSTALL
 		then
 		echo "Deleting /etc/logrotate.d/netdata ..."
 		rm -i /etc/logrotate.d/netdata
+	fi
+
+	if [ -f /etc/systemd/system/netdata.service ]
+		then
+		echo "Deleting /etc/systemd/system/netdata.service ..."
+		rm -i /etc/systemd/system/netdata.service
 	fi
 
 	getent passwd netdata > /dev/null

--- a/src/common.c
+++ b/src/common.c
@@ -596,6 +596,19 @@ uint32_t simple_hash(const char *name) {
 	return hval;
 }
 
+uint32_t simple_uhash(const char *name) {
+	unsigned char *s = (unsigned char *)name;
+	uint32_t hval = 0x811c9dc5, c;
+
+	// FNV-1a algorithm
+	while((c = *s++)) {
+		if(unlikely(c >= 'A' && c <= 'Z')) c += 'a' - 'A';
+		hval *= 16777619;
+		hval ^= c;
+	}
+	return hval;
+}
+
 /*
 // http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
 // one at a time hash

--- a/src/common.h
+++ b/src/common.h
@@ -21,6 +21,8 @@ extern void netdata_fix_chart_id(char *s);
 extern void netdata_fix_chart_name(char *s);
 
 extern uint32_t simple_hash(const char *name);
+extern uint32_t simple_uhash(const char *name);
+
 extern void strreverse(char* begin, char* end);
 extern char *mystrsep(char **ptr, char *s);
 extern char *trim(char *s);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -26,7 +26,6 @@
 #include "daemon.h"
 
 char pidfile[FILENAME_MAX + 1] = "";
-int pidfd = -1;
 
 void sig_handler(int signo)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -99,6 +99,9 @@ void web_server_threading_selection(void) {
 		if(static_threads[i].start_routine == socket_listen_main_single_threaded)
 			static_threads[i].enabled = threaded?0:1;
 	}
+
+	web_client_timeout = (int) config_get_number("global", "disconnect idle web clients after seconds", DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS);
+	web_enable_gzip = config_get_boolean("global", "enable web responses gzip compression", web_enable_gzip);
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -70,25 +70,37 @@ struct netdata_static_thread {
 
 	void (*init_routine) (void);
 	void *(*start_routine) (void *);
-};
-
-struct netdata_static_thread static_threads[] = {
-	{"tc",			"plugins",	"tc",			1, NULL, NULL,	tc_main},
-	{"idlejitter",	"plugins",	"idlejitter",	1, NULL, NULL,	cpuidlejitter_main},
-	{"proc",		"plugins",	"proc",			1, NULL, NULL,	proc_main},
-	{"cgroups",		"plugins",	"cgroups",		1, NULL, NULL,	cgroups_main},
-
+} static_threads[] = {
 #ifdef INTERNAL_PLUGIN_NFACCT
-	// nfacct requires root access
+// nfacct requires root access
 	// so, we build it as an external plugin with setuid to root
-	{"nfacct",		"plugins",	"nfacct",		1, NULL, NULL, 	nfacct_main},
+	{"nfacct",              "plugins",  "nfacct",     1, NULL, NULL, nfacct_main},
 #endif
 
-	{"plugins.d",	NULL,		NULL,			1, NULL, NULL,	pluginsd_main},
-	{"check",		"plugins",	"checks",		0, NULL, NULL,	checks_main},
-	{"web",			NULL,		NULL,			1, NULL, NULL,	socket_listen_main},
-	{NULL,			NULL,		NULL,			0, NULL, NULL,	NULL}
+	{"tc",                 "plugins",   "tc",         1, NULL, NULL, tc_main},
+	{"idlejitter",         "plugins",   "idlejitter", 1, NULL, NULL, cpuidlejitter_main},
+	{"proc",               "plugins",   "proc",       1, NULL, NULL, proc_main},
+	{"cgroups",            "plugins",   "cgroups",    1, NULL, NULL, cgroups_main},
+	{"plugins.d",           NULL,       NULL,         1, NULL, NULL, pluginsd_main},
+	{"check",               "plugins",  "checks",     0, NULL, NULL, checks_main},
+	{"web",                 NULL,       NULL,         1, NULL, NULL, socket_listen_main_multi_threaded},
+	{"web-single-threaded",	NULL,       NULL,         0, NULL, NULL, socket_listen_main_single_threaded},
+	{NULL,                  NULL,       NULL,         0, NULL, NULL, NULL}
 };
+
+void web_server_threading_selection(void) {
+	int threaded = config_get_boolean("global", "multi threaded web server", 1);
+
+	int i;
+	for(i = 0; static_threads[i].name ; i++) {
+		if(static_threads[i].start_routine == socket_listen_main_multi_threaded)
+			static_threads[i].enabled = threaded?1:0;
+
+		if(static_threads[i].start_routine == socket_listen_main_single_threaded)
+			static_threads[i].enabled = threaded?0:1;
+	}
+}
+
 
 int killpid(pid_t pid, int sig)
 {
@@ -591,28 +603,7 @@ int main(int argc, char **argv)
 
 		// --------------------------------------------------------------------
 
-		listen_backlog = (int) config_get_number("global", "http port listen backlog", LISTEN_BACKLOG);
-
-		listen_port = (int) config_get_number("global", "port", LISTEN_PORT);
-		if(listen_port < 1 || listen_port > 65535) {
-			info("Invalid listen port %d given. Defaulting to %d.", listen_port, LISTEN_PORT);
-			listen_port = LISTEN_PORT;
-		}
-		else debug(D_OPTIONS, "Listen port set to %d.", listen_port);
-
-		int ip = 0;
-		char *ipv = config_get("global", "ip version", "any");
-		if(!strcmp(ipv, "any") || !strcmp(ipv, "both") || !strcmp(ipv, "all")) ip = 0;
-		else if(!strcmp(ipv, "ipv4") || !strcmp(ipv, "IPV4") || !strcmp(ipv, "IPv4") || !strcmp(ipv, "4")) ip = 4;
-		else if(!strcmp(ipv, "ipv6") || !strcmp(ipv, "IPV6") || !strcmp(ipv, "IPv6") || !strcmp(ipv, "6")) ip = 6;
-		else info("Cannot understand ip version '%s'. Assuming 'any'.", ipv);
-
-		if(ip == 0 || ip == 6) listen_fd = create_listen_socket6(config_get("global", "bind socket to IP", "*"), listen_port, listen_backlog);
-		if(listen_fd < 0) {
-			listen_fd = create_listen_socket4(config_get("global", "bind socket to IP", "*"), listen_port, listen_backlog);
-			if(listen_fd >= 0 && ip != 4) info("Managed to open an IPv4 socket on port %d.", listen_port);
-		}
-
+		listen_fd = create_listen_socket();
 		if(listen_fd < 0) fatal("Cannot listen socket.");
 	}
 
@@ -655,6 +646,8 @@ int main(int argc, char **argv)
 
 	// ------------------------------------------------------------------------
 	// spawn the threads
+
+	web_server_threading_selection();
 
 	for (i = 0; static_threads[i].name != NULL ; i++) {
 		struct netdata_static_thread *st = &static_threads[i];

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -2134,8 +2134,8 @@ void *web_client_main(void *ptr)
 			fds[0].events = 0;
 			fds[0].revents = 0;
 
-			if(w->wait_receive) fds[0].events += POLLIN;
-			if(w->wait_send)    fds[0].events += POLLOUT;
+			if(w->wait_receive) fds[0].events |= POLLIN;
+			if(w->wait_send)    fds[0].events |= POLLOUT;
 
 			fds[1].fd = -1;
 			fds[1].events = 0;
@@ -2149,13 +2149,13 @@ void *web_client_main(void *ptr)
 			fds[0].fd = w->ifd;
 			fds[0].events = 0;
 			fds[0].revents = 0;
-			if(w->wait_receive) fds[0].events += POLLIN;
+			if(w->wait_receive) fds[0].events |= POLLIN;
 			ifd = &fds[0];
 
 			fds[1].fd = w->ofd;
 			fds[1].events = 0;
 			fds[1].revents = 0;
-			if(w->wait_send)    fds[1].events += POLLOUT;
+			if(w->wait_send)    fds[1].events |= POLLOUT;
 			ofd = &fds[1];
 
 			fdmax = 2;

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -2191,8 +2191,21 @@ void *web_client_main(void *ptr)
 	debug(D_WEB_CLIENT, "%llu: done...", w->id);
 
 	web_client_reset(w);
-	w->obsolete = 1;
-	pthread_exit(NULL);
 
+	// close the sockets/files now
+	// to free file descriptors
+	if(w->ifd == w->ofd) {
+		if(w->ifd != -1) close(w->ifd);
+	}
+	else {
+		if(w->ifd != -1) close(w->ifd);
+		if(w->ofd != -1) close(w->ifd);
+	}
+	w->ifd = -1;
+	w->ofd = -1;
+
+	w->obsolete = 1;
+
+	pthread_exit(NULL);
 	return NULL;
 }

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -273,7 +273,7 @@ uid_t web_files_uid(void)
 				owner_uid = geteuid();
 			}
 			else {
-				debug(D_WEB_CLIENT, "Web files owner set to %s.\n", web_owner);
+				debug(D_WEB_CLIENT, "Web files owner set to %s.", web_owner);
 				owner_uid = pw->pw_uid;
 			}
 		}
@@ -301,7 +301,7 @@ gid_t web_files_gid(void)
 				owner_gid = getegid();
 			}
 			else {
-				debug(D_WEB_CLIENT, "Web files group set to %s.\n", web_group);
+				debug(D_WEB_CLIENT, "Web files group set to %s.", web_group);
 				owner_gid = gr->gr_gid;
 			}
 		}

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -231,7 +231,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
 		retval = poll(&fd, 1, timeout);
 
 		if(unlikely(retval == -1)) {
-			error("LISTENER: poll() failed.");
+			debug(D_WEB_CLIENT, "LISTENER: poll() failed.");
 			failures++;
 
 			if(failures > 10) {
@@ -298,7 +298,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
 		failures = 0;
 	}
 
-	error("LISTENER: exit!");
+	debug(D_WEB_CLIENT, "LISTENER: exit!");
 	close(listen_fd);
 	listen_fd = -1;
 	return NULL;
@@ -391,7 +391,7 @@ void *socket_listen_main_single_threaded(void *ptr) {
 		retval = select(fdmax+1, &rifds, &rofds, &refds, &tv);
 
 		if(unlikely(retval == -1)) {
-			error("LISTENER: select() failed.");
+			debug(D_WEB_CLIENT, "LISTENER: select() failed.");
 			failures++;
 			if(failures > 10) {
 				if(global_statistics.connected_clients) {
@@ -483,7 +483,7 @@ void *socket_listen_main_single_threaded(void *ptr) {
 		}
 	}
 
-	error("LISTENER: exit!");
+	debug(D_WEB_CLIENT, "LISTENER: exit!");
 	close(listen_fd);
 	listen_fd = -1;
 	return NULL;

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -86,7 +86,7 @@ int create_listen_socket4(const char *ip, int port, int listen_backlog)
 
 	if(is_ip_anything(ip)) {
 		name.sin_addr.s_addr = htonl(INADDR_ANY);
-		info("Listening on any IPs (IPv4).");
+		// info("Listening on any IPs (IPv4).");
 	}
 	else {
 		int ret = inet_pton(AF_INET, ip, (void *)&name.sin_addr.s_addr);
@@ -95,7 +95,7 @@ int create_listen_socket4(const char *ip, int port, int listen_backlog)
 			close(sock);
 			return -1;
 		}
-		info("Listening on IP '%s' (IPv4).", ip);
+		// info("Listening on IP '%s' (IPv4).", ip);
 	}
 
 	if(bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
@@ -137,7 +137,7 @@ int create_listen_socket6(const char *ip, int port, int listen_backlog)
 
 	if(is_ip_anything(ip)) {
 		name.sin6_addr = in6addr_any;
-		info("Listening on all IPs (IPv6 and IPv4)");
+		// info("Listening on all IPs (IPv6 and IPv4)");
 	}
 	else {
 		int ret = inet_pton(AF_INET6, ip, (void *)&name.sin6_addr.s6_addr);
@@ -146,7 +146,7 @@ int create_listen_socket6(const char *ip, int port, int listen_backlog)
 			close(sock);
 			return -1;
 		}
-		info("Listening on IP '%s' (IPv6)", ip);
+		// info("Listening on IP '%s' (IPv6)", ip);
 	}
 
 	name.sin6_scope_id = 0;
@@ -168,6 +168,32 @@ int create_listen_socket6(const char *ip, int port, int listen_backlog)
 }
 
 
+int create_listen_socket(void) {
+	listen_backlog = (int) config_get_number("global", "http port listen backlog", LISTEN_BACKLOG);
+
+	listen_port = (int) config_get_number("global", "port", LISTEN_PORT);
+	if(listen_port < 1 || listen_port > 65535) {
+		error("Invalid listen port %d given. Defaulting to %d.", listen_port, LISTEN_PORT);
+		listen_port = LISTEN_PORT;
+	}
+	else debug(D_OPTIONS, "Listen port set to %d.", listen_port);
+
+	int ip = 0;
+	char *ipv = config_get("global", "ip version", "any");
+	if(!strcmp(ipv, "any") || !strcmp(ipv, "both") || !strcmp(ipv, "all")) ip = 0;
+	else if(!strcmp(ipv, "ipv4") || !strcmp(ipv, "IPV4") || !strcmp(ipv, "IPv4") || !strcmp(ipv, "4")) ip = 4;
+	else if(!strcmp(ipv, "ipv6") || !strcmp(ipv, "IPV6") || !strcmp(ipv, "IPv6") || !strcmp(ipv, "6")) ip = 6;
+	else error("Cannot understand ip version '%s'. Assuming 'any'.", ipv);
+
+	if(ip == 0 || ip == 6) listen_fd = create_listen_socket6(config_get("global", "bind socket to IP", "*"), listen_port, listen_backlog);
+	if(listen_fd < 0) {
+		listen_fd = create_listen_socket4(config_get("global", "bind socket to IP", "*"), listen_port, listen_backlog);
+		// if(listen_fd >= 0 && ip != 4) info("Managed to open an IPv4 socket on port %d.", listen_port);
+	}
+
+	return listen_fd;
+}
+
 // --------------------------------------------------------------------------------------
 // the main socket listener
 
@@ -176,15 +202,14 @@ int create_listen_socket6(const char *ip, int port, int listen_backlog)
 // 3. spawns a new pthread to serve the client (this is optimal for keep-alive clients)
 // 4. cleans up old web_clients that their pthreads have been exited
 
-void *socket_listen_main(void *ptr)
-{
+void *socket_listen_main_multi_threaded(void *ptr) {
 	if(ptr) { ; }
 
-	info("WEB SERVER thread created with task id %d", gettid());
+	info("Multi-threaded WEB SERVER thread created with task id %d", gettid());
 
 	struct web_client *w;
 	struct timeval tv;
-	int retval;
+	int retval, failures = 0;
 
 	if(ptr) { ; }
 
@@ -199,32 +224,40 @@ void *socket_listen_main(void *ptr)
 
 	if(listen_fd < 0) fatal("LISTENER: Listen socket is not ready.");
 
-	fd_set ifds, ofds, efds;
-	int fdmax = listen_fd;
-
+	fd_set ifds;
 	FD_ZERO (&ifds);
-	FD_ZERO (&ofds);
-	FD_ZERO (&efds);
 
 	for(;;) {
 		tv.tv_sec = 0;
 		tv.tv_usec = 200000;
 
-		if(listen_fd >= 0) {
+		if(likely(listen_fd >= 0))
 			FD_SET(listen_fd, &ifds);
-			FD_SET(listen_fd, &efds);
-		}
 
 		// debug(D_WEB_CLIENT, "LISTENER: Waiting...");
-		retval = select(fdmax+1, &ifds, &ofds, &efds, &tv);
+		retval = select(listen_fd + 1, &ifds, NULL, NULL, &tv);
 
-		if(retval == -1) {
+		if(unlikely(retval == -1)) {
 			error("LISTENER: select() failed.");
+			failures++;
+
+			if(failures > 10) {
+				error("LISTENER: our listen port %d seems dead. Re-opening it.", listen_fd);
+				close(listen_fd);
+				listen_fd = -1;
+				sleep(5);
+				create_listen_socket();
+				if(listen_fd < 0)
+					fatal("Cannot listen for web clients (connected clients %llu).", global_statistics.connected_clients);
+
+				failures = 0;
+			}
+
 			continue;
 		}
-		else if(retval) {
+		else if(likely(retval)) {
 			// check for new incoming connections
-			if(FD_ISSET(listen_fd, &ifds)) {
+			if(likely(FD_ISSET(listen_fd, &ifds))) {
 				w = web_client_create(listen_fd);
 				if(unlikely(!w)) {
 					// no need for error log - web_client_create already logged the error
@@ -247,16 +280,20 @@ void *socket_listen_main(void *ptr)
 		//	debug(D_WEB_CLIENT, "LISTENER: select() timeout.");
 		//}
 
+		failures = 0;
+
 		// cleanup unused clients
-		for(w = web_clients; w ; w = w?w->next:NULL) {
-			if(w->obsolete) {
+		for (w = web_clients; w; ) {
+			if (w->obsolete) {
 				debug(D_WEB_CLIENT, "%llu: Removing client.", w->id);
-				// pthread_join(w->thread,  NULL);
+				// pthread_cancel(w->thread);
+				// pthread_join(w->thread, NULL);
 				w = web_client_free(w);
 #ifdef NETDATA_INTERNAL_CHECKS
 				log_allocations();
 #endif
 			}
+			else w = w->next;
 		}
 	}
 
@@ -268,3 +305,190 @@ void *socket_listen_main(void *ptr)
 	return NULL;
 }
 
+void *socket_listen_main_single_threaded(void *ptr) {
+	if(ptr) { ; }
+
+	info("Single threaded WEB SERVER thread created with task id %d", gettid());
+
+	struct web_client *w;
+	int retval, failures = 0;
+
+	if(ptr) { ; }
+
+	if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+		error("Cannot set pthread cancel type to DEFERRED.");
+
+	if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+		error("Cannot set pthread cancel state to ENABLE.");
+
+	web_client_timeout = (int) config_get_number("global", "disconnect idle web clients after seconds", DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS);
+	web_enable_gzip = config_get_boolean("global", "enable web responses gzip compression", web_enable_gzip);
+
+	if(listen_fd < 0) fatal("LISTENER: Listen socket is not ready.");
+
+	fd_set ifds, ofds, efds;
+	int fdmax = listen_fd;
+
+	for(;;) {
+		int has_obsolete = 0;
+		FD_ZERO (&ifds);
+		FD_ZERO (&ofds);
+		FD_ZERO (&efds);
+
+		if(listen_fd >= 0) {
+			// debug(D_WEB_CLIENT_ACCESS, "LISTENER: adding listen socket %d to ifds, efds", listen_fd);
+			FD_SET(listen_fd, &ifds);
+			FD_SET(listen_fd, &efds);
+		}
+
+		for(w = web_clients; w ; w = w->next) {
+			if(unlikely(w->dead)) {
+				error("%llu: client is dead.");
+				w->obsolete = 1;
+			}
+			else if(unlikely(!w->wait_receive && !w->wait_send)) {
+				error("%llu: client is not set for neither receiving nor sending data.");
+				w->obsolete = 1;
+			}
+
+			if(unlikely(w->obsolete)) {
+				has_obsolete++;
+				continue;
+			}
+
+			// debug(D_WEB_CLIENT_ACCESS, "%llu: adding input socket %d to efds", w->id, w->ifd);
+			FD_SET(w->ifd, &efds);
+			if(w->ifd > fdmax) fdmax = w->ifd;
+
+			if(w->ifd != w->ofd) {
+				// debug(D_WEB_CLIENT_ACCESS, "%llu: adding output socket %d to efds", w->id, w->ofd);
+				FD_SET(w->ofd, &efds);
+				if(w->ofd > fdmax) fdmax = w->ofd;
+			}
+
+			if (w->wait_receive) {
+				// debug(D_WEB_CLIENT_ACCESS, "%llu: adding input socket %d to ifds", w->id, w->ifd);
+				FD_SET(w->ifd, &ifds);
+				if(w->ifd > fdmax) fdmax = w->ifd;
+			}
+
+			if (w->wait_send) {
+				// debug(D_WEB_CLIENT_ACCESS, "%llu: adding output socket %d to ofds", w->id, w->ofd);
+				FD_SET(w->ofd, &ofds);
+				if(w->ofd > fdmax) fdmax = w->ofd;
+			}
+		}
+
+		// cleanup unused clients
+		if(unlikely(has_obsolete)) {
+			for (w = web_clients; w; ) {
+				if (w->obsolete) {
+					debug(D_WEB_CLIENT, "%llu: Removing client.", w->id);
+					w = web_client_free(w);
+#ifdef NETDATA_INTERNAL_CHECKS
+					log_allocations();
+#endif
+				}
+				else w = w->next;
+			}
+		}
+
+		debug(D_WEB_CLIENT_ACCESS, "LISTENER: Waiting...");
+		struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
+		errno = 0;
+		retval = select(fdmax+1, &ifds, &ofds, &efds, &tv);
+
+		if(retval == -1) {
+			error("LISTENER: select() failed.");
+
+			if(errno != EAGAIN) {
+				// debug(D_WEB_CLIENT_ACCESS, "LISTENER: select() failed.");
+				error("REMOVING ALL %lu WEB CLIENTS !", global_statistics.connected_clients);
+				while (web_clients) web_client_free(web_clients);
+			}
+
+			failures++;
+			if(failures > 10) {
+				error("LISTENER: our listen port %d seems dead. Re-opening it.", listen_fd);
+				close(listen_fd);
+				listen_fd = -1;
+				sleep(5);
+				create_listen_socket();
+				if(listen_fd < 0)
+					fatal("Cannot listen for web clients (connected clients %llu).", global_statistics.connected_clients);
+
+				failures = 0;
+			}
+
+			continue;
+		}
+		else if(retval) {
+			for(w = web_clients; w ; w = w->next) {
+				if (unlikely(w->obsolete)) continue;
+
+				if (unlikely(FD_ISSET(w->ifd, &efds))) {
+					debug(D_WEB_CLIENT_ACCESS, "%llu: Received error on input socket.", w->id);
+					web_client_reset(w);
+					w->obsolete = 1;
+					continue;
+				}
+
+				if (unlikely(FD_ISSET(w->ofd, &efds))) {
+					debug(D_WEB_CLIENT_ACCESS, "%llu: Received error on output socket.", w->id);
+					web_client_reset(w);
+					w->obsolete = 1;
+					continue;
+				}
+
+				if (unlikely(w->wait_receive && FD_ISSET(w->ifd, &ifds))) {
+					long bytes;
+					if (unlikely((bytes = web_client_receive(w)) < 0)) {
+						debug(D_WEB_CLIENT, "%llu: Cannot receive data from client. Closing client.", w->id);
+						errno = 0;
+						web_client_reset(w);
+						w->obsolete = 1;
+						continue;
+					}
+
+					if (w->mode == WEB_CLIENT_MODE_NORMAL) {
+						debug(D_WEB_CLIENT, "%llu: Processing received data (%ld bytes).", w->id, bytes);
+						// info("%llu: Attempting to process received data (%ld bytes).", w->id, bytes);
+						web_client_process(w);
+					}
+					else {
+						debug(D_WEB_CLIENT, "%llu: NO Processing for received data (%ld bytes).", w->id, bytes);
+					}
+				}
+
+				if (unlikely(w->wait_send && FD_ISSET(w->ofd, &ofds))) {
+					ssize_t bytes;
+					if (unlikely((bytes = web_client_send(w)) < 0)) {
+						debug(D_WEB_CLIENT, "%llu: Cannot send data to client. Closing client.", w->id);
+						errno = 0;
+						web_client_reset(w);
+						w->obsolete = 1;
+						continue;
+					}
+				}
+			}
+
+			// check for new incoming connections
+			if(FD_ISSET(listen_fd, &ifds)) {
+				debug(D_WEB_CLIENT_ACCESS, "LISTENER: new connection.");
+				web_client_create(listen_fd);
+			}
+		}
+		else {
+			debug(D_WEB_CLIENT_ACCESS, "LISTENER: timeout.");
+		}
+
+		failures = 0;
+	}
+
+	error("LISTENER: exit!");
+
+	if(listen_fd >= 0) close(listen_fd);
+	exit(2);
+
+	return NULL;
+}

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -13,6 +13,10 @@ extern int listen_backlog;
 extern int listen_fd;
 extern int listen_port;
 
+#define WEB_SERVER_MODE_MULTI_THREADED 0
+#define WEB_SERVER_MODE_SINGLE_THREADED 1
+extern int web_server_mode;
+
 extern int create_listen_socket4(const char *ip, int port, int listen_backlog);
 extern int create_listen_socket6(const char *ip, int port, int listen_backlog);
 extern void *socket_listen_main_multi_threaded(void *ptr);

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -15,6 +15,8 @@ extern int listen_port;
 
 extern int create_listen_socket4(const char *ip, int port, int listen_backlog);
 extern int create_listen_socket6(const char *ip, int port, int listen_backlog);
-extern void *socket_listen_main(void *ptr);
+extern void *socket_listen_main_multi_threaded(void *ptr);
+extern void *socket_listen_main_single_threaded(void *ptr);
+extern int create_listen_socket(void);
 
 #endif /* NETDATA_WEB_SERVER_H */

--- a/web/index.html
+++ b/web/index.html
@@ -980,6 +980,9 @@
 						<table id="gotoServerList">
 						</table>
 					</div>
+					<p style="padding-top: 10px;"><small>
+						Checks may fail if you are viewing an HTTPS page and the server to be checked is HTTP only.
+					</small></p>
 					<div id="gotoServerResponse" style="display: block; width: 100%; text-align: center; padding-top: 20px;"></div>
 				</div>
 				<div class="modal-footer">
@@ -1017,6 +1020,12 @@ if(isdemo()) {
 }
 var gotoServerValidateRemaining = 0;
 function gotoServerValidateUrl(id, guid, url) {
+	var penaldy = 0;
+	if(document.location.toString().startsWith('http://') && url.toString().startsWith('https://'))
+			// we penalize https only if the current url is http
+			// to allow the user walk through all its servers.
+			penaldy = 500;
+
 	setTimeout(function() {
 		document.getElementById('gotoServerList').innerHTML += '<tr><td style="padding-left: 20px;"><a href="' + url + '" target="_blank">' + url + '</a></td><td style="padding-left: 30px;"><code id="' + guid + '-' + id + '-status">checking...</code></td></tr>';
 		NETDATA.registry.hello(url, function(data) {
@@ -1032,7 +1041,7 @@ function gotoServerValidateUrl(id, guid, url) {
 					document.getElementById('gotoServerResponse').innerHTML = '<b>Sorry! I cannot find any operational URL for this server</b>';
 			}
 		});
-	}, id * 50);
+	}, (id * 50) + penaldy);
 }
 
 function gotoServerModalHandler(guid) {


### PR DESCRIPTION

- [x] added single threaded web server option (disabled by default). This web server has the limit of about 1000 concurrent sockets (a limitation of `select()`).

- [x] updated the multi-threaded web server (the default) to use `poll()` instead of `select()`. This web server can now handle any number of sockets, but it spawns a thread per socket, so `ulimit -n` has to be set properly for this to scale. The lockless design of the multi-threaded web server allows about 10.000 queries/second per core before seeing any CPU congestion.

- [x] fixes #459 to prevent logs on the console, when no errors are encountered. Errors will still log on the console.

- [x] installer now installs systemd service (and the uninstaller removes it) when the installer is run as root.

- [x] installer now restarts netdata using the `service` command if available. If falls back to the previous behavior if netdata cannot be started the official way.
