### PR TITLE
fix 562 (use /usr/bin/env)

### DIFF
--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3 -u
-
 NAME = "mysql.chart.py"
 from sys import stderr
 try:


### PR DESCRIPTION
Adding PYTHONUNBUFFERED=1 to environment enabled using `env` in python shebang.

Tested.