### PR TITLE
TCP_CORK when available; gzip compression configuration options

### DIFF
--- a/src/global_statistics.c
+++ b/src/global_statistics.c
@@ -5,7 +5,7 @@
 
 #include "global_statistics.h"
 
-struct global_statistics global_statistics = { 0, 0ULL, 0ULL, 0ULL, 0ULL};
+struct global_statistics global_statistics = { 0, 0ULL, 0ULL, 0ULL, 0ULL, 0ULL, 0ULL};
 
 pthread_mutex_t global_statistics_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/src/global_statistics.h
+++ b/src/global_statistics.h
@@ -5,11 +5,13 @@
 // global statistics
 
 struct global_statistics {
-	unsigned long volatile connected_clients;
-	unsigned long long volatile web_requests;
-	unsigned long long volatile web_usec;
-	unsigned long long volatile bytes_received;
-	unsigned long long volatile bytes_sent;
+	volatile unsigned long volatile connected_clients;
+	volatile unsigned long long volatile web_requests;
+	volatile unsigned long long volatile web_usec;
+	volatile unsigned long long volatile bytes_received;
+	volatile unsigned long long volatile bytes_sent;
+	volatile unsigned long long volatile content_size;
+	volatile unsigned long long volatile compressed_content_size;
 };
 
 extern struct global_statistics global_statistics;

--- a/src/registry.c
+++ b/src/registry.c
@@ -1024,8 +1024,8 @@ static inline void registry_set_person_cookie(struct web_client *w, PERSON *p) {
 }
 
 static inline void registry_json_header(struct web_client *w, const char *action, const char *status) {
-	w->response.data->contenttype = CT_APPLICATION_JSON;
 	buffer_flush(w->response.data);
+	w->response.data->contenttype = CT_APPLICATION_JSON;
 	buffer_sprintf(w->response.data, "{\n\t\"action\": \"%s\",\n\t\"status\": \"%s\",\n\t\"hostname\": \"%s\",\n\t\"machine_guid\": \"%s\"",
 				   action, status, registry.hostname, registry.machine_guid);
 }

--- a/src/registry.c
+++ b/src/registry.c
@@ -612,7 +612,7 @@ static inline PERSON_URL *registry_person_link_to_url(PERSON *p, MACHINE *m, URL
 	else {
 		debug(D_REGISTRY, "registry_person_link_to_url('%s', '%s', '%s'): found", p->guid, m->guid, u->url);
 		pu->usages++;
-		if(likely(pu->last_t < when)) pu->last_t = when;
+		if(likely(pu->last_t < (uint32_t)when)) pu->last_t = when;
 
 		if(pu->machine != m) {
 			MACHINE_URL *mu = dictionary_get(pu->machine->urls, u->url);
@@ -637,7 +637,7 @@ static inline PERSON_URL *registry_person_link_to_url(PERSON *p, MACHINE *m, URL
 	}
 
 	p->usages++;
-	if(likely(p->last_t < when)) p->last_t = when;
+	if(likely(p->last_t < (uint32_t)when)) p->last_t = when;
 
 	if(pu->flags & REGISTRY_URL_FLAGS_EXPIRED) {
 		info("registry_person_link_to_url('%s', '%s', '%s'): accessing an expired URL. Re-enabling URL.", p->guid, m->guid, u->url);
@@ -663,14 +663,14 @@ static inline MACHINE_URL *registry_machine_link_to_url(PERSON *p, MACHINE *m, U
 	else {
 		debug(D_REGISTRY, "registry_machine_link_to_url('%s', '%s', '%s'): found", p->guid, m->guid, u->url);
 		mu->usages++;
-		if(likely(mu->last_t < when)) mu->last_t = when;
+		if(likely(mu->last_t < (uint32_t)when)) mu->last_t = when;
 	}
 
 	//debug(D_REGISTRY, "registry_machine_link_to_url('%s', '%s', '%s'): indexing person in machine", p->guid, m->guid, u->url);
 	//dictionary_set(mu->persons, p->guid, p, sizeof(PERSON));
 
 	m->usages++;
-	if(likely(m->last_t < when)) m->last_t = when;
+	if(likely(m->last_t < (uint32_t)when)) m->last_t = when;
 
 	if(mu->flags & REGISTRY_URL_FLAGS_EXPIRED) {
 		info("registry_machine_link_to_url('%s', '%s', '%s'): accessing an expired URL.", p->guid, m->guid, u->url);

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1837,7 +1837,7 @@ ssize_t web_client_send_chunk_header(struct web_client *w, size_t len)
 {
 	debug(D_DEFLATE, "%llu: OPEN CHUNK of %d bytes (hex: %x).", w->id, len, len);
 	char buf[1024];
-	sprintf(buf, "%lX\r\n", len);
+	sprintf(buf, "%zX\r\n", len);
 	
 	ssize_t bytes = send(w->ofd, buf, strlen(buf), 0);
 	if(bytes > 0) {

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1726,11 +1726,11 @@ void web_client_process(struct web_client *w) {
 
 	buffer_strcat(w->response.header_output, "\r\n");
 
-/*	// disable TCP_NODELAY, to buffer the header
+	// disable TCP_NODELAY, to buffer the header
 	int flag = 0;
 	if(setsockopt(w->ofd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0)
 		error("%llu: failed to disable TCP_NODELAY on socket.", w->id);
-*/
+
 	// sent the HTTP header
 	debug(D_WEB_DATA, "%llu: Sending response HTTP header of size %d: '%s'"
 			, w->id
@@ -1752,11 +1752,11 @@ void web_client_process(struct web_client *w) {
 	else 
 		w->stats_sent_bytes += bytes;
 
-/*	// enable TCP_NODELAY, to send all data immediately at the next send()
+	// enable TCP_NODELAY, to send all data immediately at the next send()
 	flag = 1;
 	if(setsockopt(w->ofd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0)
  		error("%llu: failed to enable TCP_NODELAY on socket.", w->id);
-*/
+
 	// enable sending immediately if we have data
 	if(w->response.data->len) w->wait_send = 1;
 	else w->wait_send = 0;

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -11,12 +11,14 @@
 #include <pthread.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <netinet/tcp.h>
 #include <malloc.h>
 #include <pwd.h>
 #include <grp.h>
 #include <ctype.h>
 #include <poll.h>
+
+// TCP_CORK
+#include <netinet/tcp.h>
 
 #include "common.h"
 #include "log.h"

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -65,16 +65,13 @@ struct web_client {
 	uint8_t dead:1;						// if set to 1, this client is dead
 
 	uint8_t keepalive:1;				// if set to 1, the web client will be re-used
-	uint8_t enable_gzip:1;				// if set to 1, the response will be compressed
 
 	uint8_t mode:3;						// the operational mode of the client
 
 	uint8_t wait_receive:1;				// 1 = we are waiting more input data
 	uint8_t wait_send:1;				// 1 = we have data to send to the client
 
-#ifdef TCP_CORK
 	int tcp_cork;						// 1 = we have a cork on the socket
-#endif /* TCP_CORK */
 
 	int ifd;
 	int ofd;

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -16,7 +16,10 @@
 
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
 extern int web_client_timeout;
-extern int web_enable_gzip;
+
+#ifdef NETDATA_WITH_ZLIB
+extern int web_enable_gzip, web_gzip_level, web_gzip_strategy;
+#endif /* NETDATA_WITH_ZLIB */
 
 #ifndef NETDATA_WEB_CLIENT_H
 #define NETDATA_WEB_CLIENT_H 1
@@ -48,7 +51,7 @@ struct response {
 	size_t zsent;					// the compressed bytes we have sent to the client
 	size_t zhave;					// the compressed bytes that we have received from zlib
 	int zinitialized:1;
-#endif
+#endif /* NETDATA_WITH_ZLIB */
 
 };
 

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -5,6 +5,7 @@
 
 #include <sys/time.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -67,6 +68,10 @@ struct web_client {
 
 	uint8_t wait_receive:1;				// 1 = we are waiting more input data
 	uint8_t wait_send:1;				// 1 = we have data to send to the client
+
+#ifdef TCP_CORK
+	int tcp_cork;						// 1 = we have a cork on the socket
+#endif /* TCP_CORK */
 
 	int ifd;
 	int ofd;


### PR DESCRIPTION

1. TCP_CORK is used (only when available) to defragment TCP packets. So, instead of sending a packet with the HTTP header, a packet with the data and when gzip is enabled a packet for the chunk suffix, we enable TCP_CORK and the kernel is pushing the data in full packets. TCP_CORK is removed from the socket when all the data have been sent.

2. added 2 more global options about the compression level and strategy used. Also the default compression level changed from 6 to 3. The difference is <5% in bandwidth savings but the speed difference is quite remarkable.

  Using level 1, netdata is able to serve about 1.800 chart refreshes per second per core!
  Using level 3, it falls to 1.500 chart refreshes per second.

3. added a new chart in the netdata monitoring section that reports bandwidth savings due to gzip compression.
