### PR TITLE
API: new data grouping methods: sum and incremental-sum

### DIFF
--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -35,9 +35,10 @@ extern char *hostname;
 #define DATASOURCE_FORMAT_SSV_COMMA "ssvcomma"
 #define DATASOURCE_FORMAT_CSV_JSON_ARRAY "csvjsonarray"
 
-#define GROUP_AVERAGE	0
-#define GROUP_MAX 		1
-#define GROUP_SUM		2
+#define GROUP_AVERAGE			0
+#define GROUP_MAX 				1
+#define GROUP_SUM				2
+#define GROUP_INCREMENTAL_SUM	3
 
 #define RRDR_OPTION_NONZERO 		0x00000001 // don't output dimensions will just zero values
 #define RRDR_OPTION_REVERSED		0x00000002 // output the rows in reverse order (oldest to newest)

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -629,7 +629,13 @@ int web_client_api_request_v1_data_group(char *name)
 	else if(!strcmp(name, "average"))
 		return GROUP_AVERAGE;
 
-	return GROUP_MAX;
+	else if(!strcmp(name, "sum"))
+		return GROUP_SUM;
+
+	else if(!strcmp(name, "incremental-sum"))
+		return GROUP_INCREMENTAL_SUM;
+
+	return GROUP_AVERAGE;
 }
 
 int web_client_api_request_v1_charts(struct web_client *w, char *url)
@@ -711,7 +717,7 @@ int web_client_api_v1_badge(struct web_client *w, char *url) {
 			, *label_color = NULL
 			, *value_color = NULL;
 
-	int group = GROUP_MAX;
+	int group = GROUP_AVERAGE;
 	uint32_t options = 0x00000000;
 
 	while(url) {
@@ -847,7 +853,7 @@ int web_client_api_request_v1_data(struct web_client *w, char *url)
 			, *after_str = NULL
 			, *points_str = NULL;
 
-	int group = GROUP_MAX;
+	int group = GROUP_AVERAGE;
 	uint32_t format = DATASOURCE_JSON;
 	uint32_t options = 0x00000000;
 

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -89,10 +89,10 @@ paths:
           default: 20
         - name: group
           in: query
-          description: 'The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. Two methods are supported, "max" and "average". "max" is actually calculated on the absolute value collected (so it works for both positive and negative dimesions to return the most extreme value in either direction).'
+          description: 'The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. 4 methods are supported, "max", "average", "sum", "incremental-sum". "max" is actually calculated on the absolute value collected (so it works for both positive and negative dimesions to return the most extreme value in either direction).'
           required: true
           type: string
-          enum: [ 'max', 'average' ]
+          enum: [ 'max', 'average', 'sum', 'incremental-sum' ]
           default: 'average'
           allowEmptyValue: false
         - name: format
@@ -184,10 +184,10 @@ paths:
           default: 0
         - name: group
           in: query
-          description: 'The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. Two methods are supported, "max" and "average". "max" is actually calculated on the absolute value collected (so it works for both positive and negative dimesions to return the most extreme value in either direction).'
+          description: 'The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. 4 methods are supported, "max", "average", "sum", "incremental-sum". "max" is actually calculated on the absolute value collected (so it works for both positive and negative dimesions to return the most extreme value in either direction).'
           required: true
           type: string
-          enum: [ 'max', 'average' ]
+          enum: [ 'max', 'average', 'sum', 'incremental-sum' ]
           default: 'average'
           allowEmptyValue: false
         - name: options


### PR DESCRIPTION
added "sum" and "incremental-sum" grouping methods; the default grouping was faulty set to "max" - it is now "average" according to documentation