### PR TITLE
web browser cookies support at the registry is now done using application level redirects

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -1666,11 +1666,7 @@ int registry_init(void) {
 	registry.registry_to_announce = config_get("registry", "registry to announce", "https://registry.my-netdata.io");
 	registry.hostname = config_get("registry", "registry hostname", config_get("global", "hostname", hostname));
 
-	registry.verify_cookies_redirects = config_get_number("registry", "verify browser cookies support max redirects", 2);
-	if(registry.verify_cookies_redirects < 0) {
-		registry.verify_cookies_redirects = 0;
-		config_set_number("registry", "verify browser cookies support max redirects", registry.verify_cookies_redirects);
-	}
+	registry.verify_cookies_redirects = config_get_boolean("registry", "verify browser cookies support max redirects", 1);
 
 	registry.max_url_length = config_get_number("registry", "max URL length", 1024);
 	if(registry.max_url_length < 10) {

--- a/src/registry.c
+++ b/src/registry.c
@@ -1665,8 +1665,7 @@ int registry_init(void) {
 	registry.registry_domain = config_get("registry", "registry domain", "");
 	registry.registry_to_announce = config_get("registry", "registry to announce", "https://registry.my-netdata.io");
 	registry.hostname = config_get("registry", "registry hostname", config_get("global", "hostname", hostname));
-
-	registry.verify_cookies_redirects = config_get_boolean("registry", "verify browser cookies support max redirects", 1);
+	registry.verify_cookies_redirects = config_get_boolean("registry", "verify browser cookies support", 1);
 
 	registry.max_url_length = config_get_number("registry", "max URL length", 1024);
 	if(registry.max_url_length < 10) {

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -992,6 +992,7 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 				redirects++;
 
 				registry_set_cookie(w, "give-me-back-this-cookie-please");
+				w->response.data->contenttype = CT_APPLICATION_JSON;
 				buffer_sprintf(w->response.data, "{ \"status\": \"redirect\", \"registry\": \"%s\" }", registry_to_announce());
 
 /*

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -862,7 +862,7 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 {
 	static uint32_t hash_action = 0, hash_access = 0, hash_hello = 0, hash_delete = 0, hash_search = 0,
 			hash_switch = 0, hash_machine = 0, hash_url = 0, hash_name = 0, hash_delete_url = 0, hash_for = 0,
-			hash_to = 0, hash_redirects = 0;
+			hash_to = 0 /*, hash_redirects = 0 */;
 
 	if(unlikely(!hash_action)) {
 		hash_action = simple_hash("action");
@@ -877,7 +877,9 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 		hash_delete_url = simple_hash("delete_url");
 		hash_for = simple_hash("for");
 		hash_to = simple_hash("to");
+/*
 		hash_redirects = simple_hash("redirects");
+*/
 	}
 
 	char person_guid[36 + 1] = "";
@@ -898,7 +900,9 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 			*search_machine_guid = NULL,
 			*delete_url = NULL,
 			*to_person_guid = NULL;
+/*
 	int redirects = 0;
+*/
 
 	while(url) {
 		char *value = mystrsep(&url, "?&[]");
@@ -924,9 +928,10 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
             else error("unknown registry action '%s'", value);
 #endif /* NETDATA_INTERNAL_CHECKS */
 		}
+/*
 		else if(hash == hash_redirects && !strcmp(name, "redirects"))
 			redirects = atoi(value);
-
+*/
 		else if(hash == hash_machine && !strcmp(name, "machine"))
 			machine_guid = value;
 
@@ -984,18 +989,24 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 			if(registry_verify_cookies_redirects() > 0 && (!cookie || !person_guid[0])) {
 				buffer_flush(w->response.data);
 
+				registry_set_cookie(w, "give-me-back-this-cookie-please");
+				w->response.data->contenttype = CT_APPLICATION_JSON;
+				buffer_sprintf(w->response.data, "{ \"status\": \"redirect\", \"registry\": \"%s\" }", registry_to_announce());
+				return 200;
+
+/*
+ * it seems that web browsers are ignoring 307 (Moved Temporarily)
+ * under certain conditions, when using CORS
+ * so this is commented and we use application level redirects instead
+ *
+				redirects++;
+
 				if(redirects > registry_verify_cookies_redirects()) {
+					buffer_flush(w->response.data);
 					buffer_sprintf(w->response.data, "Your browser does not support cookies");
 					return 400;
 				}
 
-				redirects++;
-
-				registry_set_cookie(w, "give-me-back-this-cookie-please");
-				w->response.data->contenttype = CT_APPLICATION_JSON;
-				buffer_sprintf(w->response.data, "{ \"status\": \"redirect\", \"registry\": \"%s\" }", registry_to_announce());
-
-/*
 				char *encoded_url = url_encode(machine_url);
 				if(!encoded_url) {
 					error("%llu: Cannot URL encode string '%s'", w->id, machine_url);
@@ -1023,8 +1034,8 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 				free(encoded_guid);
 				free(encoded_name);
 				free(encoded_url);
+				return 307
 */
-				return 200;
 			}
 			return registry_request_access_json(w, person_guid, machine_guid, machine_url, url_name, time(NULL));
 

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -991,6 +991,10 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 
 				redirects++;
 
+				registry_set_cookie(w, "give-me-back-this-cookie-please");
+				buffer_sprintf(w->response.data, "{ \"status\": \"redirect\", \"registry\": \"%s\" }", registry_to_announce());
+
+/*
 				char *encoded_url = url_encode(machine_url);
 				if(!encoded_url) {
 					error("%llu: Cannot URL encode string '%s'", w->id, machine_url);
@@ -1012,13 +1016,14 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 					return 500;
 				}
 
-				registry_set_cookie(w, "give-me-back-this-cookie-please");
 				buffer_sprintf(w->response.header, "Location: %s/api/v1/registry?action=access&machine=%s&name=%s&url=%s&redirects=%d\r\n",
 							   registry_to_announce(), encoded_guid, encoded_name, encoded_url, redirects);
+
 				free(encoded_guid);
 				free(encoded_name);
 				free(encoded_url);
-				return 307;
+*/
+				return 200;
 			}
 			return registry_request_access_json(w, person_guid, machine_guid, machine_url, url_name, time(NULL));
 

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -5569,7 +5569,7 @@
 					NETDATA.registry.machine_guid = data.machine_guid;
 					NETDATA.registry.hostname = data.hostname;
 
-					NETDATA.registry.access(10, function (person_urls) {
+					NETDATA.registry.access(2, function (person_urls) {
 						NETDATA.registry.parsePersonUrls(person_urls);
 
 					});


### PR DESCRIPTION
The problem with the previous implementation is that there are browsers that do not respect HTTP response 307 moved temporarily, apparently when used with CORS.

The new implementation uses redirects handled at the dashboard.
