### PR TITLE
added API option "unaligned"

### DIFF
--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -42,7 +42,7 @@ extern char *hostname;
 #define RRDR_OPTION_NONZERO 		0x00000001 // don't output dimensions will just zero values
 #define RRDR_OPTION_REVERSED		0x00000002 // output the rows in reverse order (oldest to newest)
 #define RRDR_OPTION_ABSOLUTE 		0x00000004 // values positive, for DATASOURCE_SSV before summing
-#define RRDR_OPTION_MIN2MAX	 		0x00000008 // for DATASOURCE_SSV, out max - min, instead of sum
+#define RRDR_OPTION_MIN2MAX	 		0x00000008 // when adding dimensions, use max - min, instead of sum
 #define RRDR_OPTION_SECONDS			0x00000010 // output seconds, instead of dates
 #define RRDR_OPTION_MILLISECONDS	0x00000020 // output milliseconds, instead of dates
 #define RRDR_OPTION_NULL2ZERO		0x00000040 // do not show nulls, convert them to zeros
@@ -51,6 +51,7 @@ extern char *hostname;
 #define RRDR_OPTION_JSON_WRAP		0x00000200 // wrap the response in a JSON header with info about the result
 #define RRDR_OPTION_LABEL_QUOTES 	0x00000400 // in CSV output, wrap header labels in double quotes
 #define RRDR_OPTION_PERCENTAGE		0x00000800 // give values as percentage of total
+#define RRDR_OPTION_NOT_ALIGNED		0x00001000 // do not align charts for persistant timeframes
 
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrd_stats_api_v1_charts(BUFFER *wb);

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -559,6 +559,8 @@ uint32_t web_client_api_request_v1_data_options(char *o)
 			ret |= RRDR_OPTION_GOOGLE_JSON;
 		else if(!strcmp(tok, "percentage"))
 			ret |= RRDR_OPTION_PERCENTAGE;
+		else if(!strcmp(tok, "unaligned"))
+			ret |= RRDR_OPTION_NOT_ALIGNED;
 	}
 
 	return ret;
@@ -802,7 +804,7 @@ int web_client_api_v1_badge(struct web_client *w, char *url) {
 	ret = 500;
 
 	// if the collected value is too old, don't calculate its value
-	if(st->last_updated.tv_sec >= (time(NULL) - (st->update_every * st->gap_when_lost_iterations_above)))
+	if(rrdset_last_entry_t(st) >= (time(NULL) - (st->update_every * st->gap_when_lost_iterations_above)))
 		ret = rrd2value(st, w->response.data, &n, dimensions, points, after, before, group, options, &latest_timestamp, &value_is_null);
 
 	// if the value cannot be calculated, show empty badge

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -110,7 +110,7 @@ paths:
           type: array
           items:
             type: string
-            enum: [ 'nonzero', 'flip', 'jsonwrap', 'min2max', 'seconds', 'milliseconds', 'abs', 'absolute', 'absolute-sum', 'null2zero', 'objectrows', 'google_json', 'percentage' ]
+            enum: [ 'nonzero', 'flip', 'jsonwrap', 'min2max', 'seconds', 'milliseconds', 'abs', 'absolute', 'absolute-sum', 'null2zero', 'objectrows', 'google_json', 'percentage', 'unaligned' ]
             collectionFormat: pipes
           default: [seconds, jsonwrap]
           allowEmptyValue: false
@@ -182,14 +182,6 @@ paths:
           type: number
           format: integer
           default: 0
-        - name: points
-          in: query
-          description: 'The number of points to be returned. If not given, or it is <= 0, or it is bigger than the points stored in the round robin database for this chart for the given duration, all the available collected values for the given duration are returned.'
-          required: true
-          type: number
-          format: integer
-          allowEmptyValue: false
-          default: 20
         - name: group
           in: query
           description: 'The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. Two methods are supported, "max" and "average". "max" is actually calculated on the absolute value collected (so it works for both positive and negative dimesions to return the most extreme value in either direction).'
@@ -205,7 +197,7 @@ paths:
           type: array
           items:
             type: string
-            enum: [ 'nonzero', 'flip', 'abs', 'absolute', 'absolute-sum', 'null2zero', 'percentage' ]
+            enum: [ 'abs', 'absolute', 'absolute-sum', 'null2zero', 'percentage', 'unaligned' ]
             collectionFormat: pipes
           default: ['absolute']
           allowEmptyValue: true


### PR DESCRIPTION
This options allows getting unaligned data for any timeframe

- fixes #208 
- fixes #253
- useful in #205 
- useful in #316 
- useful in badges #483 (to get the last X seconds of data)

Just pass `&options=unaligned` to any data URL.
Don't use this for charts that auto-refresh. The charts will change shape on each update.
