### PR TITLE
gcc options to check format of snprintfz(), fixes 387

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -398,7 +398,7 @@ struct target *get_users_target(uid_t uid)
 	users_root_target = w;
 
 	if(unlikely(debug))
-		fprintf(stderr, "apps.plugin: added uid %d ('%s') target\n", w->uid, w->name);
+		fprintf(stderr, "apps.plugin: added uid %u ('%s') target\n", w->uid, w->name);
 
 	return w;
 }
@@ -436,7 +436,7 @@ struct target *get_groups_target(gid_t gid)
 	groups_root_target = w;
 
 	if(unlikely(debug))
-		fprintf(stderr, "apps.plugin: added gid %d ('%s') target\n", w->gid, w->name);
+		fprintf(stderr, "apps.plugin: added gid %u ('%s') target\n", w->gid, w->name);
 
 	return w;
 }
@@ -1995,7 +1995,7 @@ void calculate_netdata_statistics(void)
 			w = p->user_target;
 		else {
 			if(unlikely(debug && p->user_target))
-					fprintf(stderr, "apps.plugin: \t\tpid %d (%s) switched user from %d (%s) to %d.\n", p->pid, p->comm, p->user_target->uid, p->user_target->name, p->uid);
+					fprintf(stderr, "apps.plugin: \t\tpid %d (%s) switched user from %u (%s) to %u.\n", p->pid, p->comm, p->user_target->uid, p->user_target->name, p->uid);
 
 			w = p->user_target = get_users_target(p->uid);
 		}
@@ -2013,7 +2013,7 @@ void calculate_netdata_statistics(void)
 			w = p->group_target;
 		else {
 			if(unlikely(debug && p->group_target))
-					fprintf(stderr, "apps.plugin: \t\tpid %d (%s) switched group from %d (%s) to %d.\n", p->pid, p->comm, p->group_target->gid, p->group_target->name, p->gid);
+					fprintf(stderr, "apps.plugin: \t\tpid %d (%s) switched group from %u (%s) to %u.\n", p->pid, p->comm, p->group_target->gid, p->group_target->name, p->gid);
 
 			w = p->group_target = get_groups_target(p->gid);
 		}

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -149,7 +149,7 @@ void free_debug(const char *file, int line, const char *function, void *ptr) {
 	allocations.allocated -= size;
 	allocations.allocations--;
 
-	debug(D_MEMORY, "MEMORY: freed %zu bytes for %s/%u@%s."
+	debug(D_MEMORY, "MEMORY: freed %zu bytes for %s/%d@%s."
 		" Status: allocated %zu in %zu allocs."
 		, size
 		, function, line, file
@@ -171,7 +171,7 @@ void *realloc_debug(const char *file, int line, const char *function, void *ptr,
 	allocations.allocated += size;
 	allocations.allocated -= old_size;
 
-	debug(D_MEMORY, "MEMORY: Re-allocated from %zu to %zu bytes for %s/%u@%s."
+	debug(D_MEMORY, "MEMORY: Re-allocated from %zu to %zu bytes for %s/%d@%s."
 		" Status: allocated %zu in %zu allocs."
 		, old_size, size
 		, function, line, file
@@ -377,16 +377,16 @@ struct target *get_users_target(uid_t uid)
 		return NULL;
 	}
 
-	snprintfz(w->compare, MAX_COMPARE_NAME, "%d", uid);
+	snprintfz(w->compare, MAX_COMPARE_NAME, "%u", uid);
 	w->comparehash = simple_hash(w->compare);
 	w->comparelen = strlen(w->compare);
 
-	snprintfz(w->id, MAX_NAME, "%d", uid);
+	snprintfz(w->id, MAX_NAME, "%u", uid);
 	w->idhash = simple_hash(w->id);
 
 	struct passwd *pw = getpwuid(uid);
 	if(!pw)
-		snprintfz(w->name, MAX_NAME, "%d", uid);
+		snprintfz(w->name, MAX_NAME, "%u", uid);
 	else
 		snprintfz(w->name, MAX_NAME, "%s", pw->pw_name);
 
@@ -415,16 +415,16 @@ struct target *get_groups_target(gid_t gid)
 		return NULL;
 	}
 
-	snprintfz(w->compare, MAX_COMPARE_NAME, "%d", gid);
+	snprintfz(w->compare, MAX_COMPARE_NAME, "%u", gid);
 	w->comparehash = simple_hash(w->compare);
 	w->comparelen = strlen(w->compare);
 
-	snprintfz(w->id, MAX_NAME, "%d", gid);
+	snprintfz(w->id, MAX_NAME, "%u", gid);
 	w->idhash = simple_hash(w->id);
 
 	struct group *gr = getgrgid(gid);
 	if(!gr)
-		snprintfz(w->name, MAX_NAME, "%d", gid);
+		snprintfz(w->name, MAX_NAME, "%u", gid);
 	else
 		snprintfz(w->name, MAX_NAME, "%s", gr->gr_name);
 
@@ -735,13 +735,13 @@ struct pid_stat *get_pid_entry(pid_t pid)
 
 	all_pids[pid] = calloc(sizeof(struct pid_stat), 1);
 	if(!all_pids[pid]) {
-		error("Cannot allocate %lu bytes of memory", (unsigned long)sizeof(struct pid_stat));
+		error("Cannot allocate %zu bytes of memory", (size_t)sizeof(struct pid_stat));
 		return NULL;
 	}
 
 	all_pids[pid]->fds = calloc(sizeof(int), 100);
 	if(!all_pids[pid]->fds)
-		error("Cannot allocate %ld bytes of memory", (unsigned long)(sizeof(int) * 100));
+		error("Cannot allocate %zu bytes of memory", (size_t)(sizeof(int) * 100));
 	else all_pids[pid]->fds_size = 100;
 
 	if(root_of_pids) root_of_pids->prev = all_pids[pid];

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -166,7 +166,7 @@ void *realloc_debug(const char *file, int line, const char *function, void *ptr,
 	void *real_ptr = check_allocation(file, line, function, ptr, &old_size);
 
 	void *new_ptr = realloc(real_ptr, size + MALLOC_OVERHEAD);
-	if(!new_ptr) fatal("MEMORY: Cannot allocate %zu bytes for %s/%u@%s.", size, function, line, file);
+	if(!new_ptr) fatal("MEMORY: Cannot allocate %zu bytes for %s/%d@%s.", size, function, line, file);
 
 	allocations.allocated += size;
 	allocations.allocated -= old_size;

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -92,12 +92,12 @@ void *check_allocation(const char *file, int line, const char *function, void *m
 
 	// fprintf(stderr, "MEMORY_POINTER: Checking pointer at %p, real %p for %s/%u@%s.\n", marked_ptr, (void *)(marked_ptr - MALLOC_PREFIX), function, line, file);
 
-	if(real_ptr[0] != MALLOC_MARK) fatal("MEMORY: prefix MARK is not valid for %s/%u@%s.", function, line, file);
+	if(real_ptr[0] != MALLOC_MARK) fatal("MEMORY: prefix MARK is not valid for %s/%d@%s.", function, line, file);
 
 	size_t size = real_ptr[1];
 
 	uint32_t *end_ptr = (uint32_t *)(marked_ptr + size);
-	if(end_ptr[0] != MALLOC_MARK) fatal("MEMORY: suffix MARK of allocation with size %zu is not valid for %s/%u@%s.", size, function, line, file);
+	if(end_ptr[0] != MALLOC_MARK) fatal("MEMORY: suffix MARK of allocation with size %zu is not valid for %s/%d@%s.", size, function, line, file);
 
 	if(size_without_overheads_ptr) *size_without_overheads_ptr = size;
 
@@ -106,12 +106,12 @@ void *check_allocation(const char *file, int line, const char *function, void *m
 
 void *malloc_debug(const char *file, int line, const char *function, size_t size) {
 	void *ptr = malloc(size + MALLOC_OVERHEAD);
-	if(!ptr) fatal("MEMORY: Cannot allocate %zu bytes for %s/%u@%s.", size, function, line, file);
+	if(!ptr) fatal("MEMORY: Cannot allocate %zu bytes for %s/%d@%s.", size, function, line, file);
 
 	allocations.allocated += size;
 	allocations.allocations++;
 
-	debug(D_MEMORY, "MEMORY: Allocated %zu bytes for %s/%u@%s."
+	debug(D_MEMORY, "MEMORY: Allocated %zu bytes for %s/%d@%s."
 		" Status: allocated %zu in %zu allocs."
 		, size
 		, function, line, file

--- a/src/common.c
+++ b/src/common.c
@@ -685,7 +685,7 @@ void *mymmap(const char *filename, size_t size, int flags, int ksm)
 		if(lseek(fd, size, SEEK_SET) == (off_t)size) {
 			if(write(fd, "", 1) == 1) {
 				if(ftruncate(fd, size))
-					error("Cannot truncate file '%s' to size %ld. Will use the larger file.", filename, size);
+					error("Cannot truncate file '%s' to size %zu. Will use the larger file.", filename, size);
 
 #ifdef MADV_MERGEABLE
 				if(flags & MAP_SHARED || !enable_ksm || !ksm) {
@@ -734,9 +734,9 @@ void *mymmap(const char *filename, size_t size, int flags, int ksm)
 				}
 #endif
 			}
-			else error("Cannot write to file '%s' at position %ld.", filename, size);
+			else error("Cannot write to file '%s' at position %zu.", filename, size);
 		}
-		else error("Cannot seek file '%s' to size %ld.", filename, size);
+		else error("Cannot seek file '%s' to size %zu.", filename, size);
 
 		close(fd);
 	}

--- a/src/common.h
+++ b/src/common.h
@@ -29,7 +29,7 @@ extern char *trim(char *s);
 
 extern char *strncpyz(char *dst, const char *src, size_t n);
 extern int  vsnprintfz(char *dst, size_t n, const char *fmt, va_list args);
-extern int  snprintfz(char *dst, size_t n, const char *fmt, ...);
+extern int  snprintfz(char *dst, size_t n, const char *fmt, ...) __attribute__ (( format (printf, 3, 4)));
 
 extern void *mymmap(const char *filename, size_t size, int flags, int ksm);
 extern int savememory(const char *filename, void *mem, size_t size);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -93,29 +93,29 @@ int become_user(const char *username, int access_fd, int output_fd, int error_fd
 	}
 
 	if(setresgid(gid, gid, gid) != 0) {
-		error("Cannot switch to user's %s group (gid: %d).", username, gid);
+		error("Cannot switch to user's %s group (gid: %u).", username, gid);
 		return -1;
 	}
 
 	if(setresuid(uid, uid, uid) != 0) {
-		error("Cannot switch to user %s (uid: %d).", username, uid);
+		error("Cannot switch to user %s (uid: %u).", username, uid);
 		return -1;
 	}
 
 	if(setgid(gid) != 0) {
-		error("Cannot switch to user's %s group (gid: %d).", username, gid);
+		error("Cannot switch to user's %s group (gid: %u).", username, gid);
 		return -1;
 	}
 	if(setegid(gid) != 0) {
-		error("Cannot effectively switch to user's %s group (gid: %d).", username, gid);
+		error("Cannot effectively switch to user's %s group (gid: %u).", username, gid);
 		return -1;
 	}
 	if(setuid(uid) != 0) {
-		error("Cannot switch to user %s (uid: %d).", username, uid);
+		error("Cannot switch to user %s (uid: %u).", username, uid);
 		return -1;
 	}
 	if(seteuid(uid) != 0) {
-		error("Cannot effectively switch to user %s (uid: %d).", username, uid);
+		error("Cannot effectively switch to user %s (uid: %u).", username, uid);
 		return -1;
 	}
 

--- a/src/proc_net_netstat.c
+++ b/src/proc_net_netstat.c
@@ -48,7 +48,7 @@ int do_proc_net_netstat(int update_every, unsigned long long dt) {
 			}
 			words = procfile_linewords(ff, l);
 			if(words < 12) {
-				error("Cannot read /proc/net/netstat IpExt line. Expected 12 params, read %d.", words);
+				error("Cannot read /proc/net/netstat IpExt line. Expected 12 params, read %u.", words);
 				continue;
 			}
 

--- a/src/proc_net_rpc_nfsd.c
+++ b/src/proc_net_rpc_nfsd.c
@@ -196,7 +196,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 
 		if(do_rc == 1 && strcmp(type, "rc") == 0) {
 			if(words < 4) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 4);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 4);
 				continue;
 			}
 
@@ -210,7 +210,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_fh == 1 && strcmp(type, "fh") == 0) {
 			if(words < 6) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 6);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 6);
 				continue;
 			}
 
@@ -226,7 +226,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_io == 1 && strcmp(type, "io") == 0) {
 			if(words < 3) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 3);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 3);
 				continue;
 			}
 
@@ -239,7 +239,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_th == 1 && strcmp(type, "th") == 0) {
 			if(words < 13) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 13);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 13);
 				continue;
 			}
 
@@ -270,7 +270,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_ra == 1 && strcmp(type, "ra") == 0) {
 			if(words < 13) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 13);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 13);
 				continue;
 			}
 
@@ -299,7 +299,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_net == 1 && strcmp(type, "net") == 0) {
 			if(words < 5) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 5);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 5);
 				continue;
 			}
 
@@ -314,7 +314,7 @@ int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
 		}
 		else if(do_rpc == 1 && strcmp(type, "rpc") == 0) {
 			if(words < 6) {
-				error("%s line of /proc/net/rpc/nfsd has %d words, expected %d", type, words, 6);
+				error("%s line of /proc/net/rpc/nfsd has %u words, expected %d", type, words, 6);
 				continue;
 			}
 

--- a/src/proc_net_snmp.c
+++ b/src/proc_net_snmp.c
@@ -60,7 +60,7 @@ int do_proc_net_snmp(int update_every, unsigned long long dt) {
 
 			words = procfile_linewords(ff, l);
 			if(words < 20) {
-				error("Cannot read /proc/net/snmp Ip line. Expected 20 params, read %d.", words);
+				error("Cannot read /proc/net/snmp Ip line. Expected 20 params, read %u.", words);
 				continue;
 			}
 
@@ -193,7 +193,7 @@ int do_proc_net_snmp(int update_every, unsigned long long dt) {
 
 			words = procfile_linewords(ff, l);
 			if(words < 15) {
-				error("Cannot read /proc/net/snmp Tcp line. Expected 15 params, read %d.", words);
+				error("Cannot read /proc/net/snmp Tcp line. Expected 15 params, read %u.", words);
 				continue;
 			}
 
@@ -306,7 +306,7 @@ int do_proc_net_snmp(int update_every, unsigned long long dt) {
 
 			words = procfile_linewords(ff, l);
 			if(words < 7) {
-				error("Cannot read /proc/net/snmp Udp line. Expected 7 params, read %d.", words);
+				error("Cannot read /proc/net/snmp Udp line. Expected 7 params, read %u.", words);
 				continue;
 			}
 

--- a/src/proc_net_snmp6.c
+++ b/src/proc_net_snmp6.c
@@ -361,7 +361,7 @@ int do_proc_net_snmp6(int update_every, unsigned long long dt) {
 	for(l = 0; l < lines ;l++) {
 		words = procfile_linewords(ff, l);
 		if(words < 2) {
-			if(words) error("Cannot read /proc/net/snmp6 line %d. Expected 2 params, read %d.", l, words);
+			if(words) error("Cannot read /proc/net/snmp6 line %u. Expected 2 params, read %u.", l, words);
 			continue;
 		}
 

--- a/src/proc_net_stat_conntrack.c
+++ b/src/proc_net_stat_conntrack.c
@@ -48,7 +48,7 @@ int do_proc_net_stat_conntrack(int update_every, unsigned long long dt) {
 	for(l = 1; l < lines ;l++) {
 		words = procfile_linewords(ff, l);
 		if(words < 17) {
-			if(words) error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %d.", words);
+			if(words) error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %u.", words);
 			continue;
 		}
 

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -48,7 +48,7 @@ int do_proc_stat(int update_every, unsigned long long dt) {
 		if(strncmp(procfile_lineword(ff, l, 0), "cpu", 3) == 0) {
 			words = procfile_linewords(ff, l);
 			if(words < 9) {
-				error("Cannot read /proc/stat cpu line. Expected 9 params, read %d.", words);
+				error("Cannot read /proc/stat cpu line. Expected 9 params, read %u.", words);
 				continue;
 			}
 

--- a/src/proc_vmstat.c
+++ b/src/proc_vmstat.c
@@ -321,7 +321,7 @@ int do_proc_vmstat(int update_every, unsigned long long dt) {
 	for(l = 0; l < lines ;l++) {
 		words = procfile_linewords(ff, l);
 		if(words < 2) {
-			if(words) error("Cannot read /proc/vmstat line %d. Expected 2 params, read %d.", l, words);
+			if(words) error("Cannot read /proc/vmstat line %d. Expected 2 params, read %u.", l, words);
 			continue;
 		}
 

--- a/src/proc_vmstat.c
+++ b/src/proc_vmstat.c
@@ -321,7 +321,7 @@ int do_proc_vmstat(int update_every, unsigned long long dt) {
 	for(l = 0; l < lines ;l++) {
 		words = procfile_linewords(ff, l);
 		if(words < 2) {
-			if(words) error("Cannot read /proc/vmstat line %d. Expected 2 params, read %u.", l, words);
+			if(words) error("Cannot read /proc/vmstat line %u. Expected 2 params, read %u.", l, words);
 			continue;
 		}
 

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -325,7 +325,7 @@ procfile *procfile_readall(procfile *ff) {
 			ff->size += PROCFILE_INCREMENT_BUFFER;
 		}
 
-		debug(D_PROCFILE, "Reading file '%s', from position %ld with length %ld", ff->filename, s, ff->size - s);
+		debug(D_PROCFILE, "Reading file '%s', from position %ld with length %lu", ff->filename, s, ff->size - s);
 		r = read(ff->fd, &ff->data[s], ff->size - s);
 		if(unlikely(r == -1)) {
 			if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot read from file '%s'", ff->filename);
@@ -496,16 +496,16 @@ void procfile_print(procfile *ff) {
 	uint32_t words, w;
 	char *s;
 
-	debug(D_PROCFILE, "File '%s' with %d lines and %d words", ff->filename, ff->lines->len, ff->words->len);
+	debug(D_PROCFILE, "File '%s' with %u lines and %u words", ff->filename, ff->lines->len, ff->words->len);
 
 	for(l = 0; likely(l < lines) ;l++) {
 		words = procfile_linewords(ff, l);
 
-		debug(D_PROCFILE, "	line %d starts at word %d and has %d words", l, ff->lines->lines[l].first, ff->lines->lines[l].words);
+		debug(D_PROCFILE, "	line %u starts at word %u and has %u words", l, ff->lines->lines[l].first, ff->lines->lines[l].words);
 
 		for(w = 0; likely(w < words) ;w++) {
 			s = procfile_lineword(ff, l, w);
-			debug(D_PROCFILE, "		[%d.%d] '%s'", l, w, s);
+			debug(D_PROCFILE, "		[%u.%u] '%s'", l, w, s);
 		}
 	}
 }

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -876,7 +876,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
 	// check if we will re-write the entire data set
 	if(unlikely(usecdiff(&st->last_collected_time, &st->last_updated) > st->update_every * st->entries * 1000000ULL)) {
-		info("%s: too old data (last updated at %zu.%zu, last collected at %zu.%zu). Reseting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
+		info("%s: too old data (last updated at %ld.%ld, last collected at %ld.%ld). Reseting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
 		rrdset_reset(st);
 
 		st->usec_since_last_update = st->update_every * 1000000ULL;

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -32,8 +32,8 @@ void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb)
 		"\t\t\t\"data_url\": \"/api/v1/data?chart=%s\",\n"
 		"\t\t\t\"chart_type\": \"%s\",\n"
 		"\t\t\t\"duration\": %ld,\n"
-		"\t\t\t\"first_entry\": %lu,\n"
-		"\t\t\t\"last_entry\": %lu,\n"
+		"\t\t\t\"first_entry\": %ld,\n"
+		"\t\t\t\"last_entry\": %ld,\n"
 		"\t\t\t\"update_every\": %d,\n"
 		"\t\t\t\"dimensions\": {\n"
 		, st->id
@@ -132,12 +132,12 @@ unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb)
 		"\t\t\t\"units\": \"%s\",\n"
 		"\t\t\t\"url\": \"/data/%s/%s\",\n"
 		"\t\t\t\"chart_type\": \"%s\",\n"
-		"\t\t\t\"counter\": %ld,\n"
+		"\t\t\t\"counter\": %lu,\n"
 		"\t\t\t\"entries\": %ld,\n"
-		"\t\t\t\"first_entry_t\": %lu,\n"
-		"\t\t\t\"last_entry\": %ld,\n"
-		"\t\t\t\"last_entry_t\": %lu,\n"
-		"\t\t\t\"last_entry_secs_ago\": %lu,\n"
+		"\t\t\t\"first_entry_t\": %ld,\n"
+		"\t\t\t\"last_entry\": %lu,\n"
+		"\t\t\t\"last_entry_t\": %ld,\n"
+		"\t\t\t\"last_entry_secs_ago\": %ld,\n"
 		"\t\t\t\"update_every\": %d,\n"
 		"\t\t\t\"isdetail\": %d,\n"
 		"\t\t\t\"usec_since_last_update\": %llu,\n"
@@ -184,7 +184,7 @@ unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb)
 			"\t\t\t\t\t\"algorithm\": \"%s\",\n"
 			"\t\t\t\t\t\"multiplier\": %ld,\n"
 			"\t\t\t\t\t\"divisor\": %ld,\n"
-			"\t\t\t\t\t\"last_entry_t\": %lu,\n"
+			"\t\t\t\t\t\"last_entry_t\": %ld,\n"
 			"\t\t\t\t\t\"collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
 			"\t\t\t\t\t\"calculated_value\": " CALCULATED_NUMBER_FORMAT ",\n"
 			"\t\t\t\t\t\"last_collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
@@ -1429,7 +1429,7 @@ RRDR *rrd2rrdr(RRDSET *st, long points, long long after, long long before, int g
 		if(unlikely(slot < 0)) slot = st->entries - 1;
 		if(unlikely(slot == stop_at_slot)) stop_now = counter;
 
-		if(unlikely(debug)) debug(D_RRD_STATS, "ROW %s slot: %ld, entries_counter: %ld, group_count: %ld, added: %ld, now: %lu, %s %s"
+		if(unlikely(debug)) debug(D_RRD_STATS, "ROW %s slot: %ld, entries_counter: %ld, group_count: %ld, added: %ld, now: %ld, %s %s"
 				, st->id
 				, slot
 				, counter
@@ -1822,7 +1822,7 @@ time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long points, long group,
 	// checks for debugging
 
 	if(st->debug) {
-		debug(D_RRD_STATS, "%s first_entry_t = %lu, last_entry_t = %lu, duration = %lu, after = %lu, before = %lu, duration = %lu, entries_to_show = %lu, group = %lu"
+		debug(D_RRD_STATS, "%s first_entry_t = %ld, last_entry_t = %ld, duration = %ld, after = %ld, before = %ld, duration = %ld, entries_to_show = %ld, group = %ld"
 			, st->id
 			, rrdset_first_entry_t(st)
 			, rrdset_last_entry_t(st)
@@ -1835,10 +1835,10 @@ time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long points, long group,
 			);
 
 		if(before < after)
-			debug(D_RRD_STATS, "WARNING: %s The newest value in the database (%lu) is earlier than the oldest (%lu)", st->name, before, after);
+			debug(D_RRD_STATS, "WARNING: %s The newest value in the database (%ld) is earlier than the oldest (%ld)", st->name, before, after);
 
 		if((before - after) > st->entries * st->update_every)
-			debug(D_RRD_STATS, "WARNING: %s The time difference between the oldest and the newest entries (%lu) is higher than the capacity of the database (%lu)", st->name, before - after, st->entries * st->update_every);
+			debug(D_RRD_STATS, "WARNING: %s The time difference between the oldest and the newest entries (%ld) is higher than the capacity of the database (%ld)", st->name, before - after, st->entries * st->update_every);
 	}
 
 
@@ -1934,7 +1934,7 @@ time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long points, long group,
 
 			int print_this = 0;
 
-			if(st->debug) debug(D_RRD_STATS, "%s t = %ld, count = %ld, group_count = %ld, printed = %ld, now = %lu, %s %s"
+			if(st->debug) debug(D_RRD_STATS, "%s t = %ld, count = %ld, group_count = %ld, printed = %ld, now = %ld, %s %s"
 					, st->id
 					, t
 					, count + 1
@@ -2070,7 +2070,7 @@ time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long points, long group,
 
 	} // max_loop
 
-	debug(D_RRD_STATS, "RRD_STATS_JSON: %s total %ld bytes", st->name, wb->len);
+	debug(D_RRD_STATS, "RRD_STATS_JSON: %s total %lu bytes", st->name, wb->len);
 
 	pthread_rwlock_unlock(&st->rwlock);
 	return last_timestamp;

--- a/src/storage_number.h
+++ b/src/storage_number.h
@@ -16,9 +16,8 @@ typedef long double collected_number;
 #define COLLECTED_NUMBER_FORMAT "%0.7Lf"
 */
 
-typedef int32_t storage_number;
-typedef uint32_t ustorage_number;
-#define STORAGE_NUMBER_FORMAT "%d"
+typedef uint32_t storage_number;
+#define STORAGE_NUMBER_FORMAT "%u"
 
 #define SN_NOT_EXISTS		(0x0 << 24)
 #define SN_EXISTS			(0x1 << 24)

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -252,7 +252,7 @@ void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 		if(!ff) return;
 
 		if(procfile_lines(ff) < 1) {
-			error("File '%s' should have 1+ lines but has %d.", ca->filename, procfile_lines(ff));
+			error("File '%s' should have 1+ lines but has %u.", ca->filename, procfile_lines(ff));
 			return;
 		}
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1018,14 +1018,14 @@ void update_cgroup_charts(int update_every) {
 				st = rrdset_create(type, "cpu_per_core", NULL, "cpu", "cgroup.cpu_per_core", title, "%", 40100, update_every, RRDSET_TYPE_STACKED);
 
 				for(i = 0; i < cg->cpuacct_usage.cpus ;i++) {
-					snprintfz(id, CHART_TITLE_MAX, "cpu%d", i);
+					snprintfz(id, CHART_TITLE_MAX, "cpu%u", i);
 					rrddim_add(st, id, NULL, 100, 1000000, RRDDIM_INCREMENTAL);
 				}
 			}
 			else rrdset_next(st);
 
 			for(i = 0; i < cg->cpuacct_usage.cpus ;i++) {
-				snprintfz(id, CHART_TITLE_MAX, "cpu%d", i);
+				snprintfz(id, CHART_TITLE_MAX, "cpu%u", i);
 				rrddim_set(st, id, cg->cpuacct_usage.cpu_percpu[i]);
 			}
 			rrdset_done(st);

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -760,7 +760,7 @@ int unit_test(long delay, long shift)
 
 	unsigned long oincrement = increment;
 	increment = increment * st->update_every * 1000000 / delay;
-	fprintf(stderr, "\n\nORIGINAL INCREMENT: %lu, INCREMENT %lu, DELAY %lu, SHIFT %lu\n", oincrement * 10, increment * 10, delay, shift);
+	fprintf(stderr, "\n\nORIGINAL INCREMENT: %lu, INCREMENT %ld, DELAY %ld, SHIFT %ld\n", oincrement * 10, increment * 10, delay, shift);
 
 	int ret = 0;
 	storage_number sn;

--- a/src/web_buffer.c
+++ b/src/web_buffer.c
@@ -29,7 +29,7 @@ static inline void buffer_overflow_init(BUFFER *b)
 static inline void _buffer_overflow_check(BUFFER *b, const char *file, const char *function, const unsigned long line)
 {
 	if(b->len > b->size) {
-		error("BUFFER: length %ld is above size %ld, at line %lu, at function %s() of file '%s'.", b->len, b->size, line, function, file);
+		error("BUFFER: length %zu is above size %zu, at line %lu, at function %s() of file '%s'.", b->len, b->size, line, function, file);
 		b->len = b->size;
 	}
 
@@ -93,7 +93,7 @@ void buffer_strcat(BUFFER *wb, const char *txt)
 	buffer_overflow_check(wb);
 
 	if(*txt) {
-		debug(D_WEB_BUFFER, "strcat(): increasing web_buffer at position %ld, size = %ld\n", wb->len, wb->size);
+		debug(D_WEB_BUFFER, "strcat(): increasing web_buffer at position %zu, size = %zu\n", wb->len, wb->size);
 		len = strlen(txt);
 		buffer_increase(wb, len);
 		buffer_strcat(wb, txt);
@@ -160,7 +160,7 @@ void buffer_sprintf(BUFFER *wb, const char *fmt, ...)
 		// if it does.
 		buffer_overflow_check(wb);
 
-		debug(D_WEB_BUFFER, "web_buffer_sprintf(): increasing web_buffer at position %ld, size = %ld\n", wb->len, wb->size);
+		debug(D_WEB_BUFFER, "web_buffer_sprintf(): increasing web_buffer at position %zu, size = %zu\n", wb->len, wb->size);
 		buffer_need_bytes(wb, len + WEB_DATA_LENGTH_INCREASE_STEP);
 
 		va_start(args, fmt);


### PR DESCRIPTION
fixes #387 

To check the format strings for correct signness, use gcc 5+ and compile with this:

```sh
 CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1" ./netdata-installer.sh
```
