### PR TITLE
Add couple more applications to default apps groups

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -47,7 +47,7 @@
 
 compile: cc1 cc1plus as gcc* ld make automake autoconf git
 rsync: rsync
-media: mplayer vlc xine mediatomb omxplayer* kodi* xbmc* mediacenter eventlircd
+media: mplayer vlc xine mediatomb omxplayer* kodi* xbmc* mediacenter eventlircd mpd minidlnad
 squid: squid* c-icap
 apache: apache* httpd
 mysql: mysql*
@@ -60,6 +60,7 @@ postfix: master
 nginx: nginx
 splunk: splunkd
 mongo: mongod
+redis: redis*
 lighttpd: lighttpd
 ftpd: proftpd in.tftpd
 samba: smbd nmbd winbindd
@@ -72,7 +73,7 @@ named: named rncd
 clam: clam* *clam
 cups: cups*
 ntp: ntp*
-deluge: deluge*
+torrent: deluge* transmission*
 vbox: vbox* VBox*
 log: ulogd syslog* rsyslog* logrotate
 nms: snmpd vnstatd smokeping zabbix* monit munin* mon openhpid
@@ -94,3 +95,4 @@ zfs-spl: spl_*
 zfs-posix: z_*
 zfs-txg: txg_* zil_*
 zfs-arc: arc_* l2arc* 
+php: php*


### PR DESCRIPTION
Add two popular media applications. Change 'deluge' group to 'torrent' due to addition of transmission. Also add 'php' and 'redis' groups.