### PR TITLE
Update contrib/debian/control to include uuid-dev

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -3,7 +3,8 @@ Build-Depends: debhelper (>= 9),
                dh-autoreconf,
                dh-systemd (>= 1.5),
                dpkg-dev (>= 1.13.19),
-               zlib1g-dev
+               zlib1g-dev,
+               uuid-dev
 Section: net
 Priority: optional
 Maintainer: Costa Tsaousis <costa@tsaousis.gr>


### PR DESCRIPTION
Add build dependency uuid-dev, which is needed since Netdata 1.2