### PR TITLE
ensure correct path to nologin shell for user netdata

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -376,7 +376,7 @@ if [ ${UID} -eq 0 ]
 	if [ $? -ne 0 ]
 		then
 		echo >&2 "Adding netdata user account ..."
-		run useradd -r -g netdata -c netdata -s $(which nologin) -d / netdata
+		run useradd -r -g netdata -c netdata -s $(which nologin || echo '/bin/false') -d / netdata
 	fi
 
 	getent group docker > /dev/null

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -376,7 +376,7 @@ if [ ${UID} -eq 0 ]
 	if [ $? -ne 0 ]
 		then
 		echo >&2 "Adding netdata user account ..."
-		run useradd -r -g netdata -c netdata -s /sbin/nologin -d / netdata
+		run useradd -r -g netdata -c netdata -s $(which nologin) -d / netdata
 	fi
 
 	getent group docker > /dev/null


### PR DESCRIPTION
`nologin` shell can be in different locations, ex. on Debian it is in `/usr/sbin/nologin`. Do not assume `/sbin/nologin`.