### PR TITLE
strict printf type checking for all similar netdata functions

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -417,7 +417,7 @@ int load_config(char *filename, int overwrite_used)
 		if(!cv) cv = config_value_create(co, name, value);
 		else {
 			if(((cv->flags & CONFIG_VALUE_USED) && overwrite_used) || !(cv->flags & CONFIG_VALUE_USED)) {
-				debug(D_CONFIG, "Overwriting '%s/%s'.", line, co->name, cv->name);
+				debug(D_CONFIG, "Line %d, overwriting '%s/%s'.", line, co->name, cv->name);
 				free(cv->value);
 				cv->value = strdup(value);
 				if(!cv->value) fatal("Cannot allocate config.value");

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -172,7 +172,7 @@ void *realloc_debug(const char *file, int line, const char *function, void *ptr,
 	allocations.allocated -= old_size;
 
 	debug(D_MEMORY, "MEMORY: Re-allocated from %zu to %zu bytes for %s/%u@%s."
-		" Status: allocated %z in %zu allocs."
+		" Status: allocated %zu in %zu allocs."
 		, old_size, size
 		, function, line, file
 		, allocations.allocated
@@ -547,7 +547,7 @@ int read_apps_groups_conf(const char *name)
 
 			struct target *n = get_apps_groups_target(s, w);
 			if(!n) {
-				error("Cannot create target '%s' (line %d, word %d)", s, line, word);
+				error("Cannot create target '%s' (line %lu, word %lu)", s, line, word);
 				continue;
 			}
 

--- a/src/common.c
+++ b/src/common.c
@@ -701,6 +701,18 @@ void *mymmap(const char *filename, size_t size, int flags, int ksm)
 #ifdef MADV_MERGEABLE
 				}
 				else {
+/*
+					// test - load the file into memory
+					mem = calloc(1, size);
+					if(mem) {
+						if(lseek(fd, 0, SEEK_SET) == 0) {
+							if(read(fd, mem, size) != (ssize_t)size)
+								error("Cannot read from file '%s'", filename);
+						}
+						else
+							error("Cannot seek to beginning of file '%s'.", filename);
+					}
+*/
 					mem = mmap(NULL, size, PROT_READ|PROT_WRITE, flags|MAP_ANONYMOUS, -1, 0);
 					if(mem != MAP_FAILED) {
 						if(lseek(fd, 0, SEEK_SET) == 0) {

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -90,14 +90,14 @@ static NAME_VALUE *dictionary_name_value_create_nolock(DICTIONARY *dict, const c
 	debug(D_DICTIONARY, "Creating name value entry for name '%s'.", name);
 
 	NAME_VALUE *nv = calloc(1, sizeof(NAME_VALUE));
-	if(unlikely(!nv)) fatal("Cannot allocate name_value of size %z", sizeof(NAME_VALUE));
+	if(unlikely(!nv)) fatal("Cannot allocate name_value of size %zu", sizeof(NAME_VALUE));
 
 	if(dict->flags & DICTIONARY_FLAG_NAME_LINK_DONT_CLONE)
 		nv->name = (char *)name;
 	else {
 		nv->name = strdup(name);
 		if (unlikely(!nv->name))
-			fatal("Cannot allocate name_value.name of size %z", strlen(name));
+			fatal("Cannot allocate name_value.name of size %zu", strlen(name));
 	}
 
 	nv->hash = (hash)?hash:simple_hash(nv->name);
@@ -107,7 +107,7 @@ static NAME_VALUE *dictionary_name_value_create_nolock(DICTIONARY *dict, const c
 	else {
 		nv->value = malloc(value_len);
 		if (unlikely(!nv->value))
-			fatal("Cannot allocate name_value.value of size %z", value_len);
+			fatal("Cannot allocate name_value.value of size %zu", value_len);
 
 		memcpy(nv->value, value, value_len);
 	}
@@ -215,7 +215,7 @@ void *dictionary_set(DICTIONARY *dict, const char *name, void *value, size_t val
 					*old = nv->value;
 
 			if(unlikely(!nv->value))
-				fatal("Cannot allocate value of size %z", value_len);
+				fatal("Cannot allocate value of size %zu", value_len);
 
 			memcpy(value, value, value_len);
 			nv->value = value;

--- a/src/log.h
+++ b/src/log.h
@@ -59,10 +59,10 @@ extern int error_log_limit(int reset);
 #define fatal(args...)   fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args)
 
 extern void log_date(FILE *out);
-extern void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... );
-extern void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... );
-extern void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... );
-extern void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) __attribute__ ((noreturn));
-extern void log_access( const char *fmt, ... );
+extern void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) __attribute__ (( format (printf, 4, 5)));
+extern void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) __attribute__ (( format (printf, 4, 5)));
+extern void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) __attribute__ (( format (printf, 5, 6)));
+extern void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) __attribute__ ((noreturn, format (printf, 4, 5)));
+extern void log_access( const char *fmt, ... ) __attribute__ (( format (printf, 1, 2)));
 
 #endif /* NETDATA_LOG_H */

--- a/src/main.c
+++ b/src/main.c
@@ -119,17 +119,17 @@ void web_server_threading_selection(void) {
 	else if(!strcmp(s, "fixed"))
 		web_gzip_strategy = Z_FIXED;
 	else {
-		error("Invalid compression strategy '%s'. Valid strategies are 'default', 'filtered', 'huffman only', 'rle' and 'fixed'. Proceeding with 'default'.");
+		error("Invalid compression strategy '%s'. Valid strategies are 'default', 'filtered', 'huffman only', 'rle' and 'fixed'. Proceeding with 'default'.", s);
 		web_gzip_strategy = Z_DEFAULT_STRATEGY;
 	}
 
 	web_gzip_level = (int)config_get_number("global", "web compression level", 3);
 	if(web_gzip_level < 1) {
-		error("Invalid compression level %d. Valid levels are 1 (fastest) to 9 (best ratio). Proceeding with level 1 (fastest compression).");
+		error("Invalid compression level %d. Valid levels are 1 (fastest) to 9 (best ratio). Proceeding with level 1 (fastest compression).", web_gzip_level);
 		web_gzip_level = 1;
 	}
 	else if(web_gzip_level > 9) {
-		error("Invalid compression level %d. Valid levels are 1 (fastest) to 9 (best ratio). Proceeding with level 9 (best compression).");
+		error("Invalid compression level %d. Valid levels are 1 (fastest) to 9 (best ratio). Proceeding with level 9 (best compression).", web_gzip_level);
 		web_gzip_level = 9;
 	}
 #endif /* NETDATA_WITH_ZLIB */

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -257,7 +257,7 @@ static inline void tc_device_commit(struct tc_device *d)
 				RRDDIM *rd = rrddim_find(st, c->id);
 
 				if(!rd) {
-					debug(D_TC_LOOP, "TC: Adding to chart '%s', dimension '%s'", st->id, c->id, c->name);
+					debug(D_TC_LOOP, "TC: Adding to chart '%s', dimension '%s' (name: '%s')", st->id, c->id, c->name);
 
 					// new class, we have to add it
 					rd = rrddim_add(st, c->id, c->name?c->name:c->id, 8, 1024, RRDDIM_INCREMENTAL);

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -423,7 +423,7 @@ void *pluginsd_worker_thread(void *arg)
 					sleep((unsigned int) (cd->update_every * 10));
 				}
 				else {
-					error("PLUGINSD: '%s' exited with error code %d, but has given useful output in the past (%zu times). We tried %d times to restart it, but it failed to generate data. Disabling it.", cd->fullfilename, code, cd->successful_collections, cd->serial_failures);
+					error("PLUGINSD: '%s' exited with error code %d, but has given useful output in the past (%zu times). We tried %zu times to restart it, but it failed to generate data. Disabling it.", cd->fullfilename, code, cd->successful_collections, cd->serial_failures);
 					cd->enabled = 0;
 				}
 			}
@@ -439,7 +439,7 @@ void *pluginsd_worker_thread(void *arg)
 					sleep((unsigned int) (cd->update_every * 10));
 				}
 				else {
-					error("PLUGINSD: '%s' (pid %d) does not generate useful output, although it reports success (exits with 0), but we have tried %d times to collect something. Disabling it.", cd->fullfilename, cd->pid, cd->serial_failures);
+					error("PLUGINSD: '%s' (pid %d) does not generate useful output, although it reports success (exits with 0), but we have tried %zu times to collect something. Disabling it.", cd->fullfilename, cd->pid, cd->serial_failures);
 					cd->enabled = 0;
 				}
 			}

--- a/src/proc_net_stat_synproxy.c
+++ b/src/proc_net_stat_synproxy.c
@@ -37,9 +37,9 @@ int do_proc_net_stat_synproxy(int update_every, unsigned long long dt) {
 	if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
 	// make sure we have 3 lines
-	unsigned long lines = procfile_lines(ff), l;
+	size_t lines = procfile_lines(ff), l;
 	if(lines < 2) {
-		error("/proc/net/stat/synproxy has %d lines, expected no less than 2. Disabling it.", lines);
+		error("/proc/net/stat/synproxy has %zu lines, expected no less than 2. Disabling it.", lines);
 		return 1;
 	}
 

--- a/src/registry.c
+++ b/src/registry.c
@@ -337,7 +337,7 @@ static inline URL *registry_url_allocate_nolock(const char *url, size_t urllen) 
 
 	debug(D_REGISTRY, "Registry: registry_url_allocate_nolock('%s'): allocating %zu bytes", url, sizeof(URL) + urllen);
 	URL *u = malloc(sizeof(URL) + urllen);
-	if(!u) fatal("Cannot allocate %zu bytes for URL '%s'", sizeof(URL) + urllen);
+	if(!u) fatal("Cannot allocate %zu bytes for URL '%s'", sizeof(URL) + urllen, url);
 
 	// a simple strcpy() should do the job
 	// but I prefer to be safe, since the caller specified urllen
@@ -782,7 +782,7 @@ int registry_log_load(void) {
 
 					// verify it is valid
 					if (unlikely(len < 85 || s[1] != '\t' || s[10] != '\t' || s[47] != '\t' || s[84] != '\t')) {
-						error("Registry: log line %u is wrong (len = %zu).", line, len);
+						error("Registry: log line %zu is wrong (len = %zu).", line, len);
 						continue;
 					}
 					s[1] = s[10] = s[47] = s[84] = '\0';
@@ -797,7 +797,7 @@ int registry_log_load(void) {
 					char *url = name;
 					while(*url && *url != '\t') url++;
 					if(!*url) {
-						error("Registry: log line %u does not have a url.", line);
+						error("Registry: log line %zu does not have a url.", line);
 						continue;
 					}
 					*url++ = '\0';
@@ -1521,7 +1521,7 @@ static inline size_t registry_load(void) {
 		switch(*s) {
 			case 'T': // totals
 				if(unlikely(len != 103 || s[1] != '\t' || s[18] != '\t' || s[35] != '\t' || s[52] != '\t' || s[69] != '\t' || s[86] != '\t' || s[103] != '\0')) {
-					error("Registry totals line %u is wrong (len = %zu).", line, len);
+					error("Registry totals line %zu is wrong (len = %zu).", line, len);
 					continue;
 				}
 				registry.persons_count = strtoull(&s[2], NULL, 16);
@@ -1536,7 +1536,7 @@ static inline size_t registry_load(void) {
 				m = NULL;
 				// verify it is valid
 				if(unlikely(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0')) {
-					error("Registry person line %u is wrong (len = %zu).", line, len);
+					error("Registry person line %zu is wrong (len = %zu).", line, len);
 					continue;
 				}
 
@@ -1551,7 +1551,7 @@ static inline size_t registry_load(void) {
 				p = NULL;
 				// verify it is valid
 				if(unlikely(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0')) {
-					error("Registry person line %u is wrong (len = %zu).", line, len);
+					error("Registry person line %zu is wrong (len = %zu).", line, len);
 					continue;
 				}
 
@@ -1570,7 +1570,7 @@ static inline size_t registry_load(void) {
 
 				// verify it is valid
 				if(len < 69 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[31] != '\t' || s[68] != '\t') {
-					error("Registry person URL line %u is wrong (len = %zu).", line, len);
+					error("Registry person URL line %zu is wrong (len = %zu).", line, len);
 					continue;
 				}
 
@@ -1580,7 +1580,7 @@ static inline size_t registry_load(void) {
 				char *url = &s[69];
 				while(*url && *url != '\t') url++;
 				if(!*url) {
-					error("Registry person URL line %u does not have a url.", line);
+					error("Registry person URL line %zu does not have a url.", line);
 					continue;
 				}
 				*url++ = '\0';
@@ -1607,7 +1607,7 @@ static inline size_t registry_load(void) {
 
 				// verify it is valid
 				if(len < 32 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[31] != '\t') {
-					error("Registry person URL line %u is wrong (len = %zu).", line, len);
+					error("Registry person URL line %zu is wrong (len = %zu).", line, len);
 					continue;
 				}
 

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -876,7 +876,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
 	// check if we will re-write the entire data set
 	if(unlikely(usecdiff(&st->last_collected_time, &st->last_updated) > st->update_every * st->entries * 1000000ULL)) {
-		info("%s: too old data (last updated at %u.%u, last collected at %u.%u). Reseting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
+		info("%s: too old data (last updated at %zu.%zu, last collected at %zu.%zu). Reseting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
 		rrdset_reset(st);
 
 		st->usec_since_last_update = st->update_every * 1000000ULL;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -262,7 +262,7 @@ void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 
 			ca->cpu_percpu = malloc(sizeof(unsigned long long) * i);
 			if(!ca->cpu_percpu)
-				fatal("Cannot allocate memory (%z bytes)", sizeof(unsigned long long) * i);
+				fatal("Cannot allocate memory (%zu bytes)", sizeof(unsigned long long) * i);
 
 			ca->cpus = i;
 		}

--- a/src/web_buffer.c
+++ b/src/web_buffer.c
@@ -281,11 +281,11 @@ void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minute
 	buffer_overflow_check(wb);
 }
 
-BUFFER *buffer_create(long size)
+BUFFER *buffer_create(size_t size)
 {
 	BUFFER *b;
 
-	debug(D_WEB_BUFFER, "Creating new web buffer of size %d.", size);
+	debug(D_WEB_BUFFER, "Creating new web buffer of size %zu.", size);
 
 	b = calloc(1, sizeof(BUFFER));
 	if(!b) {
@@ -295,7 +295,7 @@ BUFFER *buffer_create(long size)
 
 	b->buffer = malloc(size + sizeof(BUFFER_OVERFLOW_EOF) + 2);
 	if(!b->buffer) {
-		error("Cannot allocate a buffer of size %u.", size + sizeof(BUFFER_OVERFLOW_EOF) + 2);
+		error("Cannot allocate a buffer of size %zu.", size + sizeof(BUFFER_OVERFLOW_EOF) + 2);
 		free(b);
 		return NULL;
 	}
@@ -312,7 +312,7 @@ void buffer_free(BUFFER *b)
 {
 	buffer_overflow_check(b);
 
-	debug(D_WEB_BUFFER, "Freeing web buffer of size %d.", b->size);
+	debug(D_WEB_BUFFER, "Freeing web buffer of size %zu.", b->size);
 
 	if(b->buffer) free(b->buffer);
 	free(b);
@@ -329,11 +329,11 @@ void buffer_increase(BUFFER *b, size_t free_size_required)
 	size_t increase = free_size_required - left;
 	if(increase < WEB_DATA_LENGTH_INCREASE_STEP) increase = WEB_DATA_LENGTH_INCREASE_STEP;
 
-	debug(D_WEB_BUFFER, "Increasing data buffer from size %d to %d.", b->size, b->size + increase);
+	debug(D_WEB_BUFFER, "Increasing data buffer from size %zu to %zu.", b->size, b->size + increase);
 
 	b->buffer = realloc(b->buffer, b->size + increase + sizeof(BUFFER_OVERFLOW_EOF) + 2);
 	if(!b->buffer)
-		fatal("Failed to increase data buffer from size %d to %d.",
+		fatal("Failed to increase data buffer from size %zu to %zu.",
 			b->size + sizeof(BUFFER_OVERFLOW_EOF) + 2,
 			b->size + increase + sizeof(BUFFER_OVERFLOW_EOF) + 2);
 

--- a/src/web_buffer.h
+++ b/src/web_buffer.h
@@ -57,13 +57,13 @@ extern void buffer_rrd_value(BUFFER *wb, calculated_number value);
 extern void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
 extern void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
 
-extern BUFFER *buffer_create(long size);
+extern BUFFER *buffer_create(size_t size);
 extern void buffer_free(BUFFER *b);
 extern void buffer_increase(BUFFER *b, size_t free_size_required);
 
-extern void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...);
+extern void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...) __attribute__ (( format (printf, 3, 4)));
 extern void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args);
-extern void buffer_sprintf(BUFFER *wb, const char *fmt, ...);
+extern void buffer_sprintf(BUFFER *wb, const char *fmt, ...) __attribute__ (( format (printf, 2, 3)));
 
 extern void buffer_char_replace(BUFFER *wb, char from, char to);
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -277,7 +277,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
 				sleep(5);
 				create_listen_socket();
 				if(listen_fd < 0)
-					fatal("Cannot listen for web clients (connected clients %llu).", global_statistics.connected_clients);
+					fatal("Cannot listen for web clients (connected clients %lu).", global_statistics.connected_clients);
 
 				failures = 0;
 			}
@@ -294,7 +294,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
 				}
 
 				if(pthread_create(&w->thread, NULL, web_client_main, w) != 0) {
-					error("%llu: failed to create new thread for web client.");
+					error("%llu: failed to create new thread for web client.", w->id);
 					w->obsolete = 1;
 				}
 				else if(pthread_detach(w->thread) != 0) {
@@ -446,7 +446,7 @@ void *socket_listen_main_single_threaded(void *ptr) {
 
 				create_listen_socket();
 				if(listen_fd < 0 || listen_fd >= FD_SETSIZE)
-					fatal("Cannot listen for web clients (connected clients %llu).", global_statistics.connected_clients);
+					fatal("Cannot listen for web clients (connected clients %lu).", global_statistics.connected_clients);
 
 				FD_ZERO (&ifds);
 				FD_ZERO (&ofds);


### PR DESCRIPTION
added gcc printf checking to debug(), error(), fatal(), info(), web_sprintf() and fixed all the occurences reported by the compiler