### PR TITLE
fix javascript error and create /var/lib/netdata

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,7 @@ fi
 AC_DEFINE_UNQUOTED([NETDATA_USER], ["${with_user}"], [use this user to drop privileged])
 
 AC_SUBST([varlibdir], ["\$(localstatedir)/lib/netdata"])
+AC_SUBST([registrydir], ["\$(localstatedir)/lib/netdata/registry"])
 AC_SUBST([cachedir], ["\$(localstatedir)/cache/netdata"])
 AC_SUBST([chartsdir], ["\$(libexecdir)/netdata/charts.d"])
 AC_SUBST([nodedir], ["\$(libexecdir)/netdata/node.d"])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,8 @@ AM_CFLAGS = \
 
 sbin_PROGRAMS = netdata
 dist_cache_DATA = .keep
+dist_varlib_DATA = .keep
+dist_registry_DATA = .keep
 dist_log_DATA = .keep
 plugins_PROGRAMS = apps.plugin
 

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -5649,7 +5649,7 @@
 						NETDATA.registry.access(max_redirects - 1, callback);
 					}
 					else {
-						if(typeof data.person_guid === 'string')
+						if(data !== null && typeof data.person_guid === 'string')
 							NETDATA.registry.person_guid = data.person_guid;
 
 						if(typeof callback === 'function')
@@ -5688,7 +5688,7 @@
 						callback(null);
 				});
 		},
-		
+
 		switch: function(new_person_guid, callback) {
 			// impersonate
 			$.ajax({


### PR DESCRIPTION
1. prevent a javascript error when the registry is not accessible, #561 
2. `make install` creates the directories `/var/lib/netdata` and `/var/lib/netdata/registry`, fixes #495 