### PR TITLE
allow cookies on all requests; respect DoNotTrack; generate SVG badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ web/gadget.xml
 web/index_new.html
 web/version.txt
 
+system/netdata-lsb
 system/netdata-openrc
 system/netdata-init-d
 system/netdata.logrotate

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,6 +67,7 @@ netdata_SOURCES = \
 	unit_test.c unit_test.h \
 	url.c url.h \
 	web_buffer.c web_buffer.h \
+	web_buffer_svg.c web_buffer_svg.h \
 	web_client.c web_client.h \
 	web_server.c web_server.h \
 	$(NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,8 @@ void web_server_threading_selection(void) {
 
 	web_client_timeout = (int) config_get_number("global", "disconnect idle web clients after seconds", DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS);
 
+	web_donotrack_comply = config_get_boolean("global", "respect web browser do not track policy", web_donotrack_comply);
+
 #ifdef NETDATA_WITH_ZLIB
 	web_enable_gzip = config_get_boolean("global", "enable web responses gzip compression", web_enable_gzip);
 

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -64,6 +64,6 @@ extern void rrd_stats_all_json(BUFFER *wb);
 extern time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long entries_to_show, long group, int group_method, time_t after, time_t before, int only_non_zero);
 
 extern int rrd2format(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points, long long after, long long before, int group_method, uint32_t options, time_t *latest_timestamp);
-
+extern int rrd2value(RRDSET *st, BUFFER *wb, calculated_number *n, BUFFER *dimensions, long points, long long after, long long before, int group_method, uint32_t options, time_t *latest_timestamp, int *value_is_null);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/src/web_buffer_svg.c
+++ b/src/web_buffer_svg.c
@@ -1,0 +1,569 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <math.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+#include "common.h"
+#include "log.h"
+#include "appconfig.h"
+#include "url.h"
+#include "web_buffer.h"
+#include "web_buffer_svg.h"
+
+#define BADGE_HORIZONTAL_PADDING 4
+#define VERDANA_KERNING 0.5
+
+/*
+ * verdana11_widths[] has been generated with this method:
+ * https://github.com/badges/shields/blob/master/measure-text.js
+*/
+
+double verdana11_widths[256] = {
+	[0] = 0.0,
+	[1] = 0.0,
+	[2] = 0.0,
+	[3] = 0.0,
+	[4] = 0.0,
+	[5] = 0.0,
+	[6] = 0.0,
+	[7] = 0.0,
+	[8] = 0.0,
+	[9] = 0.0,
+	[10] = 0.0,
+	[11] = 0.0,
+	[12] = 0.0,
+	[13] = 0.0,
+	[14] = 0.0,
+	[15] = 0.0,
+	[16] = 0.0,
+	[17] = 0.0,
+	[18] = 0.0,
+	[19] = 0.0,
+	[20] = 0.0,
+	[21] = 0.0,
+	[22] = 0.0,
+	[23] = 0.0,
+	[24] = 0.0,
+	[25] = 0.0,
+	[26] = 0.0,
+	[27] = 0.0,
+	[28] = 0.0,
+	[29] = 0.0,
+	[30] = 0.0,
+	[31] = 0.0,
+	[32] = 3.8671874999999996, //
+	[33] = 4.3291015625, // !
+	[34] = 5.048828125, // "
+	[35] = 9.001953125, // #
+	[36] = 6.9931640625, // $
+	[37] = 11.837890625, // %
+	[38] = 7.992187499999999, // &
+	[39] = 2.9541015625, // '
+	[40] = 4.9951171875, // (
+	[41] = 4.9951171875, // )
+	[42] = 6.9931640625, // *
+	[43] = 9.001953125, // +
+	[44] = 4.00146484375, // ,
+	[45] = 4.9951171875, // -
+	[46] = 4.00146484375, // .
+	[47] = 4.9951171875, // /
+	[48] = 6.9931640625, // 0
+	[49] = 6.9931640625, // 1
+	[50] = 6.9931640625, // 2
+	[51] = 6.9931640625, // 3
+	[52] = 6.9931640625, // 4
+	[53] = 6.9931640625, // 5
+	[54] = 6.9931640625, // 6
+	[55] = 6.9931640625, // 7
+	[56] = 6.9931640625, // 8
+	[57] = 6.9931640625, // 9
+	[58] = 4.9951171875, // :
+	[59] = 4.9951171875, // ;
+	[60] = 9.001953125, // <
+	[61] = 9.001953125, // =
+	[62] = 9.001953125, // >
+	[63] = 5.99951171875, // ?
+	[64] = 11.0, // @
+	[65] = 7.51953125, // A
+	[66] = 7.541015625, // B
+	[67] = 7.680664062499999, // C
+	[68] = 8.4755859375, // D
+	[69] = 6.95556640625, // E
+	[70] = 6.32177734375, // F
+	[71] = 8.529296875, // G
+	[72] = 8.26611328125, // H
+	[73] = 4.6298828125, // I
+	[74] = 5.00048828125, // J
+	[75] = 7.62158203125, // K
+	[76] = 6.123046875, // L
+	[77] = 9.2705078125, // M
+	[78] = 8.228515625, // N
+	[79] = 8.658203125, // O
+	[80] = 6.63330078125, // P
+	[81] = 8.658203125, // Q
+	[82] = 7.6484375, // R
+	[83] = 7.51953125, // S
+	[84] = 6.7783203125, // T
+	[85] = 8.05126953125, // U
+	[86] = 7.51953125, // V
+	[87] = 10.87646484375, // W
+	[88] = 7.53564453125, // X
+	[89] = 6.767578125, // Y
+	[90] = 7.53564453125, // Z
+	[91] = 4.9951171875, // [
+	[92] = 4.9951171875, // backslash
+	[93] = 4.9951171875, // ]
+	[94] = 9.001953125, // ^
+	[95] = 6.9931640625, // _
+	[96] = 6.9931640625, // `
+	[97] = 6.6064453125, // a
+	[98] = 6.853515625, // b
+	[99] = 5.73095703125, // c
+	[100] = 6.853515625, // d
+	[101] = 6.552734375, // e
+	[102] = 3.8671874999999996, // f
+	[103] = 6.853515625, // g
+	[104] = 6.9609375, // h
+	[105] = 3.0185546875, // i
+	[106] = 3.78662109375, // j
+	[107] = 6.509765625, // k
+	[108] = 3.0185546875, // l
+	[109] = 10.69921875, // m
+	[110] = 6.9609375, // n
+	[111] = 6.67626953125, // o
+	[112] = 6.853515625, // p
+	[113] = 6.853515625, // q
+	[114] = 4.6943359375, // r
+	[115] = 5.73095703125, // s
+	[116] = 4.33447265625, // t
+	[117] = 6.9609375, // u
+	[118] = 6.509765625, // v
+	[119] = 9.001953125, // w
+	[120] = 6.509765625, // x
+	[121] = 6.509765625, // y
+	[122] = 5.779296875, // z
+	[123] = 6.982421875, // {
+	[124] = 4.9951171875, // |
+	[125] = 6.982421875, // }
+	[126] = 9.001953125, // ~
+	[127] = 0.0,
+	[128] = 0.0,
+	[129] = 0.0,
+	[130] = 0.0,
+	[131] = 0.0,
+	[132] = 0.0,
+	[133] = 0.0,
+	[134] = 0.0,
+	[135] = 0.0,
+	[136] = 0.0,
+	[137] = 0.0,
+	[138] = 0.0,
+	[139] = 0.0,
+	[140] = 0.0,
+	[141] = 0.0,
+	[142] = 0.0,
+	[143] = 0.0,
+	[144] = 0.0,
+	[145] = 0.0,
+	[146] = 0.0,
+	[147] = 0.0,
+	[148] = 0.0,
+	[149] = 0.0,
+	[150] = 0.0,
+	[151] = 0.0,
+	[152] = 0.0,
+	[153] = 0.0,
+	[154] = 0.0,
+	[155] = 0.0,
+	[156] = 0.0,
+	[157] = 0.0,
+	[158] = 0.0,
+	[159] = 0.0,
+	[160] = 0.0,
+	[161] = 0.0,
+	[162] = 0.0,
+	[163] = 0.0,
+	[164] = 0.0,
+	[165] = 0.0,
+	[166] = 0.0,
+	[167] = 0.0,
+	[168] = 0.0,
+	[169] = 0.0,
+	[170] = 0.0,
+	[171] = 0.0,
+	[172] = 0.0,
+	[173] = 0.0,
+	[174] = 0.0,
+	[175] = 0.0,
+	[176] = 0.0,
+	[177] = 0.0,
+	[178] = 0.0,
+	[179] = 0.0,
+	[180] = 0.0,
+	[181] = 0.0,
+	[182] = 0.0,
+	[183] = 0.0,
+	[184] = 0.0,
+	[185] = 0.0,
+	[186] = 0.0,
+	[187] = 0.0,
+	[188] = 0.0,
+	[189] = 0.0,
+	[190] = 0.0,
+	[191] = 0.0,
+	[192] = 0.0,
+	[193] = 0.0,
+	[194] = 0.0,
+	[195] = 0.0,
+	[196] = 0.0,
+	[197] = 0.0,
+	[198] = 0.0,
+	[199] = 0.0,
+	[200] = 0.0,
+	[201] = 0.0,
+	[202] = 0.0,
+	[203] = 0.0,
+	[204] = 0.0,
+	[205] = 0.0,
+	[206] = 0.0,
+	[207] = 0.0,
+	[208] = 0.0,
+	[209] = 0.0,
+	[210] = 0.0,
+	[211] = 0.0,
+	[212] = 0.0,
+	[213] = 0.0,
+	[214] = 0.0,
+	[215] = 0.0,
+	[216] = 0.0,
+	[217] = 0.0,
+	[218] = 0.0,
+	[219] = 0.0,
+	[220] = 0.0,
+	[221] = 0.0,
+	[222] = 0.0,
+	[223] = 0.0,
+	[224] = 0.0,
+	[225] = 0.0,
+	[226] = 0.0,
+	[227] = 0.0,
+	[228] = 0.0,
+	[229] = 0.0,
+	[230] = 0.0,
+	[231] = 0.0,
+	[232] = 0.0,
+	[233] = 0.0,
+	[234] = 0.0,
+	[235] = 0.0,
+	[236] = 0.0,
+	[237] = 0.0,
+	[238] = 0.0,
+	[239] = 0.0,
+	[240] = 0.0,
+	[241] = 0.0,
+	[242] = 0.0,
+	[243] = 0.0,
+	[244] = 0.0,
+	[245] = 0.0,
+	[246] = 0.0,
+	[247] = 0.0,
+	[248] = 0.0,
+	[249] = 0.0,
+	[250] = 0.0,
+	[251] = 0.0,
+	[252] = 0.0,
+	[253] = 0.0,
+	[254] = 0.0,
+	[255] = 0.0
+};
+
+// find the width of the string using the verdana 11points font
+// re-write the string in place, skiping zero-length characters
+static inline int verdana11_width(char *s) {
+	double w = 0.0;
+	char *d = s;
+
+	while(*s) {
+		double t = verdana11_widths[(unsigned char)*s];
+		if(t == 0.0)
+			s++;
+		else {
+			w += t + VERDANA_KERNING;
+			if(d != s)
+				*d++ = *s++;
+			else
+				d = ++s;
+		}
+	}
+
+	*d = '\0';
+	w -= VERDANA_KERNING;
+	return ceil(w);
+}
+
+static inline size_t escape_xmlz(char *dst, const char *src, size_t len) {
+	size_t i = len;
+
+	// required escapes from
+	// https://github.com/badges/shields/blob/master/badge.js
+	while(*src && i) {
+		switch(*src) {
+			case '&':
+				if(i > 5) {
+					strcpy(dst, "&amp;");
+					i -= 5;
+					dst += 5;
+					src++;
+				}
+				else goto cleanup;
+				break;
+
+			case '<':
+				if(i > 4) {
+					strcpy(dst, "&lt;");
+					i -= 4;
+					dst += 4;
+					src++;
+				}
+				else goto cleanup;
+				break;
+
+			case '>':
+				if(i > 4) {
+					strcpy(dst, "&gt;");
+					i -= 4;
+					dst += 4;
+					src++;
+				}
+				else goto cleanup;
+				break;
+
+			case '"':
+				if(i > 6) {
+					strcpy(dst, "&quot;");
+					i -= 6;
+					dst += 6;
+					src++;
+				}
+				else goto cleanup;
+				break;
+
+			case '\'':
+				if(i > 6) {
+					strcpy(dst, "&apos;");
+					i -= 6;
+					dst += 6;
+					src++;
+				}
+				else goto cleanup;
+				break;
+
+			default:
+				i--;
+				*dst++ = *src++;
+				break;
+		}
+	}
+
+cleanup:
+	*dst = '\0';
+	return len - i;
+}
+
+static inline const char *fix_units(const char *units) {
+	if(!strcmp(units, "percentage") || !strcmp(units, "percent") || !strcmp(units, "pcent")) return "%";
+	return units;
+}
+
+static inline const char *color_map(const char *color) {
+	// colors from:
+	// https://github.com/badges/shields/blob/master/colorscheme.json
+	     if(!strcmp(color, "brightgreen")) return "#4c1";
+	else if(!strcmp(color, "green"))       return "#97CA00";
+	else if(!strcmp(color, "yellow"))      return "#dfb317";
+	else if(!strcmp(color, "yellowgreen")) return "#a4a61d";
+	else if(!strcmp(color, "orange"))      return "#fe7d37";
+	else if(!strcmp(color, "red"))         return "#e05d44";
+	else if(!strcmp(color, "blue"))        return "#007ec6";
+	else if(!strcmp(color, "grey"))        return "#555";
+	else if(!strcmp(color, "gray"))        return "#555";
+	else if(!strcmp(color, "lightgrey"))   return "#9f9f9f";
+	else if(!strcmp(color, "lightgray"))   return "#9f9f9f";
+	return color;
+}
+
+static inline void calc_colorz(const char *color, char *final, size_t len, calculated_number value, int value_is_null) {
+	char color_buffer[256 + 1] = "";
+	char value_buffer[256 + 1] = "";
+	char comparison = '>';
+
+	// example input:
+	// color<max|color>min|color:null...
+
+	const char *c = color;
+	while(*c) {
+		char *dc = color_buffer, *dv = NULL;
+		size_t ci = 0, vi = 0;
+
+		const char *t = c;
+
+		while(*t && *t != '|') {
+			switch(*t) {
+				case ':':
+					comparison = '=';
+					dv = value_buffer;
+					break;
+
+				case '}':
+				case ')':
+				case '>':
+					if(t[1] == '=') {
+						comparison = ')';
+						t++;
+					}
+					else
+						comparison = '>';
+					dv = value_buffer;
+					break;
+
+				case '{':
+				case '(':
+				case '<':
+					if(t[1] == '=') {
+						comparison = '(';
+						t++;
+					}
+					else
+						comparison = '<';
+					dv = value_buffer;
+					break;
+
+				default:
+					if(dv) {
+						if(vi < 256) {
+							vi++;
+							*dv++ = *t;
+						}
+					}
+					else {
+						if(ci < 256) {
+							ci++;
+							*dc++ = *t;
+						}
+					}
+					break;
+			}
+
+			t++;
+		}
+
+		// prepare for next iteration
+		if(*t == '|') t++;
+		c = t;
+
+		// do the math
+		*dc = '\0';
+		if(dv) {
+			*dv = '\0';
+
+			if(value_is_null) {
+				if(!*value_buffer || !strcmp(value_buffer, "null"))
+					break;
+			}
+			else {
+				calculated_number v = strtold(value_buffer, NULL);
+
+				     if(comparison == '<' && value < v) break;
+				else if(comparison == '(' && value <= v) break;
+				else if(comparison == '>' && value > v) break;
+				else if(comparison == ')' && value >= v) break;
+				else if(comparison == '=' && value == v) break;
+			}
+		}
+		else
+			break;
+	}
+
+	const char *b;
+	if(color_buffer[0])
+		b = color_buffer;
+	else
+		b = color;
+
+	strncpyz(final, b, len);
+}
+
+void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int value_is_null) {
+	char label_buffer[256 + 1], value_string[512 + 1], value_color_buffer[256 + 1];
+	char label_escaped[256 + 1], value_escaped[512 + 1], label_color_escaped[256 + 1], value_color_escaped[256 + 1];
+	int label_width, value_width, total_width;
+
+	if(!label_color || !*label_color) label_color = "#555";
+	if(!value_color || !*value_color) value_color = "#4c1";
+
+	units = fix_units(units);
+	calc_colorz(value_color, value_color_buffer, 256, value, value_is_null);
+
+	char *separator = "";
+	if(isalnum(*units)) separator = " ";
+
+	if(value_is_null)
+		strcpy(value_string, "-");
+	else {
+		calculated_number abs = (value < (calculated_number)0)?-value:value;
+		if(abs > (calculated_number)1000.0)      snprintfz(value_string, 512, "%0.0Lf%s%s", (long double)value, separator, units);
+		else if(abs > (calculated_number)100.0)  snprintfz(value_string, 512, "%0.1Lf%s%s", (long double)value, separator, units);
+		else if(abs > (calculated_number)1.0)    snprintfz(value_string, 512, "%0.2Lf%s%s", (long double)value, separator, units);
+		else if(abs > (calculated_number)0.1)    snprintfz(value_string, 512, "%0.3Lf%s%s", (long double)value, separator, units);
+		else                                     snprintfz(value_string, 512, "%0.4Lf%s%s", (long double)value, separator, units);
+	}
+
+	// we need to copy the label, since verdana11_width may write to it
+	strncpyz(label_buffer, label, 256);
+
+	label_width = verdana11_width(label_buffer) + (BADGE_HORIZONTAL_PADDING * 2);
+	value_width = verdana11_width(value_string) + (BADGE_HORIZONTAL_PADDING * 2);
+	total_width = label_width + value_width;
+
+	escape_xmlz(label_escaped, label_buffer, 256);
+	escape_xmlz(value_escaped, value_string, 256);
+	escape_xmlz(label_color_escaped, color_map(label_color), 256);
+	escape_xmlz(value_color_escaped, color_map(value_color_buffer), 256);
+
+	wb->contenttype = CT_IMAGE_SVG_XML;
+
+	// svg template from:
+	// https://raw.githubusercontent.com/badges/shields/master/templates/flat-template.svg
+	buffer_sprintf(wb,
+		"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"%zu\" height=\"20\">"
+			"<linearGradient id=\"smooth\" x2=\"0\" y2=\"100%%\">"
+				"<stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/>"
+				"<stop offset=\"1\" stop-opacity=\".1\"/>"
+			"</linearGradient>"
+			"<mask id=\"round\">"
+				"<rect width=\"%zu\" height=\"20\" rx=\"3\" fill=\"#fff\"/>"
+			"</mask>"
+			"<g mask=\"url(#round)\">"
+				"<rect width=\"%zu\" height=\"20\" fill=\"%s\"/>"
+				"<rect x=\"%zu\" width=\"%zu\" height=\"20\" fill=\"%s\"/>"
+				"<rect width=\"%zu\" height=\"20\" fill=\"url(#smooth)\"/>"
+			"</g>"
+			"<g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu Sans,Verdana,Geneva,sans-serif\" font-size=\"11\">"
+				"<text x=\"%zu\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">%s</text>"
+				"<text x=\"%zu\" y=\"14\">%s</text>"
+				"<text x=\"%zu\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">%s</text>"
+				"<text x=\"%zu\" y=\"14\">%s</text>"
+			"</g>"
+		"</svg>",
+		total_width, total_width,
+		label_width, label_color_escaped,
+		label_width, value_width, value_color_escaped,
+		total_width,
+		label_width / 2, label_escaped,
+		label_width / 2, label_escaped,
+		label_width + value_width / 2 -1, value_escaped,
+		label_width + value_width / 2 -1, value_escaped);
+}

--- a/src/web_buffer_svg.h
+++ b/src/web_buffer_svg.h
@@ -1,0 +1,9 @@
+#include "web_buffer.h"
+#include "dictionary.h"
+
+#ifndef NETDATA_WEB_BUFFER_SVG_H
+#define NETDATA_WEB_BUFFER_SVG_H 1
+
+extern void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int value_is_null);
+
+#endif /* NETDATA_WEB_BUFFER_SVG_H */

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -38,6 +38,7 @@
 #define TOO_BIG_REQUEST 16384
 
 int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
+int web_donotrack_comply = 0;
 
 #ifdef NETDATA_WITH_ZLIB
 int web_enable_gzip = 1, web_gzip_level = 3, web_gzip_strategy = Z_DEFAULT_STRATEGY;
@@ -250,6 +251,9 @@ void web_client_reset(struct web_client *w) {
 
 	w->mode = WEB_CLIENT_MODE_NORMAL;
 
+	w->tcp_cork = 0;
+	w->donottrack = 0;
+	w->tracking_required = 0;
 	w->keepalive = 0;
 	w->decoded_url[0] = '\0';
 
@@ -959,6 +963,12 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 #endif /* NETDATA_INTERNAL_CHECKS */
 	}
 
+	if(web_donotrack_comply && w->donottrack) {
+		buffer_flush(w->response.data);
+		buffer_sprintf(w->response.data, "Your web browser is sending 'DNT: 1' (Do Not Track). The registry requires persistent cookies on your browser to work.");
+		return 400;
+	}
+
 	if(action == 'A' && (!machine_guid || !machine_url || !url_name)) {
 		buffer_flush(w->response.data);
 		buffer_sprintf(w->response.data, "Invalid registry request - access requires these parameters: machine ('%s'), url ('%s'), name ('%s')",
@@ -986,6 +996,7 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 
 	switch(action) {
 		case 'A':
+			w->tracking_required = 1;
 			if(registry_verify_cookies_redirects() > 0 && (!cookie || !person_guid[0])) {
 				buffer_flush(w->response.data);
 
@@ -1040,12 +1051,15 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
 			return registry_request_access_json(w, person_guid, machine_guid, machine_url, url_name, time(NULL));
 
 		case 'D':
+			w->tracking_required = 1;
 			return registry_request_delete_json(w, person_guid, machine_guid, machine_url, delete_url, time(NULL));
 
 		case 'S':
+			w->tracking_required = 1;
 			return registry_request_search_json(w, person_guid, machine_guid, machine_url, search_machine_guid, time(NULL));
 
 		case 'W':
+			w->tracking_required = 1;
 			return registry_request_switch_json(w, person_guid, machine_guid, machine_url, to_person_guid, time(NULL));
 
 		case 'H':
@@ -1399,26 +1413,30 @@ const char *web_response_code_to_string(int code) {
 }
 
 static inline char *http_header_parse(struct web_client *w, char *s) {
-	static uint32_t hash_origin = 0, hash_connection = 0, hash_accept_encoding = 0;
+	static uint32_t hash_origin = 0, hash_connection = 0, hash_accept_encoding = 0, hash_donottrack = 0;
 
 	if(unlikely(!hash_origin)) {
 		hash_origin = simple_uhash("Origin");
 		hash_connection = simple_uhash("Connection");
 		hash_accept_encoding = simple_uhash("Accept-Encoding");
+		hash_donottrack = simple_uhash("DNT");
 	}
 
 	char *e = s;
 
 	// find the :
 	while(*e && *e != ':') e++;
-	if(!*e || e[1] != ' ') return e;
+	if(!*e) return e;
 
 	// get the name
 	*e = '\0';
 
 	// find the value
-	char *v, *ve;
-	v = ve = e + 2;
+	char *v = e + 1, *ve;
+
+	// skip leading spaces from value
+	while(*v == ' ') v++;
+	ve = v;
 
 	// find the \r
 	while(*ve && *ve != '\r') ve++;
@@ -1439,6 +1457,10 @@ static inline char *http_header_parse(struct web_client *w, char *s) {
 	else if(hash == hash_connection && !strcasecmp(s, "Connection")) {
 		if(strcasestr(v, "keep-alive"))
 			w->keepalive = 1;
+	}
+	else if(web_donotrack_comply && hash == hash_donottrack && !strcasecmp(s, "DNT")) {
+		if(*v == '0') w->donottrack = 0;
+		else if(*v == '1') w->donottrack = 1;
 	}
 #ifdef NETDATA_WITH_ZLIB
 	else if(hash == hash_accept_encoding && !strcasecmp(s, "Accept-Encoding")) {
@@ -1778,16 +1800,32 @@ void web_client_process(struct web_client *w) {
 		, date
 		);
 
-	if(w->cookie1[0]) {
-		buffer_sprintf(w->response.header_output,
-		   "Set-Cookie: %s\r\n",
-		   w->cookie1);
-	}
+	if(w->cookie1[0] || w->cookie2[0]) {
+		if(w->cookie1[0]) {
+			buffer_sprintf(w->response.header_output,
+			   "Set-Cookie: %s\r\n",
+			   w->cookie1);
+		}
 
-	if(w->cookie2[0]) {
-		buffer_sprintf(w->response.header_output,
-		   "Set-Cookie: %s\r\n",
-		   w->cookie2);
+		if(w->cookie2[0]) {
+			buffer_sprintf(w->response.header_output,
+			   "Set-Cookie: %s\r\n",
+			   w->cookie2);
+		}
+
+		if(web_donotrack_comply)
+			buffer_sprintf(w->response.header_output,
+			   "Tk: T;cookies\r\n");
+	}
+	else {
+		if(web_donotrack_comply) {
+			if(w->tracking_required)
+				buffer_sprintf(w->response.header_output,
+				   "Tk: T;cookies\r\n");
+			else
+				buffer_sprintf(w->response.header_output,
+				   "Tk: N\r\n");
+		}
 	}
 
 	if(w->mode == WEB_CLIENT_MODE_OPTIONS) {

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -18,7 +18,7 @@
 extern int web_client_timeout;
 
 #ifdef NETDATA_WITH_ZLIB
-extern int web_enable_gzip, web_gzip_level, web_gzip_strategy;
+extern int web_enable_gzip, web_gzip_level, web_gzip_strategy, web_donotrack_comply;
 #endif /* NETDATA_WITH_ZLIB */
 
 #ifndef NETDATA_WEB_CLIENT_H
@@ -70,6 +70,9 @@ struct web_client {
 
 	uint8_t wait_receive:1;				// 1 = we are waiting more input data
 	uint8_t wait_send:1;				// 1 = we have data to send to the client
+
+	uint8_t donottrack:1;				// 1 = we should not set cookies on this client
+	uint8_t tracking_required:1;		// 1 = if the request requires cookies
 
 	int tcp_cork;						// 1 = we have a cork on the socket
 

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -14,15 +14,15 @@
 #include "web_buffer.h"
 #include "dictionary.h"
 
+#ifndef NETDATA_WEB_CLIENT_H
+#define NETDATA_WEB_CLIENT_H 1
+
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
 extern int web_client_timeout;
 
 #ifdef NETDATA_WITH_ZLIB
 extern int web_enable_gzip, web_gzip_level, web_gzip_strategy, web_donotrack_comply;
 #endif /* NETDATA_WITH_ZLIB */
-
-#ifndef NETDATA_WEB_CLIENT_H
-#define NETDATA_WEB_CLIENT_H 1
 
 #define WEB_CLIENT_MODE_NORMAL		0
 #define WEB_CLIENT_MODE_FILECOPY	1

--- a/web/.well-known/dnt/cookies
+++ b/web/.well-known/dnt/cookies
@@ -1,0 +1,14 @@
+{
+  "tracking": "T",
+  "compliance": ["https://github.com/firehol/netdata/wiki/cookies#compliance"],
+  "qualifiers": "afc",
+  "controller": ["https://github.com/firehol/netdata/wiki/cookies#controller"],
+  "same-party": [
+    "my-netdata.io",
+    "mynetdata.io",
+    "netdata.online",
+    "netdata.rocks",
+    "registry.my-netdata.io"
+  ],
+  "policy": "https://github.com/firehol/netdata/wiki/cookies#policy",
+}

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -94,6 +94,16 @@ dist_webimages_DATA = \
 	images/seo-performance-multi-size.icns \
 	$(NULL)
 
+
+webwellknowndir=$(webdir)/.well-known
+dist_webwellknown_DATA = \
+	$(NULL)
+
+webdntdir=$(webdir)/.well-known/dnt
+dist_webdnt_DATA = \
+	.well-known/dnt/cookies \
+	$(NULL)
+
 version.txt:
 	if test -d "$(top_srcdir)/.git"; then \
 		git --git-dir="$(top_srcdir)/.git" log -n 1 --format=%H; \

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -581,7 +581,8 @@
 			$.ajax({
 				url: host + '/api/v1/charts',
 				async: true,
-				cache: false
+				cache: false,
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function(data) {
 				if(data !== null) {
@@ -2793,7 +2794,8 @@
 			this.xhr = $.ajax( {
 				url: this.data_url,
 				cache: false,
-				async: true
+				async: true,
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.success(function(data) {
 				if(that.debug === true)
@@ -3013,7 +3015,8 @@
 				$.ajax( {
 					url:  this.host + this.chart_url,
 					cache: false,
-					async: true
+					async: true,
+					xhrFields: { withCredentials: true } // required for the cookie
 				})
 				.done(function(chart) {
 					chart.url = that.chart_url;
@@ -3403,7 +3406,8 @@
 			$.ajax({
 				url: NETDATA.peity_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('peity', NETDATA.peity_js);
@@ -3464,7 +3468,8 @@
 			$.ajax({
 				url: NETDATA.sparkline_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('sparkline', NETDATA.sparkline_js);
@@ -3648,7 +3653,8 @@
 		$.ajax({
 			url: NETDATA.dygraph_smooth_js,
 			cache: true,
-			dataType: "script"
+			dataType: "script",
+			xhrFields: { withCredentials: true } // required for the cookie
 		})
 		.done(function() {
 			NETDATA.dygraph.smooth = true;
@@ -3668,7 +3674,8 @@
 			$.ajax({
 				url: NETDATA.dygraph_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('dygraph', NETDATA.dygraph_js);
@@ -4261,7 +4268,8 @@
 				$.ajax({
 					url: NETDATA.morris_js,
 					cache: true,
-					dataType: "script"
+					dataType: "script",
+					xhrFields: { withCredentials: true } // required for the cookie
 				})
 				.done(function() {
 					NETDATA.registerChartLibrary('morris', NETDATA.morris_js);
@@ -4326,7 +4334,8 @@
 			$.ajax({
 				url: NETDATA.raphael_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('raphael', NETDATA.raphael_js);
@@ -4390,7 +4399,8 @@
 				$.ajax({
 					url: NETDATA.c3_js,
 					cache: true,
-					dataType: "script"
+					dataType: "script",
+					xhrFields: { withCredentials: true } // required for the cookie
 				})
 				.done(function() {
 					NETDATA.registerChartLibrary('c3', NETDATA.c3_js);
@@ -4488,7 +4498,8 @@
 			$.ajax({
 				url: NETDATA.d3_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('d3', NETDATA.d3_js);
@@ -4525,7 +4536,8 @@
 			$.ajax({
 				url: NETDATA.google_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 			.done(function() {
 				NETDATA.registerChartLibrary('google', NETDATA.google_js);
@@ -4669,7 +4681,8 @@
 			$.ajax({
 				url: NETDATA.easypiechart_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 				.done(function() {
 					NETDATA.registerChartLibrary('easypiechart', NETDATA.easypiechart_js);
@@ -4861,7 +4874,8 @@
 			$.ajax({
 				url: NETDATA.gauge_js,
 				cache: true,
-				dataType: "script"
+				dataType: "script",
+				xhrFields: { withCredentials: true } // required for the cookie
 			})
 				.done(function() {
 					NETDATA.registerChartLibrary('gauge', NETDATA.gauge_js);
@@ -5470,7 +5484,8 @@
 		$.ajax({
 			url: NETDATA.requiredJs[index].url,
 			cache: true,
-			dataType: "script"
+			dataType: "script",
+			xhrFields: { withCredentials: true } // required for the cookie
 		})
 		.success(function() {
 			if(NETDATA.options.debug.main_loop === true)


### PR DESCRIPTION

1. Allow dashboard sending cookies on all requests, fixes #477 

2. Allow netdata respect DoNotTrack, according to https://github.com/firehol/netdata/issues/416#issuecomment-222487386 and instructions given at https://github.com/EFForg/privacybadgerchrome/issues/850 and https://github.com/EFForg/privacybadgerchrome/issues/781

  This feature is disabled by default. To enable it set `[global].respect web browser do not track policy = yes`.

  When enabled the following will happen: For browsers sending the http header `DNT: 1`, the registry will refuse to serve them. All responses will have the http header `Tk: T` (tracking), or `Tk: N` (not tracking) depending on whether a cookie is used by netdata or not.

3. Allow netdata generate SVG badges.

  A demonstration wiki page will be added once this is merged.