### PR TITLE
fix for mysql not collecting Questions and Qcache Inserts

### DIFF
--- a/charts.d/mysql.chart.sh
+++ b/charts.d/mysql.chart.sh
@@ -17,7 +17,7 @@ mysql_get() {
 	local oIFS="${IFS}"
 	mysql_data=()
 	IFS=$'\t'$'\n'
-	arr=($("${@}" -e "SHOW GLOBAL STATUS WHERE value REGEXP '^[0-9]';" | egrep "^(Bytes|Slow_|Queri|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)" ))
+	arr=($("${@}" -e "SHOW GLOBAL STATUS WHERE value REGEXP '^[0-9]';" | egrep "^(Bytes|Slow_|Que|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)" ))
 	IFS="${oIFS}"
 
 	[ "${#arr[@]}" -lt 3 ] && return 1
@@ -449,7 +449,7 @@ END
 BEGIN mysql_$x.qcache_ops $1
 SET Qcache_hits hits = ${mysql_data[Qcache_hits]}
 SET Qcache_lowmem_prunes = ${mysql_data[Qcache_lowmem_prunes]}
-SET Qcache_inserts_inserts = ${mysql_data[Qcache_inserts_inserts]}
+SET Qcache_inserts = ${mysql_data[Qcache_inserts]}
 SET Qcache_not_cached = ${mysql_data[Qcache_not_cached]}
 END
 BEGIN mysql_$x.qcache $1


### PR DESCRIPTION
fix for the optimization of mysql chart made with #523 
mysql plugin was not collection `Questions` and `Qcache Inserts`.
Fixed.

CC: @paulfantom 