### PR TITLE
lower memory requirements for the registry; verify the browsers support cookies

### DIFF
--- a/profile/benchmark-dictionary.c
+++ b/profile/benchmark-dictionary.c
@@ -22,19 +22,20 @@ struct myvalue {
 int main(int argc, char **argv) {
 	if(argc || argv) {;}
 
-	DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
+//	DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED|DICTIONARY_FLAG_WITH_STATISTICS);
+	DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_WITH_STATISTICS);
 	if(!dict) fatal("Cannot create dictionary.");
 
 	struct rusage start, end;
 	unsigned long long dt;
 	char buf[100 + 1];
 	struct myvalue value, *v;
-	int i, max = 10000000, max2;
+	int i, max = 100000, max2;
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Inserting %d entries in the dictionary\n", max);
 	for(i = 0; i < max; i++) {
 		value.i = i;
@@ -45,12 +46,12 @@ int main(int argc, char **argv) {
 	getrusage(RUSAGE_SELF, &end);
 	dt = (end.ru_utime.tv_sec * 1000000ULL + end.ru_utime.tv_usec) - (start.ru_utime.tv_sec * 1000000ULL + start.ru_utime.tv_usec);
 	fprintf(stderr, "Added %d entries in %llu nanoseconds: %llu inserts per second\n", max, dt, max * 1000000ULL / dt);
-	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->inserts, dict->deletes, dict->searches);
+	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->stats->inserts, dict->stats->deletes, dict->stats->searches);
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Retrieving %d entries from the dictionary\n", max);
 	for(i = 0; i < max; i++) {
 		value.i = i;
@@ -65,12 +66,12 @@ int main(int argc, char **argv) {
 	getrusage(RUSAGE_SELF, &end);
 	dt = (end.ru_utime.tv_sec * 1000000ULL + end.ru_utime.tv_usec) - (start.ru_utime.tv_sec * 1000000ULL + start.ru_utime.tv_usec);
 	fprintf(stderr, "Read %d entries in %llu nanoseconds: %llu searches per second\n", max, dt, max * 1000000ULL / dt);
-	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->inserts, dict->deletes, dict->searches);
+	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->stats->inserts, dict->stats->deletes, dict->stats->searches);
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Resetting %d entries in the dictionary\n", max);
 	for(i = 0; i < max; i++) {
 		value.i = i;
@@ -80,13 +81,13 @@ int main(int argc, char **argv) {
 	}
 	getrusage(RUSAGE_SELF, &end);
 	dt = (end.ru_utime.tv_sec * 1000000ULL + end.ru_utime.tv_usec) - (start.ru_utime.tv_sec * 1000000ULL + start.ru_utime.tv_usec);
-	fprintf(stderr, "Reset %d entries in %llu nanoseconds: %llu inserts per second\n", max, dt, max * 1000000ULL / dt);
-	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->inserts, dict->deletes, dict->searches);
+	fprintf(stderr, "Reset %d entries in %llu nanoseconds: %llu resets per second\n", max, dt, max * 1000000ULL / dt);
+	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->stats->inserts, dict->stats->deletes, dict->stats->searches);
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Searching  %d non-existing entries in the dictionary\n", max);
 	max2 = max * 2;
 	for(i = max; i < max2; i++) {
@@ -99,13 +100,13 @@ int main(int argc, char **argv) {
 	}
 	getrusage(RUSAGE_SELF, &end);
 	dt = (end.ru_utime.tv_sec * 1000000ULL + end.ru_utime.tv_usec) - (start.ru_utime.tv_sec * 1000000ULL + start.ru_utime.tv_usec);
-	fprintf(stderr, "Searched %d non-existing entries in %llu nanoseconds: %llu searches per second\n", max, dt, max * 1000000ULL / dt);
-	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->inserts, dict->deletes, dict->searches);
+	fprintf(stderr, "Searched %d non-existing entries in %llu nanoseconds: %llu not found searches per second\n", max, dt, max * 1000000ULL / dt);
+	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->stats->inserts, dict->stats->deletes, dict->stats->searches);
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Deleting %d entries from the dictionary\n", max);
 	for(i = 0; i < max; i++) {
 		value.i = i;
@@ -116,12 +117,12 @@ int main(int argc, char **argv) {
 	getrusage(RUSAGE_SELF, &end);
 	dt = (end.ru_utime.tv_sec * 1000000ULL + end.ru_utime.tv_usec) - (start.ru_utime.tv_sec * 1000000ULL + start.ru_utime.tv_usec);
 	fprintf(stderr, "Deleted %d entries in %llu nanoseconds: %llu deletes per second\n", max, dt, max * 1000000ULL / dt);
-	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->inserts, dict->deletes, dict->searches);
+	fprintf(stderr, " > Dictionary: %llu inserts, %llu deletes, %llu searches\n\n", dict->stats->inserts, dict->stats->deletes, dict->stats->searches);
 
 	// ------------------------------------------------------------------------
 
 	getrusage(RUSAGE_SELF, &start);
-	dict->inserts = dict->deletes = dict->searches = 0ULL;
+	dict->stats->inserts = dict->stats->deletes = dict->stats->searches = 0ULL;
 	fprintf(stderr, "Destroying dictionary\n");
 	dictionary_destroy(dict);
 	getrusage(RUSAGE_SELF, &end);

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -6,6 +6,13 @@
 #ifndef NETDATA_DICTIONARY_H
 #define NETDATA_DICTIONARY_H 1
 
+struct dictionary_stats {
+	unsigned long long inserts;
+	unsigned long long deletes;
+	unsigned long long searches;
+	unsigned long long entries;
+};
+
 typedef struct name_value {
 	avl avl;				// the index - this has to be first!
 
@@ -21,34 +28,15 @@ typedef struct dictionary {
 
 	uint8_t flags;
 
-#ifdef NETDATA_DICTIONARY_WITH_STATISTICS
-	unsigned long long inserts;
-	unsigned long long deletes;
-	unsigned long long searches;
-	unsigned long long entries;
-#endif /* NETDATA_DICTIONARY_WITH_STATISTICS */
-
-	pthread_rwlock_t rwlock;
+	struct dictionary_stats *stats;
+	pthread_rwlock_t *rwlock;
 } DICTIONARY;
-
-#ifdef NETDATA_DICTIONARY_WITH_STATISTICS
-#define NETDATA_DICTIONARY_STATS_INSERTS_PLUS1(dict) (dict)->inserts++
-#define NETDATA_DICTIONARY_STATS_DELETES_PLUS1(dict) (dict)->deletes++
-#define NETDATA_DICTIONARY_STATS_SEARCHES_PLUS1(dict) (dict)->searches++
-#define NETDATA_DICTIONARY_STATS_ENTRIES_PLUS1(dict) (dict)->entries++
-#define NETDATA_DICTIONARY_STATS_ENTRIES_MINUS1(dict) (dict)->entries--
-#else /* NETDATA_DICTIONARY_WITH_STATISTICS */
-#define NETDATA_DICTIONARY_STATS_INSERTS_PLUS1(dict)
-#define NETDATA_DICTIONARY_STATS_DELETES_PLUS1(dict)
-#define NETDATA_DICTIONARY_STATS_SEARCHES_PLUS1(dict)
-#define NETDATA_DICTIONARY_STATS_ENTRIES_PLUS1(dict)
-#define NETDATA_DICTIONARY_STATS_ENTRIES_MINUS1(dict)
-#endif /* NETDATA_DICTIONARY_WITH_STATISTICS */
 
 #define DICTIONARY_FLAG_DEFAULT					0x00000000
 #define DICTIONARY_FLAG_SINGLE_THREADED			0x00000001
 #define DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE	0x00000002
 #define DICTIONARY_FLAG_NAME_LINK_DONT_CLONE	0x00000004
+#define DICTIONARY_FLAG_WITH_STATISTICS			0x00000008
 
 extern DICTIONARY *dictionary_create(uint32_t flags);
 extern void dictionary_destroy(DICTIONARY *dict);

--- a/src/registry.h
+++ b/src/registry.h
@@ -5,6 +5,10 @@
 
 #define NETDATA_REGISTRY_COOKIE_NAME "netdata_registry_id"
 
+extern void registry_set_cookie(struct web_client *w, const char *guid);
+extern const char *registry_to_announce(void);
+extern int registry_verify_cookies_redirects(void);
+
 extern int registry_request_access_json(struct web_client *w, char *person_guid, char *machine_guid, char *url, char *name, time_t when);
 extern int registry_request_delete_json(struct web_client *w, char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
 extern int registry_request_search_json(struct web_client *w, char *person_guid, char *machine_guid, char *url, char *request_machine, time_t when);


### PR DESCRIPTION
This is a registry improvement:

1. It lowers the memory requirements of DICTIONARY, which affects the database size of the registry

2. Before adding persons to the registry database, it verifies the browser supports cookies. It does this by redirecting the browser to itself with a dummy cookie. If this succeeds, its adds the person to the registry. If it fails, it will retry `[registry].verify browser cookies support max redirects` times. This setting can be set to zero to disable this feature.

