### PR TITLE
More object-oriented python jobs

### DIFF
--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -1,11 +1,5 @@
 # This is the configuration for python.d.plugin
 
-# It sets custom configuration directory for python modules
-# plugins_config_dir=
-
-# This is a directory with python modules
-# plugins_dir=
-
 # By default python.d.plugin enables all modules stored in python.d
 # Modules can be disabled with setting "module_name = no"
 example: no

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -8,5 +8,5 @@
 
 # By default python.d.plugin enables all modules stored in python.d
 # Modules can be disabled with setting "module_name = no"
-example=no
-mysql=no
+example: no
+mysql: no

--- a/conf.d/python.d/example.conf
+++ b/conf.d/python.d/example.conf
@@ -1,1 +1,1 @@
-update_every=2
+update_every : 2

--- a/conf.d/python.d/mysql.conf
+++ b/conf.d/python.d/mysql.conf
@@ -1,21 +1,18 @@
 # Example configuration of mysql.chart.py
-# Indentation is important
+# YAML format
 
-#update_every=5
+update_every: 5
 
-#config=[
-#    {
-#        'name'     : 'local'
-#        'my.cnf'   : '/etc/mysql/my.cnf'
-#    },{
-#        'name'     : 'local_s',
-#        'user'     : 'root',
-#        'password' : 'blablablabla',
-#        'socket'   : '/var/run/mysqld/mysqld.sock'
-#    },{
-#        'name'     : 'remote',
-#        'user'     : 'admin',
-#        'password' : 'bla',
-#        'host'     : 'example.org',
-#        'port'     : '3306'
-#    }]
+local: 
+  'my.cnf' : '/etc/mysql/my.cnf'
+
+local_s:
+  user     : 'root'
+  password : 'blablablabla'
+  socket   : '/var/run/mysqld/mysqld.sock'
+
+remote:
+  user     : 'admin'
+  password : 'bla'
+  host     : 'example.org'
+  port     : '3306'

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -5,12 +5,22 @@ import sys
 import time
 try:
     assert sys.version_info >= (3,1)
-    import configparser
     import importlib.machinery
 except AssertionError:
-    sys.stderr.write('Not supported python version. Needed python >= 3.1\n')
+    sys.stderr.write('python.d.plugin: Not supported python version. Needed python >= 3.1\n')
     sys.stdout.write('DISABLE\n')
     sys.exit(1)
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write('python.d.plugin: Cannot find yaml library\n')
+    sys.stdout.write('DISABLE\n')
+    sys.exit(1)
+
+MODULE_EXTENSION = ".chart.py"
+BASE_CONFIG = {'update_every' : 10,
+               'priority': 12345,
+               'retries' : 0}
 
 
 class PythonCharts(object):
@@ -22,54 +32,65 @@ class PythonCharts(object):
                  modules_configs='../conf.d/',
                  modules_disabled=[]):
         self.first_run = True
-        self.default_priority = 90000
         # set configuration directory
         self.configs = modules_configs
 
         # load modules
-        modules = self._load_modules(modules_path,modules)
-        
-        # check if loaded modules are on disabled modules list
-        self.modules = [ m for m in modules if m.__name__ not in modules_disabled ]
-        
+        loaded_modules = self._load_modules(modules_path,modules, modules_disabled)
+
         # load configuration files
-        self._load_configs()
+        configured_modules = self._load_configs(loaded_modules)
 
-        # set timetable dict (last execution, next execution and frequency)
-        # set priorities
-        self.timetable = {}
-        freq = 1
-        for m in self.modules:
-            try:
-                m.priority = int(m.priority)
-            except (AttributeError,ValueError):
-                m.priority = self.default_priority
-             
-            if interval is None:
+        # good economy and prosperity:
+        self.jobs = self._create_jobs(configured_modules)
+        if DEBUG_FLAG and interval is not None:
+            for job in self.jobs:
+                job._create_timetable(interval)
+
+
+    def _create_jobs(self,modules):
+    # module store a definition of Service class
+    # module store configuration in module.config
+    # configs are list of dicts or a dict
+    # one dict is one service
+    # iterate over list of modules and inside one loop iterate over configs
+        jobs = []
+        for module in modules:
+            for name in module.config:
+                # register a new job
+                conf = module.config[name]
                 try:
-                    freq = int(m.update_every)
-                except (AttributeError, ValueError):
-                    freq = 1
-            
-            now = time.time()
-            self.timetable[m.__name__] = {'last' : now,
-                                          'next' : now - (now % freq) + freq,
-                                          'freq' : freq}
+                    job = module.Service(configuration=conf, name=name)
+                except Exception as e:
+                    debug(module.__name__ +
+                          ": Couldn't start job named " +
+                          str(name) + 
+                          ": " +
+                          str(e))
+                    return None
+                else:
+                    # set execution_name (needed to plot run time graphs)
+                    job.execution_name = module.__name__
+                    if name is not None:
+                        job.execution_name += "_" + name
+                jobs.append(job)
+        
+        return [j for j in jobs if j is not None]
 
-    def _import_plugin(self, path, name=None):
+    def _import_module(self, path, name=None):
     # try to import module using only its path
         if name is None:
             name = path.split('/')[-1]
-            if name[-9:] != ".chart.py":
+            if name[-len(MODULE_EXTENSION):] != MODULE_EXTENSION:
                 return None
-            name = name[:-9]
+            name = name[:-len(MODULE_EXTENSION)]
         try:
             return importlib.machinery.SourceFileLoader(name, path).load_module()
         except Exception as e:
             debug(str(e))
             return None
 
-    def _load_modules(self, path, modules):
+    def _load_modules(self, path, modules, disabled):
         # check if plugin directory exists
         if not os.path.isdir(path):
             debug("cannot find charts directory ", path)
@@ -80,128 +101,170 @@ class PythonCharts(object):
         loaded = []
         if len(modules) > 0:
             for m in modules:
-                mod = self._import_plugin(path + m + ".chart.py")
+                if m in disabled:
+                    continue
+                mod = self._import_module(path + m + MODULE_EXTENSION)
                 if mod is not None:
                     loaded.append(mod)
         else:
             # scan directory specified in path and load all modules from there
             names = os.listdir(path)
             for mod in names:
-                m = self._import_plugin(path + mod)
+                if mod.strip(MODULE_EXTENSION) in disabled:
+                    debug("disabling:",mod.strip(MODULE_EXTENSION))
+                    continue
+                m = self._import_module(path + mod)
                 if m is not None:
                     debug("loading chart: '" + path + mod + "'")
                     loaded.append(m)
         return loaded
 
-    def _load_configs(self):
-    # function modifies every loaded module in self.modules
-        for m in self.modules:
-            configfile = self.configs + m.__name__ + ".conf"
+    def _load_configs(self,modules):
+    # function loads configuration files to modules
+        for mod in modules:
+            configfile = self.configs + mod.__name__ + ".conf"
             if os.path.isfile(configfile):
                 debug("loading chart options: '" + configfile + "'")
-                for k, v in read_config(configfile).items():
-                    try:
-                        setattr(m, k, v)
-                    except AttributeError:
-                        self._disable_module(m,"misbehaving having bad configuration")
+                try:
+                    setattr(mod,
+                            'config',
+                            self._parse_config(mod,read_config(configfile)))
+                except Exception as e:
+                    debug("something went wrong while loading configuration",e)
             else:
-                debug(m.__name__ +
+                debug(mod.__name__ +
                       ": configuration file '" +
                       configfile +
                       "' not found. Using defaults.")
+        return modules
 
-    def _disable_module(self, mod, reason=None):
-    # modifies self.modules
-        self.modules.remove(mod)
-        del self.timetable[mod.__name__]
+    def _parse_config(self,module,config):
+        # get default values
+        defaults = {}
+        for key in BASE_CONFIG:
+            try:
+                # get defaults from module config
+                defaults[key] = int(config.pop(key))
+            except (KeyError,ValueError):
+                try:
+                    # get defaults from module source code
+                    defaults[key] = getattr(module, key)
+                except (KeyError,ValueError):
+                    # if above failed, get defaults from global dict
+                    defaults[key] = BASE_CONFIG[key]
+      
+        # check if there are dict in config dict
+        many_jobs = False
+        for name in config:
+            if type(config[name]) is dict:
+                many_jobs = True
+                break
+        
+        # assign variables needed by supervisor to every job configuration
+        if many_jobs:
+            for name in config:
+                for key in defaults:
+                    if key not in config[name]:
+                        config[name][key] = defaults[key]
+        # if only one job is needed, values doesn't have to be in dict (in YAML)
+        else:
+            config = {None: config.copy()}
+            config[None].update(defaults)
+            
+        # return dictionary of jobs where every job has BASE_CONFIG variables
+        return config
+
+    def _stop(self, job, reason=None): #FIXME test if Service has __name__
+    # modifies self.jobs
+        self.jobs.remove(job)
         if reason is None:
             return
         elif reason[:3] == "no ":
             debug("chart '" +
-                  mod.__name__,
+                  job.execution_name,
                   "' does not seem to have " +
                   reason[3:] +
                   "() function. Disabling it.")
         elif reason[:7] == "failed ":
             debug("chart '" +
-                  mod.__name__ + "' " +
+                  job.execution_name + "' " +
                   reason[7:] +
                   "() function reports failure.")
         elif reason[:13] == "configuration":
-            debug(mod.__name__,
+            debug(job.execution_name,
                   "configuration file '" +
                   self.configs +
-                  mod.__name__ +
+                  job.execution_name +
                   ".conf' not found. Using defaults.")
         elif reason[:11] == "misbehaving":
-            debug(mod.__name__, "is "+reason)
+            debug(job.execution_name, "is "+reason)
 
     def check(self):
-    # try to execute check() on every loaded module
-        for mod in self.modules:
+    # try to execute check() on every job
+        for job in self.jobs:
             try:
-                if not mod.check():
-                    self._disable_module(mod, "failed check")
+                if not job.check():
+                    self._stop(job, "failed check")
             except AttributeError:
-                self._disable_module(mod, "no check")
+                self._stop(job, "no check")
             except (UnboundLocalError, Exception) as e:
-                self._disable_module(mod, "misbehaving. Reason: " + str(e))
+                self._stop(job, "misbehaving. Reason: " + str(e))
 
     def create(self):
-    # try to execute create() on every loaded module
-        for mod in self.modules:
+    # try to execute create() on every job
+        for job in self.jobs:
             try:
-                if not mod.create():
-                    self._disable_module(mod, "failed create")
+                if not job.create():
+                    self._stop(job, "failed create")
                 else:
-                    chart = mod.__name__
+                    chart = job.execution_name
                     sys.stdout.write(
                         "CHART netdata.plugin_pythond_" +
                         chart +
                         " '' 'Execution time for " +
                         chart +
                         " plugin' 'milliseconds / run' python.d netdata.plugin_python area 145000 " +
-                        str(self.timetable[mod.__name__]['freq']) +
+                        str(job.timetable['freq']) +
                         '\n')
                     sys.stdout.write("DIMENSION run_time 'run time' absolute 1 1\n\n")
                     sys.stdout.flush()
             except AttributeError:
-                self._disable_module(mod, "no create")
+                self._stop(job, "no create")
             except (UnboundLocalError, Exception) as e:
-                self._disable_module(mod, "misbehaving. Reason: " + str(e))
+                self._stop(job, "misbehaving. Reason: " + str(e))
 
-    def _update_module(self, mod):
-    # try to execute update() on every module and draw run time graph 
+    def _update_job(self, job):
+    # try to execute update() on every job and draw run time graph 
         t_start = time.time()
-        # check if it is time to execute module update() function
-        if self.timetable[mod.__name__]['next'] > t_start:
+        # check if it is time to execute job update() function
+        if job.timetable['next'] > t_start:
             return
         try:
             if self.first_run:
                 since_last = 0
             else:
-                since_last = int((t_start - self.timetable[mod.__name__]['last']) * 1000000)
-            if not mod.update(since_last):
-                self._disable_module(mod, "update failed")
+                since_last = int((t_start - job.timetable['last']) * 1000000)
+            if not job.update(since_last):
+                self._stop(job, "update failed")
                 return
         except AttributeError:
-            self._disable_module(mod, "no update")
+            self._stop(job, "no update")
             return
         except (UnboundLocalError, Exception) as e:
-            self._disable_module(mod, "misbehaving. Reason: " + str(e))
+            self._stop(job, "misbehaving. Reason: " + str(e))
             return
         t_end = time.time()
-        self.timetable[mod.__name__]['next'] = t_end - (t_end % self.timetable[mod.__name__]['freq']) + self.timetable[mod.__name__]['freq']
+        job.timetable['next'] = t_end - (t_end % job.timetable['freq']) + job.timetable['freq']
         # draw performance graph
         if self.first_run:
             dt = 0
         else:
-            dt = int((t_end - self.timetable[mod.__name__]['last']) * 1000000)
-        sys.stdout.write("BEGIN netdata.plugin_pythond_"+mod.__name__+" "+str(since_last)+'\n')
+            dt = int((t_end - job.timetable['last']) * 1000000)
+        sys.stdout.write("BEGIN netdata.plugin_pythond_"+job.execution_name+" "+str(since_last)+'\n')
         sys.stdout.write("SET run_time = " + str(int((t_end - t_start) * 1000)) + '\n')
         sys.stdout.write("END\n")
         sys.stdout.flush()
-        self.timetable[mod.__name__]['last'] = t_start
+        job.timetable['last'] = t_start
         self.first_run = False
 
     def update(self):
@@ -210,10 +273,10 @@ class PythonCharts(object):
         while True:
             t_begin = time.time()
             next_runs = []
-            for mod in self.modules:
-                self._update_module(mod)
+            for job in self.jobs:
+                self._update_job(job)
                 try:
-                    next_runs.append(self.timetable[mod.__name__]['next'])
+                    next_runs.append(job.timetable['next'])
                 except KeyError:
                     pass
             if len(next_runs) == 0:
@@ -224,20 +287,16 @@ class PythonCharts(object):
 
 
 def read_config(path):
-    config = configparser.ConfigParser()
-    config_str = ""
     try:
-        with open(path, 'r', encoding="utf_8") as f:
-            config_str = '[config]\n' + f.read()
+        with open(path, 'r') as stream:
+            config = yaml.load(stream)
     except IsADirectoryError:
         debug(str(path), "is a directory")
-        return
-    try:
-        config.read_string(config_str)
-    except configparser.ParsingError as e:
-        debug("Malformed configuration file: "+str(e))
-        return
-    return dict(config.items('config'))
+        return None
+    except yaml.YAMLError as e:
+        debug(str(path), "is malformed:", e)
+        return None
+    return config
 
 
 def debug(*args):
@@ -301,7 +360,7 @@ def run():
     try:
         conf = read_config(configfile)
         try:
-            if str(conf['enable']) == "no":
+            if str(conf['enable']) is False:
                 debug("disabled in configuration file")
                 sys.stdout.write("DISABLE\n")
                 sys.exit(1)
@@ -309,24 +368,24 @@ def run():
             pass
         try:
             modules_conf = conf['plugins_config_dir']
-        except (KeyError):
+        except KeyError:
             modules_conf = config_dir + "python.d/"  # default configuration directory
         try:
             modules_dir = conf['plugins_dir']
-        except (KeyError):
+        except KeyError:
             modules_dir = main_dir.replace("plugins.d", "python.d")
         try:
-            interval = int(conf['interval'])
-        except (KeyError, TypeError):
+            interval = conf['interval']
+        except KeyError:
             pass  # use default interval from NETDATA_UPDATE_EVERY
         try:
-            DEBUG_FLAG = bool(conf['debug'])
-        except (KeyError, TypeError):
+            DEBUG_FLAG = conf['debug']
+        except KeyError:
             pass
         for k, v in conf.items():
             if k in ("plugins_config_dir", "plugins_dir", "interval", "debug"):
                 continue
-            if v == 'no':
+            if v is False:
                 disabled.append(k)
     except FileNotFoundError:
         modules_conf = config_dir

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -335,7 +335,8 @@ class PythonCharts(object):
         """
         Tries to execute update() on specified job.
         This cannot fail thus it is catching every exception.
-        If job.update() returns False, number of retries is decremented. If there are no more retries, job is stopped.
+        If job.update() returns False, number of retries_left is decremented.
+        If there are no more retries, job is stopped.
         Job is also stopped if it throws an exception.
         This is also updating job run time chart.
         :param job: object
@@ -350,11 +351,10 @@ class PythonCharts(object):
             else:
                 since_last = int((t_start - job.timetable['last']) * 1000000)
             if not job.update(since_last):
-                if job.retries <= 0:
+                if job.retries_left <= 0:
                     self._stop(job, "update failed")
-                else:
-                    job.retries -= 1
-                    job.timetable['next'] += job.timetable['freq']
+                job.retries_left -= 1
+                job.timetable['next'] += job.timetable['freq']
                 return
         except AttributeError:
             self._stop(job, "no update")
@@ -370,6 +370,7 @@ class PythonCharts(object):
         sys.stdout.write("END\n")
         sys.stdout.flush()
         job.timetable['last'] = t_start
+        job.retries_left = job.retries
         self.first_run = False
 
     def update(self):

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import sys
@@ -140,7 +140,7 @@ class PythonCharts(object):
                     continue
                 m = self._import_module(path + mod)
                 if m is not None:
-                    debug("loading chart: '" + path + mod + "'")
+                    debug("loading module: '" + path + mod + "'")
                     loaded.append(m)
         return loaded
 
@@ -155,7 +155,7 @@ class PythonCharts(object):
         for mod in modules:
             configfile = self.configs + mod.__name__ + ".conf"
             if os.path.isfile(configfile):
-                debug("loading chart options: '" + configfile + "'")
+                debug("loading module configuration: '" + configfile + "'")
                 try:
                     setattr(mod,
                             'config',
@@ -248,10 +248,10 @@ class PythonCharts(object):
                           str(e))
                     return None
                 else:
-                    # set execution_name (needed to plot run time graphs)
-                    job.execution_name = module.__name__
+                    # set chart_name (needed to plot run time graphs)
+                    job.chart_name = module.__name__
                     if name is not None:
-                        job.execution_name += "_" + name
+                        job.chart_name += "_" + name
                 jobs.append(job)
 
         return [j for j in jobs if j is not None]
@@ -263,28 +263,31 @@ class PythonCharts(object):
         :param job: object
         :param reason: str
         """
+        prefix = ""
+        if job.name is not None:
+            prefix = "'" + job.name + "' in "
+
+        prefix += "'" + job.__module__ + "' "
         self.jobs.remove(job)
         if reason is None:
             return
         elif reason[:3] == "no ":
-            debug("chart '" +
-                  job.execution_name,
-                  "' does not seem to have " +
+            debug(prefix +
+                  "does not seem to have " +
                   reason[3:] +
                   "() function. Disabling it.")
         elif reason[:7] == "failed ":
-            debug("chart '" +
-                  job.execution_name + "' " +
+            debug(prefix +
                   reason[7:] +
                   "() function reports failure.")
         elif reason[:13] == "configuration":
-            debug(job.execution_name,
+            debug(prefix +
                   "configuration file '" +
                   self.configs +
-                  job.execution_name +
+                  job.__module__ +
                   ".conf' not found. Using defaults.")
         elif reason[:11] == "misbehaving":
-            debug(job.execution_name, "is " + reason)
+            debug(prefix + "is " + reason)
 
     def check(self):
         """
@@ -313,7 +316,7 @@ class PythonCharts(object):
                 if not job.create():
                     self._stop(job, "failed create")
                 else:
-                    chart = job.execution_name
+                    chart = job.chart_name
                     sys.stdout.write(
                         "CHART netdata.plugin_pythond_" +
                         chart +
@@ -363,7 +366,7 @@ class PythonCharts(object):
         t_end = time.time()
         job.timetable['next'] = t_end - (t_end % job.timetable['freq']) + job.timetable['freq']
         # draw performance graph
-        sys.stdout.write("BEGIN netdata.plugin_pythond_" + job.execution_name + " " + str(since_last) + '\n')
+        sys.stdout.write("BEGIN netdata.plugin_pythond_" + job.chart_name + " " + str(since_last) + '\n')
         sys.stdout.write("SET run_time = " + str(int((t_end - t_start) * 1000)) + '\n')
         sys.stdout.write("END\n")
         sys.stdout.flush()

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -10,12 +10,13 @@ import time
 # setup environment
 # https://github.com/firehol/netdata/wiki/External-Plugins#environment-variables
 MODULES_DIR = os.getenv('NETDATA_PLUGINS_DIR',
-                        os.path.abspath(__file__).strip("python.d.plugin.py").replace("plugins.d", "python.d"))
+                        os.path.abspath(__file__).strip("python.d.plugin.py").replace("plugins.d", ""))
 CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', "/etc/netdata/")
 INTERVAL = os.getenv('NETDATA_UPDATE_EVERY', None)
 # directories should end with '/'
 if MODULES_DIR[-1] != "/":
     MODULES_DIR += "/"
+MODULES_DIR += "python.d/"
 if CONFIG_DIR[-1] != "/":
     CONFIG_DIR += "/"
 sys.path.append(MODULES_DIR + "python_modules")

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -267,7 +267,7 @@ class PythonCharts(object):
         if job.name is not None:
             prefix = "'" + job.name + "' in "
 
-        prefix += "'" + job.__module__ + "' "
+        prefix += "'" + job.__module__ + MODULE_EXTENSION + "' "
         self.jobs.remove(job)
         if reason is None:
             return
@@ -295,10 +295,14 @@ class PythonCharts(object):
         This cannot fail thus it is catching every exception
         If job.check() fails job is stopped
         """
-        for job in self.jobs:
+        i = 0
+        while i < len(self.jobs):
+            job = self.jobs[i]
             try:
                 if not job.check():
                     self._stop(job, "failed check")
+                else:
+                    i += 1
             except AttributeError:
                 self._stop(job, "no check")
             except (UnboundLocalError, Exception) as e:
@@ -311,7 +315,9 @@ class PythonCharts(object):
         If job.create() fails job is stopped.
         This is also creating job run time chart.
         """
-        for job in self.jobs:
+        i = 0
+        while i < len(self.jobs):
+            job = self.jobs[i]
             try:
                 if not job.create():
                     self._stop(job, "failed create")
@@ -327,6 +333,7 @@ class PythonCharts(object):
                         '\n')
                     sys.stdout.write("DIMENSION run_time 'run time' absolute 1 1\n\n")
                     sys.stdout.flush()
+                    i += 1
             except AttributeError:
                 self._stop(job, "no create")
             except (UnboundLocalError, Exception) as e:
@@ -340,12 +347,14 @@ class PythonCharts(object):
         If there are no more retries, job is stopped.
         Job is also stopped if it throws an exception.
         This is also updating job run time chart.
+        Return False if job is stopped
         :param job: object
+        :return: boolean
         """
         t_start = time.time()
         # check if it is time to execute job update() function
         if job.timetable['next'] > t_start:
-            return
+            return True
         try:
             if self.first_run:
                 since_last = 0
@@ -354,15 +363,16 @@ class PythonCharts(object):
             if not job.update(since_last):
                 if job.retries_left <= 0:
                     self._stop(job, "update failed")
+                    return False
                 job.retries_left -= 1
                 job.timetable['next'] += job.timetable['freq']
-                return
+                return True
         except AttributeError:
             self._stop(job, "no update")
-            return
+            return False
         except (UnboundLocalError, Exception) as e:
             self._stop(job, "misbehaving. Reason: " + str(e))
-            return
+            return False
         t_end = time.time()
         job.timetable['next'] = t_end - (t_end % job.timetable['freq']) + job.timetable['freq']
         # draw performance graph
@@ -373,6 +383,7 @@ class PythonCharts(object):
         job.timetable['last'] = t_start
         job.retries_left = job.retries
         self.first_run = False
+        return True
 
     def update(self):
         """
@@ -382,12 +393,15 @@ class PythonCharts(object):
         self.first_run = True
         while True:
             next_runs = []
-            for job in self.jobs:
-                self._update_job(job)
-                try:
-                    next_runs.append(job.timetable['next'])
-                except KeyError:
-                    pass
+            i = 0
+            while i < len(self.jobs):
+                job = self.jobs[i]
+                if self._update_job(job):
+                    try:
+                        next_runs.append(job.timetable['next'])
+                    except KeyError:
+                        pass
+                    i += 1
             if len(next_runs) == 0:
                 debug("No plugins loaded")
                 sys.stdout.write("DISABLE\n")

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -1,8 +1,25 @@
 #!/usr/bin/env python
 
+# Description: netdata python modules supervisor
+# Author: Pawel Krupa (paulfantom)
+
 import os
 import sys
 import time
+
+# setup environment
+# https://github.com/firehol/netdata/wiki/External-Plugins#environment-variables
+MODULES_DIR = os.getenv('NETDATA_PLUGINS_DIR',
+                        os.path.abspath(__file__).strip("python.d.plugin.py").replace("plugins.d", "python.d"))
+CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', "/etc/netdata/")
+INTERVAL = os.getenv('NETDATA_UPDATE_EVERY', 1)
+# directories should end with '/'
+if MODULES_DIR[-1] != "/":
+    MODULES_DIR += "/"
+if CONFIG_DIR[-1] != "/":
+    CONFIG_DIR += "/"
+sys.path.append(MODULES_DIR + "python_modules")
+
 
 try:
     assert sys.version_info >= (3, 1)
@@ -22,7 +39,7 @@ except (AssertionError, ImportError):
         # __builtin__.PY_VERSION = 2
         PY_VERSION = 2
         sys.stderr.write('python.d.plugin: Using python 2\n')
-    except (AssertionError, ImportError):
+    except ImportError:
         sys.stderr.write('python.d.plugin: Cannot start. No importlib.machinery on python3 or lack of imp on python2\n')
         sys.stdout.write('DISABLE\n')
         sys.exit(1)
@@ -482,19 +499,12 @@ def run():
     """
     global PROGRAM, DEBUG_FLAG
     PROGRAM = sys.argv[0].split('/')[-1].split('.plugin')[0]
-    # parse env variables
-    # https://github.com/firehol/netdata/wiki/External-Plugins#environment-variables
-    main_dir = os.getenv('NETDATA_PLUGINS_DIR',
-                         os.path.abspath(__file__).strip("python.d.plugin.py"))
-    config_dir = os.getenv('NETDATA_CONFIG_DIR', "/etc/netdata/")
-    interval = os.getenv('NETDATA_UPDATE_EVERY', None)
 
     # read configuration file
     disabled = []
-    if config_dir[-1] != '/':
-        config_dir += '/'
-    configfile = config_dir + "python.d.conf"
+    configfile = CONFIG_DIR + "python.d.conf"
 
+    interval = INTERVAL
     conf = read_config(configfile)
     if conf is not None:
         try:
@@ -505,14 +515,6 @@ def run():
         except (KeyError, TypeError):
             pass
         try:
-            modules_conf = conf['plugins_config_dir']
-        except (KeyError, TypeError):
-            modules_conf = config_dir + "python.d/"  # default configuration directory
-        try:
-            modules_dir = conf['plugins_dir']
-        except (KeyError, TypeError):
-            modules_dir = main_dir.replace("plugins.d", "python.d")
-        try:
             interval = conf['interval']
         except (KeyError, TypeError):
             pass  # use default interval from NETDATA_UPDATE_EVERY
@@ -521,31 +523,21 @@ def run():
         except (KeyError, TypeError):
             pass
         for k, v in conf.items():
-            if k in ("plugins_config_dir", "plugins_dir", "interval", "debug"):
+            if k in ("interval", "debug", "enable"):
                 continue
             if v is False:
                 disabled.append(k)
     else:
-        modules_conf = config_dir + "python.d/"
-        modules_dir = main_dir.replace("plugins.d", "python.d")
-
-    # directories should end with '/'
-    if modules_dir[-1] != '/':
-        modules_dir += "/"
-    if modules_conf[-1] != '/':
-        modules_conf += "/"
+        modules_conf = CONFIG_DIR + "python.d/"
 
     # parse passed command line arguments
-    out = parse_cmdline(modules_dir, *sys.argv)
+    out = parse_cmdline(MODULES_DIR, *sys.argv)
     modules = out['modules']
     if out['interval'] is not None:
         interval = out['interval']
 
-    # configure environment to run modules
-    sys.path.append(modules_dir + "python_modules")  # append path to directory with modules dependencies
-
     # run plugins
-    charts = PythonCharts(interval, modules, modules_dir, modules_conf, disabled)
+    charts = PythonCharts(interval, modules, MODULES_DIR, modules_conf, disabled)
     charts.check()
     charts.create()
     charts.update()

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -136,6 +136,14 @@ class PythonCharts(object):
                       ": configuration file '" +
                       configfile +
                       "' not found. Using defaults.")
+                # set config if not found
+                if not hasattr(mod, 'config'):
+                    mod.config = {None:{}}
+                    for var in BASE_CONFIG:
+                        try:
+                            mod.config[None][var] = getattr(var, mod)
+                        except Exception:
+                            mod.config[None][var] = BASE_CONFIG[var]
         return modules
 
     def _parse_config(self,module,config):
@@ -174,7 +182,7 @@ class PythonCharts(object):
         # return dictionary of jobs where every job has BASE_CONFIG variables
         return config
 
-    def _stop(self, job, reason=None): #FIXME test if Service has __name__
+    def _stop(self, job, reason=None):
     # modifies self.jobs
         self.jobs.remove(job)
         if reason is None:
@@ -356,9 +364,11 @@ def run():
     if config_dir[-1] != '/':
         config_dir += '/'
     configfile = config_dir + "python.d.conf"
+    print(config_dir)
 
     try:
         conf = read_config(configfile)
+        print(conf)
         try:
             if str(conf['enable']) is False:
                 debug("disabled in configuration file")
@@ -411,6 +421,7 @@ def run():
     charts.check()
     charts.create()
     charts.update()
+    sys.stdout.write("DISABLE")
 
 if __name__ == '__main__':
     run()

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -152,7 +152,6 @@ class PythonCharts(object):
         :param modules: list
         :return: list
         """
-
         for mod in modules:
             configfile = self.configs + mod.__name__ + ".conf"
             if os.path.isfile(configfile):
@@ -192,7 +191,6 @@ class PythonCharts(object):
         :param config: dict
         :return: dict
         """
-
         # get default values
         defaults = {}
         for key in BASE_CONFIG:

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -23,7 +23,7 @@ except (AssertionError, ImportError):
         PY_VERSION = 2
         sys.stderr.write('python.d.plugin: Using python 2\n')
     except (AssertionError, ImportError):
-        sys.stderr.write('python.d.plugin: Not supported python version. Needed python >= 3.1\n')
+        sys.stderr.write('python.d.plugin: Cannot start. No importlib.machinery on python3 or lack of imp on python2\n')
         sys.stdout.write('DISABLE\n')
         sys.exit(1)
 try:

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -527,8 +527,6 @@ def run():
                 continue
             if v is False:
                 disabled.append(k)
-    else:
-        modules_conf = CONFIG_DIR + "python.d/"
 
     # parse passed command line arguments
     out = parse_cmdline(MODULES_DIR, *sys.argv)
@@ -537,7 +535,7 @@ def run():
         interval = out['interval']
 
     # run plugins
-    charts = PythonCharts(interval, modules, MODULES_DIR, modules_conf, disabled)
+    charts = PythonCharts(interval, modules, MODULES_DIR, CONFIG_DIR + "python.d/", disabled)
     charts.check()
     charts.create()
     charts.update()

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -42,12 +42,22 @@ BASE_CONFIG = {'update_every': 10,
 
 
 class PythonCharts(object):
+    """
+    Main class used to control every python module.
+    """
     def __init__(self,
                  interval=None,
                  modules=None,
                  modules_path='../python.d/',
                  modules_configs='../conf.d/',
                  modules_disabled=None):
+        """
+        :param interval: int
+        :param modules: list
+        :param modules_path: str
+        :param modules_configs: str
+        :param modules_disabled: list
+        """
 
         if modules is None:
             modules = []
@@ -65,14 +75,20 @@ class PythonCharts(object):
         configured_modules = self._load_configs(loaded_modules)
 
         # good economy and prosperity:
-        self.jobs = self._create_jobs(configured_modules)
+        self.jobs = self._create_jobs(configured_modules)  # type: list
         if DEBUG_FLAG and interval is not None:
             for job in self.jobs:
                 job.create_timetable(interval)
 
     @staticmethod
     def _import_module(path, name=None):
-        # try to import module using only its path
+        """
+        Try to import module using only its path.
+        :param path: str
+        :param name: str
+        :return: object
+        """
+
         if name is None:
             name = path.split('/')[-1]
             if name[-len(MODULE_EXTENSION):] != MODULE_EXTENSION:
@@ -83,12 +99,19 @@ class PythonCharts(object):
                 return importlib.machinery.SourceFileLoader(name, path).load_module()
             else:
                 return imp.load_source(name, path)
-                # return importlib.import_module(path, name)
         except Exception as e:
             debug(str(e))
             return None
 
     def _load_modules(self, path, modules, disabled):
+        """
+        Load modules from 'modules' list or dynamically every file from 'path' (only .chart.py files)
+        :param path: str
+        :param modules: list
+        :param disabled: list
+        :return: list
+        """
+
         # check if plugin directory exists
         if not os.path.isdir(path):
             debug("cannot find charts directory ", path)
@@ -122,7 +145,14 @@ class PythonCharts(object):
         return loaded
 
     def _load_configs(self, modules):
-        # function loads configuration files to modules
+        """
+        Append configuration in list named `config` to every module.
+        For multi-job modules `config` list is created in _parse_config,
+        otherwise it is created here based on BASE_CONFIG prototype with None as identifier.
+        :param modules: list
+        :return: list
+        """
+
         for mod in modules:
             configfile = self.configs + mod.__name__ + ".conf"
             if os.path.isfile(configfile):
@@ -150,6 +180,19 @@ class PythonCharts(object):
 
     @staticmethod
     def _parse_config(module, config):
+        """
+        Parse configuration file or extract configuration from module file.
+        Example of returned dictionary:
+            config = {'name': {
+                            'update_every': 2,
+                            'retries': 3,
+                            'priority': 30000
+                            'other_val': 123}}
+        :param module: object
+        :param config: dict
+        :return: dict
+        """
+
         # get default values
         defaults = {}
         for key in BASE_CONFIG:
@@ -187,11 +230,11 @@ class PythonCharts(object):
 
     @staticmethod
     def _create_jobs(modules):
-        # module store a definition of Service class
-        # module store configuration in module.config
-        # configs are list of dicts or a dict
-        # one dict is one service
-        # iterate over list of modules and inside one loop iterate over configs
+        """
+        Create jobs based on module.config dictionary and module.Service class definition.
+        :param modules: list
+        :return: list
+        """
         jobs = []
         for module in modules:
             for name in module.config:
@@ -212,10 +255,16 @@ class PythonCharts(object):
                     if name is not None:
                         job.execution_name += "_" + name
                 jobs.append(job)
+
         return [j for j in jobs if j is not None]
 
     def _stop(self, job, reason=None):
-        # modifies self.jobs
+        """
+        Stop specified job and remove it from self.jobs list
+        Also notifies user about job failure if DEBUG_FLAG is set
+        :param job: object
+        :param reason: str
+        """
         self.jobs.remove(job)
         if reason is None:
             return
@@ -240,7 +289,11 @@ class PythonCharts(object):
             debug(job.execution_name, "is " + reason)
 
     def check(self):
-        # try to execute check() on every job
+        """
+        Tries to execute check() on every job.
+        This cannot fail thus it is catching every exception
+        If job.check() fails job is stopped
+        """
         for job in self.jobs:
             try:
                 if not job.check():
@@ -251,7 +304,12 @@ class PythonCharts(object):
                 self._stop(job, "misbehaving. Reason: " + str(e))
 
     def create(self):
-        # try to execute create() on every job
+        """
+        Tries to execute create() on every job.
+        This cannot fail thus it is catching every exception.
+        If job.create() fails job is stopped.
+        This is also creating job run time chart.
+        """
         for job in self.jobs:
             try:
                 if not job.create():
@@ -274,7 +332,14 @@ class PythonCharts(object):
                 self._stop(job, "misbehaving. Reason: " + str(e))
 
     def _update_job(self, job):
-        # try to execute update() on every job and draw run time graph
+        """
+        Tries to execute update() on specified job.
+        This cannot fail thus it is catching every exception.
+        If job.update() returns False, number of retries is decremented. If there are no more retries, job is stopped.
+        Job is also stopped if it throws an exception.
+        This is also updating job run time chart.
+        :param job: object
+        """
         t_start = time.time()
         # check if it is time to execute job update() function
         if job.timetable['next'] > t_start:
@@ -285,7 +350,11 @@ class PythonCharts(object):
             else:
                 since_last = int((t_start - job.timetable['last']) * 1000000)
             if not job.update(since_last):
-                self._stop(job, "update failed")
+                if job.retries <= 0:
+                    self._stop(job, "update failed")
+                else:
+                    job.retries -= 1
+                    job.timetable['next'] += job.timetable['freq']
                 return
         except AttributeError:
             self._stop(job, "no update")
@@ -304,7 +373,10 @@ class PythonCharts(object):
         self.first_run = False
 
     def update(self):
-        # run updates (this will stay forever and ever and ever forever and ever it'll be the one...)
+        """
+        Tries to execute update() on every job by using _update_job()
+        This will stay forever and ever and ever forever and ever it'll be the one...
+        """
         self.first_run = True
         while True:
             next_runs = []
@@ -322,6 +394,11 @@ class PythonCharts(object):
 
 
 def read_config(path):
+    """
+    Read YAML configuration from specified file
+    :param path: str
+    :return: dict
+    """
     try:
         with open(path, 'r') as stream:
             config = yaml.load(stream)
@@ -335,6 +412,9 @@ def read_config(path):
 
 
 def debug(*args):
+    """
+    Print message on stderr.
+    """
     if not DEBUG_FLAG:
         return
     sys.stderr.write(PROGRAM + ":")
@@ -345,6 +425,12 @@ def debug(*args):
 
 
 def parse_cmdline(directory, *commands):
+    """
+    Parse parameters from command line.
+    :param directory: str
+    :param commands: list of str
+    :return: dict
+    """
     global DEBUG_FLAG
     interval = None
 
@@ -375,6 +461,9 @@ def parse_cmdline(directory, *commands):
 
 # if __name__ == '__main__':
 def run():
+    """
+    Main program.
+    """
     global PROGRAM, DEBUG_FLAG
     PROGRAM = sys.argv[0].split('/')[-1].split('.plugin')[0]
     # parse env variables

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -7,10 +7,25 @@ import time
 try:
     assert sys.version_info >= (3, 1)
     import importlib.machinery
-except AssertionError:
-    sys.stderr.write('python.d.plugin: Not supported python version. Needed python >= 3.1\n')
-    sys.stdout.write('DISABLE\n')
-    sys.exit(1)
+
+    # change this hack below if we want PY_VERSION to be used in modules
+    # import builtins
+    # builtins.PY_VERSION = 3
+    PY_VERSION = 3
+    sys.stderr.write('python.d.plugin: Using python 3\n')
+except (AssertionError, ImportError):
+    try:
+        import imp
+
+        # change this hack below if we want PY_VERSION to be used in modules
+        # import __builtin__
+        # __builtin__.PY_VERSION = 2
+        PY_VERSION = 2
+        sys.stderr.write('python.d.plugin: Using python 2\n')
+    except (AssertionError, ImportError):
+        sys.stderr.write('python.d.plugin: Not supported python version. Needed python >= 3.1\n')
+        sys.stdout.write('DISABLE\n')
+        sys.exit(1)
 try:
     import yaml
 except ImportError:
@@ -29,10 +44,16 @@ BASE_CONFIG = {'update_every': 10,
 class PythonCharts(object):
     def __init__(self,
                  interval=None,
-                 modules=[],
+                 modules=None,
                  modules_path='../python.d/',
                  modules_configs='../conf.d/',
-                 modules_disabled=[]):
+                 modules_disabled=None):
+
+        if modules is None:
+            modules = []
+        if modules_disabled is None:
+            modules_disabled = []
+
         self.first_run = True
         # set configuration directory
         self.configs = modules_configs
@@ -50,36 +71,6 @@ class PythonCharts(object):
                 job.create_timetable(interval)
 
     @staticmethod
-    def _create_jobs(modules):
-        # module store a definition of Service class
-        # module store configuration in module.config
-        # configs are list of dicts or a dict
-        # one dict is one service
-        # iterate over list of modules and inside one loop iterate over configs
-        jobs = []
-        for module in modules:
-            for name in module.config:
-                # register a new job
-                conf = module.config[name]
-                try:
-                    job = module.Service(configuration=conf, name=name)
-                except Exception as e:
-                    debug(module.__name__ +
-                          ": Couldn't start job named " +
-                          str(name) +
-                          ": " +
-                          str(e))
-                    return None
-                else:
-                    # set execution_name (needed to plot run time graphs)
-                    job.execution_name = module.__name__
-                    if name is not None:
-                        job.execution_name += "_" + name
-                jobs.append(job)
-
-        return [j for j in jobs if j is not None]
-
-    @staticmethod
     def _import_module(path, name=None):
         # try to import module using only its path
         if name is None:
@@ -88,7 +79,11 @@ class PythonCharts(object):
                 return None
             name = name[:-len(MODULE_EXTENSION)]
         try:
-            return importlib.machinery.SourceFileLoader(name, path).load_module()
+            if PY_VERSION == 3:
+                return importlib.machinery.SourceFileLoader(name, path).load_module()
+            else:
+                return imp.load_source(name, path)
+                # return importlib.import_module(path, name)
         except Exception as e:
             debug(str(e))
             return None
@@ -109,6 +104,10 @@ class PythonCharts(object):
                 mod = self._import_module(path + m + MODULE_EXTENSION)
                 if mod is not None:
                     loaded.append(mod)
+                else:  # exit if plugin is not found
+                    sys.stdout.write("DISABLE")
+                    sys.stdout.flush()
+                    sys.exit(1)
         else:
             # scan directory specified in path and load all modules from there
             names = os.listdir(path)
@@ -185,6 +184,35 @@ class PythonCharts(object):
 
         # return dictionary of jobs where every job has BASE_CONFIG variables
         return config
+
+    @staticmethod
+    def _create_jobs(modules):
+        # module store a definition of Service class
+        # module store configuration in module.config
+        # configs are list of dicts or a dict
+        # one dict is one service
+        # iterate over list of modules and inside one loop iterate over configs
+        jobs = []
+        for module in modules:
+            for name in module.config:
+                # register a new job
+                conf = module.config[name]
+                try:
+                    job = module.Service(configuration=conf, name=name)
+                except Exception as e:
+                    debug(module.__name__ +
+                          ": Couldn't start job named " +
+                          str(name) +
+                          ": " +
+                          str(e))
+                    return None
+                else:
+                    # set execution_name (needed to plot run time graphs)
+                    job.execution_name = module.__name__
+                    if name is not None:
+                        job.execution_name += "_" + name
+                jobs.append(job)
+        return [j for j in jobs if j is not None]
 
     def _stop(self, job, reason=None):
         # modifies self.jobs
@@ -297,8 +325,8 @@ def read_config(path):
     try:
         with open(path, 'r') as stream:
             config = yaml.load(stream)
-    except IsADirectoryError:
-        debug(str(path), "is a directory")
+    except (OSError, IOError):
+        debug(str(path), "is not a valid configuration file")
         return None
     except yaml.YAMLError as e:
         debug(str(path), "is malformed:", e)
@@ -331,6 +359,7 @@ def parse_cmdline(directory, *commands):
             DEBUG_FLAG = True
             mods.append(cmd.replace(".chart.py", ""))
         else:
+            DEBUG_FLAG = False
             try:
                 interval = int(cmd)
             except ValueError:
@@ -346,8 +375,7 @@ def parse_cmdline(directory, *commands):
 
 # if __name__ == '__main__':
 def run():
-    global DEBUG_FLAG, PROGRAM
-    DEBUG_FLAG = True
+    global PROGRAM, DEBUG_FLAG
     PROGRAM = sys.argv[0].split('/')[-1].split('.plugin')[0]
     # parse env variables
     # https://github.com/firehol/netdata/wiki/External-Plugins#environment-variables
@@ -362,9 +390,8 @@ def run():
         config_dir += '/'
     configfile = config_dir + "python.d.conf"
 
-    try:
-        conf = read_config(configfile)
-        print(conf)
+    conf = read_config(configfile)
+    if conf is not None:
         try:
             if str(conf['enable']) is False:
                 debug("disabled in configuration file")
@@ -374,26 +401,26 @@ def run():
             pass
         try:
             modules_conf = conf['plugins_config_dir']
-        except KeyError:
+        except (KeyError, TypeError):
             modules_conf = config_dir + "python.d/"  # default configuration directory
         try:
             modules_dir = conf['plugins_dir']
-        except KeyError:
+        except (KeyError, TypeError):
             modules_dir = main_dir.replace("plugins.d", "python.d")
         try:
             interval = conf['interval']
-        except KeyError:
+        except (KeyError, TypeError):
             pass  # use default interval from NETDATA_UPDATE_EVERY
         try:
             DEBUG_FLAG = conf['debug']
-        except KeyError:
+        except (KeyError, TypeError):
             pass
         for k, v in conf.items():
             if k in ("plugins_config_dir", "plugins_dir", "interval", "debug"):
                 continue
             if v is False:
                 disabled.append(k)
-    except FileNotFoundError:
+    else:
         modules_conf = config_dir + "python.d/"
         modules_dir = main_dir.replace("plugins.d", "python.d")
 

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -144,8 +144,8 @@ class PythonCharts(object):
                     mod.config = {None: {}}
                     for var in BASE_CONFIG:
                         try:
-                            mod.config[None][var] = getattr(var, mod)
-                        except Exception:
+                            mod.config[None][var] = getattr(mod, var)
+                        except AttributeError:
                             mod.config[None][var] = BASE_CONFIG[var]
         return modules
 
@@ -361,7 +361,6 @@ def run():
     if config_dir[-1] != '/':
         config_dir += '/'
     configfile = config_dir + "python.d.conf"
-    print(config_dir)
 
     try:
         conf = read_config(configfile)
@@ -395,7 +394,7 @@ def run():
             if v is False:
                 disabled.append(k)
     except FileNotFoundError:
-        modules_conf = config_dir
+        modules_conf = config_dir + "python.d/"
         modules_dir = main_dir.replace("plugins.d", "python.d")
 
     # directories should end with '/'

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -3,8 +3,9 @@
 import os
 import sys
 import time
+
 try:
-    assert sys.version_info >= (3,1)
+    assert sys.version_info >= (3, 1)
     import importlib.machinery
 except AssertionError:
     sys.stderr.write('python.d.plugin: Not supported python version. Needed python >= 3.1\n')
@@ -17,14 +18,15 @@ except ImportError:
     sys.stdout.write('DISABLE\n')
     sys.exit(1)
 
+DEBUG_FLAG = False
+PROGRAM = "python.d.plugin"
 MODULE_EXTENSION = ".chart.py"
-BASE_CONFIG = {'update_every' : 10,
+BASE_CONFIG = {'update_every': 10,
                'priority': 12345,
-               'retries' : 0}
+               'retries': 0}
 
 
 class PythonCharts(object):
-    
     def __init__(self,
                  interval=None,
                  modules=[],
@@ -36,7 +38,7 @@ class PythonCharts(object):
         self.configs = modules_configs
 
         # load modules
-        loaded_modules = self._load_modules(modules_path,modules, modules_disabled)
+        loaded_modules = self._load_modules(modules_path, modules, modules_disabled)
 
         # load configuration files
         configured_modules = self._load_configs(loaded_modules)
@@ -45,15 +47,15 @@ class PythonCharts(object):
         self.jobs = self._create_jobs(configured_modules)
         if DEBUG_FLAG and interval is not None:
             for job in self.jobs:
-                job._create_timetable(interval)
+                job.create_timetable(interval)
 
-
-    def _create_jobs(self,modules):
-    # module store a definition of Service class
-    # module store configuration in module.config
-    # configs are list of dicts or a dict
-    # one dict is one service
-    # iterate over list of modules and inside one loop iterate over configs
+    @staticmethod
+    def _create_jobs(modules):
+        # module store a definition of Service class
+        # module store configuration in module.config
+        # configs are list of dicts or a dict
+        # one dict is one service
+        # iterate over list of modules and inside one loop iterate over configs
         jobs = []
         for module in modules:
             for name in module.config:
@@ -64,7 +66,7 @@ class PythonCharts(object):
                 except Exception as e:
                     debug(module.__name__ +
                           ": Couldn't start job named " +
-                          str(name) + 
+                          str(name) +
                           ": " +
                           str(e))
                     return None
@@ -74,11 +76,12 @@ class PythonCharts(object):
                     if name is not None:
                         job.execution_name += "_" + name
                 jobs.append(job)
-        
+
         return [j for j in jobs if j is not None]
 
-    def _import_module(self, path, name=None):
-    # try to import module using only its path
+    @staticmethod
+    def _import_module(path, name=None):
+        # try to import module using only its path
         if name is None:
             name = path.split('/')[-1]
             if name[-len(MODULE_EXTENSION):] != MODULE_EXTENSION:
@@ -111,7 +114,7 @@ class PythonCharts(object):
             names = os.listdir(path)
             for mod in names:
                 if mod.strip(MODULE_EXTENSION) in disabled:
-                    debug("disabling:",mod.strip(MODULE_EXTENSION))
+                    debug("disabling:", mod.strip(MODULE_EXTENSION))
                     continue
                 m = self._import_module(path + mod)
                 if m is not None:
@@ -119,8 +122,8 @@ class PythonCharts(object):
                     loaded.append(m)
         return loaded
 
-    def _load_configs(self,modules):
-    # function loads configuration files to modules
+    def _load_configs(self, modules):
+        # function loads configuration files to modules
         for mod in modules:
             configfile = self.configs + mod.__name__ + ".conf"
             if os.path.isfile(configfile):
@@ -128,9 +131,9 @@ class PythonCharts(object):
                 try:
                     setattr(mod,
                             'config',
-                            self._parse_config(mod,read_config(configfile)))
+                            self._parse_config(mod, read_config(configfile)))
                 except Exception as e:
-                    debug("something went wrong while loading configuration",e)
+                    debug("something went wrong while loading configuration", e)
             else:
                 debug(mod.__name__ +
                       ": configuration file '" +
@@ -138,7 +141,7 @@ class PythonCharts(object):
                       "' not found. Using defaults.")
                 # set config if not found
                 if not hasattr(mod, 'config'):
-                    mod.config = {None:{}}
+                    mod.config = {None: {}}
                     for var in BASE_CONFIG:
                         try:
                             mod.config[None][var] = getattr(var, mod)
@@ -146,28 +149,29 @@ class PythonCharts(object):
                             mod.config[None][var] = BASE_CONFIG[var]
         return modules
 
-    def _parse_config(self,module,config):
+    @staticmethod
+    def _parse_config(module, config):
         # get default values
         defaults = {}
         for key in BASE_CONFIG:
             try:
                 # get defaults from module config
                 defaults[key] = int(config.pop(key))
-            except (KeyError,ValueError):
+            except (KeyError, ValueError):
                 try:
                     # get defaults from module source code
                     defaults[key] = getattr(module, key)
-                except (KeyError,ValueError):
+                except (KeyError, ValueError):
                     # if above failed, get defaults from global dict
                     defaults[key] = BASE_CONFIG[key]
-      
+
         # check if there are dict in config dict
         many_jobs = False
         for name in config:
             if type(config[name]) is dict:
                 many_jobs = True
                 break
-        
+
         # assign variables needed by supervisor to every job configuration
         if many_jobs:
             for name in config:
@@ -178,12 +182,12 @@ class PythonCharts(object):
         else:
             config = {None: config.copy()}
             config[None].update(defaults)
-            
+
         # return dictionary of jobs where every job has BASE_CONFIG variables
         return config
 
     def _stop(self, job, reason=None):
-    # modifies self.jobs
+        # modifies self.jobs
         self.jobs.remove(job)
         if reason is None:
             return
@@ -205,10 +209,10 @@ class PythonCharts(object):
                   job.execution_name +
                   ".conf' not found. Using defaults.")
         elif reason[:11] == "misbehaving":
-            debug(job.execution_name, "is "+reason)
+            debug(job.execution_name, "is " + reason)
 
     def check(self):
-    # try to execute check() on every job
+        # try to execute check() on every job
         for job in self.jobs:
             try:
                 if not job.check():
@@ -219,7 +223,7 @@ class PythonCharts(object):
                 self._stop(job, "misbehaving. Reason: " + str(e))
 
     def create(self):
-    # try to execute create() on every job
+        # try to execute create() on every job
         for job in self.jobs:
             try:
                 if not job.create():
@@ -242,7 +246,7 @@ class PythonCharts(object):
                 self._stop(job, "misbehaving. Reason: " + str(e))
 
     def _update_job(self, job):
-    # try to execute update() on every job and draw run time graph 
+        # try to execute update() on every job and draw run time graph
         t_start = time.time()
         # check if it is time to execute job update() function
         if job.timetable['next'] > t_start:
@@ -264,11 +268,7 @@ class PythonCharts(object):
         t_end = time.time()
         job.timetable['next'] = t_end - (t_end % job.timetable['freq']) + job.timetable['freq']
         # draw performance graph
-        if self.first_run:
-            dt = 0
-        else:
-            dt = int((t_end - job.timetable['last']) * 1000000)
-        sys.stdout.write("BEGIN netdata.plugin_pythond_"+job.execution_name+" "+str(since_last)+'\n')
+        sys.stdout.write("BEGIN netdata.plugin_pythond_" + job.execution_name + " " + str(since_last) + '\n')
         sys.stdout.write("SET run_time = " + str(int((t_end - t_start) * 1000)) + '\n')
         sys.stdout.write("END\n")
         sys.stdout.flush()
@@ -276,10 +276,9 @@ class PythonCharts(object):
         self.first_run = False
 
     def update(self):
-    # run updates (this will stay forever and ever and ever forever and ever it'll be the one...)
+        # run updates (this will stay forever and ever and ever forever and ever it'll be the one...)
         self.first_run = True
         while True:
-            t_begin = time.time()
             next_runs = []
             for job in self.jobs:
                 self._update_job(job)
@@ -318,9 +317,7 @@ def debug(*args):
 
 
 def parse_cmdline(directory, *commands):
-    # TODO number -> interval
     global DEBUG_FLAG
-    DEBUG_FLAG = False
     interval = None
 
     mods = []
@@ -412,16 +409,17 @@ def run():
     modules = out['modules']
     if out['interval'] is not None:
         interval = out['interval']
-    
-    # configure environement to run modules
-    sys.path.append(modules_dir+"python_modules") # append path to directory with modules dependencies
-    
+
+    # configure environment to run modules
+    sys.path.append(modules_dir + "python_modules")  # append path to directory with modules dependencies
+
     # run plugins
     charts = PythonCharts(interval, modules, modules_dir, modules_conf, disabled)
     charts.check()
     charts.create()
     charts.update()
     sys.stdout.write("DISABLE")
+
 
 if __name__ == '__main__':
     run()

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -12,7 +12,7 @@ import time
 MODULES_DIR = os.getenv('NETDATA_PLUGINS_DIR',
                         os.path.abspath(__file__).strip("python.d.plugin.py").replace("plugins.d", "python.d"))
 CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', "/etc/netdata/")
-INTERVAL = os.getenv('NETDATA_UPDATE_EVERY', 1)
+INTERVAL = os.getenv('NETDATA_UPDATE_EVERY', None)
 # directories should end with '/'
 if MODULES_DIR[-1] != "/":
     MODULES_DIR += "/"

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -11,6 +11,7 @@ dist_python_DATA = \
 
 pythonmodulesdir=$(pythondir)/python_modules
 dist_pythonmodules_DATA = \
-	python_modules/__init__.py
+	python_modules/__init__.py \
+	python_modules/base.py \
 	$(NULL)
 

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -2,12 +2,14 @@
 
 **Python plugin support is experimental and implementation may change in the future**
 
-Currently every plugin must be written in python3.
+Every plugin should be compatible with python2 and python3.
 All third party libraries should be installed system-wide or in `python_modules` directory.
 Module configurations are written in YAML and **pyYAML is required**.
 
 Every configuration file must have one of two formats:
-1. Configuration for only one job:
+
+- Configuration for only one job:
+
 ```yaml
 update_every : 2 # update frequency
 retries      : 1 # how many failures in update() is tolerated
@@ -16,7 +18,9 @@ priority     : 20000 # where it is shown on dashboard
 other_var1   : bla  # variables passed to module
 other_var2   : alb
 ```
-2. Configuration for many jobs (ex. mysql):
+
+- Configuration for many jobs (ex. mysql):
+
 ```yaml
 # module defaults:
 update_every : 2
@@ -35,6 +39,7 @@ other_job:
 ```
 
 `update_every`, `retries`, and `priority` are always optional.
+
 ---
 
 The following python.d plugins are supported:

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -4,8 +4,38 @@
 
 Currently every plugin must be written in python3.
 All third party libraries should be installed system-wide or in `python_modules` directory.
-Also plugins support changing their data collection frequency by setting `update_every` variable in their configuration file.
+Module configurations are written in YAML and **pyYAML is required**.
 
+Every configuration file must have one of two formats:
+1. Configuration for only one job:
+```yaml
+update_every : 2 # update frequency
+retries      : 1 # how many failures in update() is tolerated
+priority     : 20000 # where it is shown on dashboard
+
+other_var1   : bla  # variables passed to module
+other_var2   : alb
+```
+2. Configuration for many jobs (ex. mysql):
+```yaml
+# module defaults:
+update_every : 2
+retries      : 1
+priority     : 20000
+
+local:  # job name
+  update_every : 5 # job update frequency
+  retries      : 2 # job retries
+  other_var1   : some_val # module specific variable
+
+other_job: 
+  priority     : 5 # job position on dashboard
+  retries      : 20 # job retries
+  other_var2   : val # module specific variable
+```
+
+`update_every`, `retries`, and `priority` are always optional.
+---
 
 The following python.d plugins are supported:
 
@@ -72,30 +102,32 @@ You can provide, per server, the following:
 6. mysql host (ip or hostname)
 7. mysql port (defaults to 3306)
 
-Here is an example for 3 servers updating data every 10 seconds
+Here is an example for 3 servers:
 
-```js
-update_every = 10
+```yaml
+update_every : 10
+priority     : 90100
+retries      : 5
 
-config=[
-    {
-        'name'     : 'local',
-        'my.cnf'   : '/etc/mysql/my.cnf'
-    },{
-    	'name'     : 'local_2',
-        'user'     : 'root',
-        'password' : 'blablablabla',
-        'socket'   : '/var/run/mysqld/mysqld.sock'
-    },{
-        'name'     : 'remote',
-        'user'     : 'admin',
-        'password' : 'bla',
-        'host'     : 'example.org',
-        'port'     : '9000'
-    }]
+local:
+  'my.cnf'   : '/etc/mysql/my.cnf'
+  priority   : 90000
+
+local_2:
+  user     : 'root'
+  password : 'blablablabla'
+  socket   : '/var/run/mysqld/mysqld.sock'
+  update_every : 1
+
+remote:
+  user     : 'admin'
+  password : 'bla'
+  host     : 'example.org'
+  port     : 9000
+  retries  : 20
 ```
 
-If no configuration is given, the plugin will attempt to connect to mysql server via unix socket at `/var/run/mysqld/mysqld.sock` without password and username `root`
+If no configuration is given, the plugin will attempt to connect to mysql server via unix socket at `/var/run/mysqld/mysqld.sock` without password and with username `root`
 
 ---
 

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -13,7 +13,7 @@ retries = 7
 
 class Service(BaseService):
     def __init__(self, configuration=None, name=None):
-        super(self.__class__,self).__init__(configuration=configuration)
+        super(self.__class__,self).__init__(configuration=configuration, name=name)
 
     def check(self):
         return True

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -1,18 +1,31 @@
+# Description: example netdata python.d plugin
+# Author: Pawel Krupa (paulfantom)
+
+NAME = "example.chart.py"
+import sys
 import random
+from base import BaseService
 
-update_every = 5
-priority = 150000
+# default module values
+update_every = 3
+priority = 90000
+retries = 7
 
-def check():
-    return True
 
-def create():
-    print("CHART example.python_random '' 'A random number' 'random number' random random line "+str(priority)+" 1")
-    print("DIMENSION random1 '' absolute 1 1")
-    return True
+class Service(BaseService):
+    def __init__(self,configuration=None,name=None):
+        super().__init__(configuration=configuration)
 
-def update(interval):
-    print("BEGIN example.python_random "+str(interval))
-    print("SET random1 = "+str(random.randint(0,100)))
-    print("END")
-    return True
+    def check(self):
+        return True
+    
+    def create(self):
+        print("CHART example.python_random '' 'A random number' 'random number' random random line "+str(self.priority)+" "+str(self.update_every))
+        print("DIMENSION random1 '' absolute 1 1")
+        return True
+    
+    def update(self,interval):
+        print("BEGIN example.python_random "+str(interval))
+        print("SET random1 = "+str(random.randint(0,100)))
+        print("END")
+        return True

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -1,11 +1,10 @@
 # Description: example netdata python.d plugin
 # Author: Pawel Krupa (paulfantom)
 
-NAME = "example.chart.py"
-import sys
 import random
 from base import BaseService
 
+NAME = "example.chart.py"
 # default module values
 update_every = 3
 priority = 90000
@@ -13,7 +12,7 @@ retries = 7
 
 
 class Service(BaseService):
-    def __init__(self,configuration=None,name=None):
+    def __init__(self, configuration=None, name=None):
         super().__init__(configuration=configuration)
 
     def check(self):
@@ -24,7 +23,7 @@ class Service(BaseService):
         print("DIMENSION random1 '' absolute 1 1")
         return True
     
-    def update(self,interval):
+    def update(self, interval):
         print("BEGIN example.python_random "+str(interval))
         print("SET random1 = "+str(random.randint(0,100)))
         print("END")

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -19,7 +19,10 @@ class Service(BaseService):
         return True
     
     def create(self):
-        print("CHART example.python_random '' 'A random number' 'random number' random random line "+str(self.priority)+" "+str(self.update_every))
+        print("CHART example.python_random '' 'A random number' 'random number' random random line " +
+              str(self.priority) +
+              " " +
+              str(self.update_every))
         print("DIMENSION random1 '' absolute 1 1")
         return True
     

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -13,7 +13,7 @@ retries = 7
 
 class Service(BaseService):
     def __init__(self, configuration=None, name=None):
-        super().__init__(configuration=configuration)
+        super(self.__class__,self).__init__(configuration=configuration)
 
     def check(self):
         return True

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -21,7 +21,6 @@ except ImportError:
 from base import BaseService
 
 # default configuration (overridden by python.d.plugin)
-# FIXME change password
 config = {
     'local': {
         'user'     : 'root',
@@ -334,7 +333,7 @@ CHARTS = {
 
 class Service(BaseService):
     def __init__(self,configuration=None,name=None):
-        super().__init__(configuration=configuration)
+        super(self.__class__, self).__init__(configuration=configuration)
         self.name = name
         self.configuration = self._parse_config(configuration)
         self.connection = None

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -2,16 +2,19 @@
 # Author: Pawel Krupa (paulfantom)
 
 import sys
+
 NAME = "mysql.chart.py"
 
 # import 3rd party library to handle MySQL communication
 try:
     import MySQLdb
+
     # https://github.com/PyMySQL/mysqlclient-python
     sys.stderr.write(NAME + ": using MySQLdb\n")
 except ImportError:
     try:
         import pymysql as MySQLdb
+
         # https://github.com/PyMySQL/PyMySQL
         sys.stderr.write(NAME + ": using pymysql\n")
     except ImportError:
@@ -23,12 +26,12 @@ from base import BaseService
 # default configuration (overridden by python.d.plugin)
 config = {
     'local': {
-        'user'     : 'root',
-        'password' : '',
-        'socket'   : '/var/run/mysqld/mysqld.sock',
-        'update_every' : 3,
-        'retries'  : 4,
-        'priority' : 100
+        'user': 'root',
+        'password': '',
+        'socket': '/var/run/mysqld/mysqld.sock',
+        'update_every': 3,
+        'retries': 4,
+        'priority': 100
     }
 }
 
@@ -87,20 +90,20 @@ ORDER = ['net',
 #    }
 
 CHARTS = {
-    'net' : (
+    'net': (
         "'' 'mysql Bandwidth' 'kilobits/s' bandwidth mysql.net area",
         [
             ("Bytes_received", "in incremental 8 1024"),
-            ("Bytes_sent",     "out incremental -8 1024")
+            ("Bytes_sent", "out incremental -8 1024")
         ]),
-    'queries' : (
+    'queries': (
         "'' 'mysql Queries' 'queries/s' queries mysql.queries line",
         [
-            ("Queries",      "queries incremental 1 1"),
-            ("Questions",    "questions incremental 1 1"),
+            ("Queries", "queries incremental 1 1"),
+            ("Questions", "questions incremental 1 1"),
             ("Slow_queries", "slow_queries incremental -1 1")
         ]),
-    'handlers' : (
+    'handlers': (
         "'' 'mysql Handlers' 'handlers/s' handlers mysql.handlers line",
         [
             ("Handler_commit", "commit incremental 1 1"),
@@ -118,13 +121,13 @@ CHARTS = {
             ("Handler_update", "update incremental 1 1"),
             ("Handler_write", "write incremental 1 1")
         ]),
-    'table_locks' : (
+    'table_locks': (
         "'' 'mysql Tables Locks' 'locks/s' locks mysql.table_locks line",
         [
             ("Table_locks_immediate", "immediate incremental 1 1"),
             ("Table_locks_waited", "waited incremental -1 1")
         ]),
-    'join_issues' : (
+    'join_issues': (
         "'' 'mysql Select Join Issues' 'joins/s' issues mysql.join_issues line",
         [
             ("Select_full_join", "full_join incremental 1 1"),
@@ -133,33 +136,33 @@ CHARTS = {
             ("Select_range_check", "range_check incremental 1 1"),
             ("Select_scan", "scan incremental 1 1"),
         ]),
-    'sort_issues' : (
+    'sort_issues': (
         "'' 'mysql Sort Issues' 'issues/s' issues mysql.sort.issues line",
         [
             ("Sort_merge_passes", "merge_passes incremental 1 1"),
             ("Sort_range", "range incremental 1 1"),
             ("Sort_scan", "scan incremental 1 1"),
         ]),
-    'tmp' : (
+    'tmp': (
         "'' 'mysql Tmp Operations' 'counter' temporaries mysql.tmp line",
         [
             ("Created_tmp_disk_tables", "disk_tables incremental 1 1"),
             ("Created_tmp_files", "files incremental 1 1"),
             ("Created_tmp_tables", "tables incremental 1 1"),
         ]),
-    'connections' : (
+    'connections': (
         "'' 'mysql Connections' 'connections/s' connections mysql.connections line",
         [
             ("Connections", "all incremental 1 1"),
             ("Aborted_connects", "aborted incremental 1 1"),
         ]),
-    'binlog_cache' : (
+    'binlog_cache': (
         "'' 'mysql Binlog Cache' 'transactions/s' binlog mysql.binlog_cache line",
         [
             ("Binlog_cache_disk_use", "disk incremental 1 1"),
             ("Binlog_cache_use", "all incremental 1 1"),
         ]),
-    'threads' : (
+    'threads': (
         "'' 'mysql Threads' 'threads' threads mysql.threads line",
         [
             ("Threads_connected", "connected absolute 1 1"),
@@ -167,56 +170,56 @@ CHARTS = {
             ("Threads_cached", "cached absolute -1 1"),
             ("Threads_running", "running absolute 1 1"),
         ]),
-    'thread_cache_misses' : (
+    'thread_cache_misses': (
         "'' 'mysql Threads Cache Misses' 'misses' threads mysql.thread_cache_misses area",
         [
             ("Thread_cache_misses", "misses misses absolute 1 100"),
         ]),
-    'innodb_io' : (
+    'innodb_io': (
         "'' 'mysql InnoDB I/O Bandwidth' 'kilobytes/s' innodb mysql.innodb_io area",
         [
             ("Innodb_data_read", "read incremental 1 1024"),
             ("Innodb_data_written", "write incremental -1 1024"),
         ]),
-    'innodb_io_ops' : (
+    'innodb_io_ops': (
         "'' 'mysql InnoDB I/O Operations' 'operations/s' innodb mysql.innodb_io_ops line",
         [
             ("Innodb_data_reads", "reads incremental 1 1"),
             ("Innodb_data_writes", "writes incremental -1 1"),
             ("Innodb_data_fsyncs", "fsyncs incremental 1 1"),
         ]),
-    'innodb_io_pending_ops' : (
+    'innodb_io_pending_ops': (
         "'' 'mysql InnoDB Pending I/O Operations' 'operations' innodb mysql.innodb_io_pending_ops line",
         [
             ("Innodb_data_pending_reads", "reads absolute 1 1"),
             ("Innodb_data_pending_writes", "writes absolute -1 1"),
             ("Innodb_data_pending_fsyncs", "fsyncs absolute 1 1"),
         ]),
-    'innodb_log' : (
+    'innodb_log': (
         "'' 'mysql InnoDB Log Operations' 'operations/s' innodb mysql.innodb_log line",
         [
             ("Innodb_log_waits", "waits incremental 1 1"),
             ("Innodb_log_write_requests", "write_requests incremental -1 1"),
             ("Innodb_log_writes", "incremental -1 1"),
         ]),
-    'innodb_os_log' : (
+    'innodb_os_log': (
         "'' 'mysql InnoDB OS Log Operations' 'operations' innodb mysql.innodb_os_log line",
         [
             ("Innodb_os_log_fsyncs", "fsyncs incremental 1 1"),
             ("Innodb_os_log_pending_fsyncs", "pending_fsyncs absolute 1 1"),
             ("Innodb_os_log_pending_writes", "pending_writes absolute -1 1"),
         ]),
-    'innodb_os_log_io' : (
+    'innodb_os_log_io': (
         "'' 'mysql InnoDB OS Log Bandwidth' 'kilobytes/s' innodb mysql.innodb_os_log_io area",
         [
             ("Innodb_os_log_written", "write incremental -1 1024"),
         ]),
-    'innodb_cur_row_lock' : (
+    'innodb_cur_row_lock': (
         "'' 'mysql InnoDB Current Row Locks' 'operations' innodb mysql.innodb_cur_row_lock area",
         [
             ("Innodb_row_lock_current_waits", "current_waits absolute 1 1"),
         ]),
-    'innodb_rows' : (
+    'innodb_rows': (
         "'' 'mysql InnoDB Row Operations' 'operations/s' innodb mysql.innodb_rows area",
         [
             ("Innodb_rows_inserted", "read incremental 1 1"),
@@ -224,7 +227,7 @@ CHARTS = {
             ("Innodb_rows_updated", "inserted incremental 1 1"),
             ("Innodb_rows_deleted", "updated incremental -1 1"),
         ]),
-    'innodb_buffer_pool_pages' : (
+    'innodb_buffer_pool_pages': (
         "'' 'mysql InnoDB Buffer Pool Pages' 'pages' innodb mysql.innodb_buffer_pool_pages line",
         [
             ("Innodb_buffer_pool_pages_data", "data absolute 1 1"),
@@ -234,32 +237,32 @@ CHARTS = {
             ("Innodb_buffer_pool_pages_misc", "misc absolute -1 1"),
             ("Innodb_buffer_pool_pages_total", "total absolute 1 1"),
         ]),
-    'innodb_buffer_pool_bytes' : (
+    'innodb_buffer_pool_bytes': (
         "'' 'mysql InnoDB Buffer Pool Bytes' 'MB' innodb mysql.innodb_buffer_pool_bytes area",
         [
             ("Innodb_buffer_pool_bytes_data", "data absolute 1"),
             ("Innodb_buffer_pool_bytes_dirty", "dirty absolute -1"),
         ]),
-    'innodb_buffer_pool_read_ahead' : (
+    'innodb_buffer_pool_read_ahead': (
         "'' 'mysql InnoDB Buffer Pool Read Ahead' 'operations/s' innodb mysql.innodb_buffer_pool_read_ahead area",
         [
             ("Innodb_buffer_pool_read_ahead", "all incremental 1 1"),
             ("Innodb_buffer_pool_read_ahead_evicted", "evicted incremental -1 1"),
             ("Innodb_buffer_pool_read_ahead_rnd", "random incremental 1 1"),
         ]),
-    'innodb_buffer_pool_reqs' : (
+    'innodb_buffer_pool_reqs': (
         "'' 'mysql InnoDB Buffer Pool Requests' 'requests/s' innodb mysql.innodb_buffer_pool_reqs area",
         [
             ("Innodb_buffer_pool_read_requests", "reads incremental 1 1"),
             ("Innodb_buffer_pool_write_requests", "writes incremental -1 1"),
         ]),
-    'innodb_buffer_pool_ops' : (
+    'innodb_buffer_pool_ops': (
         "'' 'mysql InnoDB Buffer Pool Operations' 'operations/s' innodb mysql.innodb_buffer_pool_ops area",
         [
             ("Innodb_buffer_pool_reads", "'disk reads' incremental 1 1"),
             ("Innodb_buffer_pool_wait_free", "'wait free' incremental -1 1"),
         ]),
-    'qcache_ops' : (
+    'qcache_ops': (
         "'' 'mysql QCache Operations' 'queries/s' qcache mysql.qcache_ops line",
         [
             ("Qcache_hits", "hits incremental 1 1"),
@@ -267,58 +270,58 @@ CHARTS = {
             ("Qcache_inserts", "inserts incremental 1 1"),
             ("Qcache_not_cached", "'not cached' incremental -1 1"),
         ]),
-    'qcache' : (
+    'qcache': (
         "'' 'mysql QCache Queries in Cache' 'queries' qcache mysql.qcache line",
         [
             ("Qcache_queries_in_cache", "queries absolute 1 1"),
         ]),
-    'qcache_freemem' : (
+    'qcache_freemem': (
         "'' 'mysql QCache Free Memory' 'MB' qcache mysql.qcache_freemem area",
         [
             ("Qcache_free_memory", "free absolute 1"),
         ]),
-    'qcache_memblocks' : (
+    'qcache_memblocks': (
         "'' 'mysql QCache Memory Blocks' 'blocks' qcache mysql.qcache_memblocks line",
         [
             ("Qcache_free_blocks", "free absolute 1"),
             ("Qcache_total_blocks", "total absolute 1 1"),
         ]),
-    'key_blocks' : (
+    'key_blocks': (
         "'' 'mysql MyISAM Key Cache Blocks' 'blocks' myisam mysql.key_blocks line",
         [
             ("Key_blocks_unused", "unused absolute 1 1"),
             ("Key_blocks_used", "used absolute -1 1"),
             ("Key_blocks_not_flushed", "'not flushed' absolute 1 1"),
         ]),
-    'key_requests' : (
+    'key_requests': (
         "'' 'mysql MyISAM Key Cache Requests' 'requests/s' myisam mysql.key_requests area",
         [
             ("Key_read_requests", "reads incremental 1 1"),
             ("Key_write_requests", "writes incremental -1 1"),
         ]),
-    'key_disk_ops' : (
+    'key_disk_ops': (
         "'' 'mysql MyISAM Key Cache Disk Operations' 'operations/s' myisam mysql.key_disk_ops area",
         [
             ("Key_reads", "reads incremental 1 1"),
             ("Key_writes", "writes incremental -1 1"),
         ]),
-    'files' : (
+    'files': (
         "'' 'mysql Open Files' 'files' files mysql.files line",
         [
             ("Open_files", "files absolute 1 1"),
         ]),
-    'files_rate' : (
+    'files_rate': (
         "'' 'mysql Opened Files Rate' 'files/s' files mysql.files_rate line",
         [
             ("Opened_files", "files incremental 1 1"),
         ]),
-    'binlog_stmt_cache' : (
+    'binlog_stmt_cache': (
         "'' 'mysql Binlog Statement Cache' 'statements/s' binlog mysql.binlog_stmt_cache line",
         [
             ("Binlog_stmt_cache_disk_use", "disk incremental 1 1"),
             ("Binlog_stmt_cache_use", "all incremental 1 1"),
         ]),
-    'connection_errors' : (
+    'connection_errors': (
         "'' 'mysql Connection Errors' 'connections/s' connections mysql.connection_errors line",
         [
             ("Connection_errors_accept", "accept incremental 1 1"),
@@ -332,14 +335,14 @@ CHARTS = {
 
 
 class Service(BaseService):
-    def __init__(self,configuration=None,name=None):
+    def __init__(self, configuration=None, name=None):
         super(self.__class__, self).__init__(configuration=configuration)
         self.name = name
         self.configuration = self._parse_config(configuration)
         self.connection = None
         self.defs = {}
 
-    def _parse_config(self,configuration):
+    def _parse_config(self, configuration):
         # parse configuration to collect data from mysql server
         if self.name is None:
             self.name = 'local'
@@ -376,11 +379,14 @@ class Service(BaseService):
                                               connect_timeout=self.configuration['update_every'])
         except Exception as e:
             self.error(NAME + " has problem connecting to server:", e)
-            raise RuntimeError  # stop creating module, need to catch it in supervisor
+            raise RuntimeError
 
     def _get_data(self):
         if self.connection is None:
-            self._connect()
+            try:
+                self._connect()
+            except RuntimeError:
+                return None
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(QUERY)
@@ -420,7 +426,7 @@ class Service(BaseService):
             # check if server has this data point
             for line in CHARTS[name][1]:
                 if line[0] in data:
-                     content += "DIMENSION " + line[0] + " " + line[1] + "\n"
+                    content += "DIMENSION " + line[0] + " " + line[1] + "\n"
             if len(content) > 0:
                 print(header)
                 print(content)

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -1,8 +1,8 @@
 # Description: MySQL netdata python.d plugin
 # Author: Pawel Krupa (paulfantom)
 
-NAME = "mysql.chart.py"
 import sys
+NAME = "mysql.chart.py"
 
 # import 3rd party library to handle MySQL communication
 try:
@@ -20,7 +20,7 @@ except ImportError:
 
 from base import BaseService
 
-# default configuration (overriden by python.d.plugin)
+# default configuration (overridden by python.d.plugin)
 # FIXME change password
 config = {
     'local': {
@@ -41,19 +41,19 @@ retries = 7
 # query executed on MySQL server
 QUERY = "SHOW GLOBAL STATUS"
 
-# charts order (can be overriden if you want less charts, or different order)
-ORDER = ['net', 
-         'queries', 
-         'handlers', 
-         'table_locks', 
-         'join_issues', 
-         'sort_issues', 
-         'tmp', 
-         'connections', 
-         'binlog_cache', 
-         'threads', 
-         'thread_cache_misses', 
-         'innodb_io', 
+# charts order (can be overridden if you want less charts, or different order)
+ORDER = ['net',
+         'queries',
+         'handlers',
+         'table_locks',
+         'join_issues',
+         'sort_issues',
+         'tmp',
+         'connections',
+         'binlog_cache',
+         'threads',
+         'thread_cache_misses',
+         'innodb_io',
          'innodb_io_ops',
          'innodb_io_pending_ops',
          'innodb_log',
@@ -83,7 +83,7 @@ ORDER = ['net',
 #    'chart_name_in_netdata': (
 #        "parameters defining chart (passed to CHART statement)",
 #        [ # dimensions (lines) definitions
-#            ("dimension_name", "dimension parameters (passed to DIMENSION statement)", "additional parameter (optional)")
+#            ("dimension_name", "dimension parameters (passed to DIMENSION statement)")
 #        ])
 #    }
 
@@ -377,8 +377,8 @@ class Service(BaseService):
                                               connect_timeout=self.configuration['update_every'])
         except Exception as e:
             self.error(NAME + " has problem connecting to server:", e)
-            raise RuntimeError #stop creating module, need to catch it in supervisor
-    
+            raise RuntimeError  # stop creating module, need to catch it in supervisor
+
     def _get_data(self):
         if self.connection is None:
             self._connect()
@@ -391,7 +391,7 @@ class Service(BaseService):
             self.connection.close()
             self.connection = None
             return None
-        
+
         return dict(raw_data)
 
     def check(self):
@@ -407,7 +407,7 @@ class Service(BaseService):
             self.defs[name] = []
             for line in CHARTS[name][1]:
                 self.defs[name].append(line[0])
-   
+
         idx = 0
         data = self._get_data()
         for name in ORDER:
@@ -418,7 +418,7 @@ class Service(BaseService):
                      str(self.priority + idx) + " " + \
                      str(self.update_every)
             content = ""
-            # check if server has this datapoint
+            # check if server has this data point
             for line in CHARTS[name][1]:
                 if line[0] in data:
                      content += "DIMENSION " + line[0] + " " + line[1] + "\n"
@@ -426,17 +426,17 @@ class Service(BaseService):
                 print(header)
                 print(content)
                 idx += 1
-    
+
         if idx == 0:
             return False
         return True
 
-    def update(self,interval):
+    def update(self, interval):
         data = self._get_data()
         if data is None:
             return False
         try:
-            data['Thread cache misses'] = int( int(data['Threads_created']) * 10000 / int(data['Connections']))
+            data['Thread cache misses'] = int(int(data['Threads_created']) * 10000 / int(data['Connections']))
         except Exception:
             pass
         for chart, dimensions in self.defs.items():
@@ -449,5 +449,5 @@ class Service(BaseService):
                     pass
             if len(lines) > 0:
                 print(header + lines + "END")
-        
+
         return True

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -1,31 +1,47 @@
+# Description: MySQL netdata python.d plugin
+# Author: Pawel Krupa (paulfantom)
+
 NAME = "mysql.chart.py"
-from sys import stderr
+import sys
+
+# import 3rd party library to handle MySQL communication
 try:
     import MySQLdb
-    stderr.write(NAME + ": using MySQLdb")
     # https://github.com/PyMySQL/mysqlclient-python
+    sys.stderr.write(NAME + ": using MySQLdb\n")
 except ImportError:
     try:
         import pymysql as MySQLdb
         # https://github.com/PyMySQL/PyMySQL
-        stderr.write(NAME + ": using pymysql")
+        sys.stderr.write(NAME + ": using pymysql\n")
     except ImportError:
-        stderr.write(NAME + ": You need to install PyMySQL module to use mysql.chart.py plugin\n")
+        sys.stderr.write(NAME + ": You need to install MySQLdb or PyMySQL module to use mysql.chart.py plugin\n")
+        raise ImportError
 
-config = [
-    {
-        'name'     : 'local',
+from base import BaseService
+
+# default configuration (overriden by python.d.plugin)
+# FIXME change password
+config = {
+    'local': {
         'user'     : 'root',
         'password' : '',
-        'socket'   : '/var/run/mysqld/mysqld.sock'
+        'socket'   : '/var/run/mysqld/mysqld.sock',
+        'update_every' : 3,
+        'retries'  : 4,
+        'priority' : 100
     }
-]
+}
 
+# default module values (can be overridden per job in `config`)
 update_every = 3
 priority = 90000
+retries = 7
 
-#query = "SHOW GLOBAL STATUS WHERE value REGEX '^[0-9]'"
+# query executed on MySQL server
 QUERY = "SHOW GLOBAL STATUS"
+
+# charts order (can be overriden if you want less charts, or different order)
 ORDER = ['net', 
          'queries', 
          'handlers', 
@@ -62,23 +78,32 @@ ORDER = ['net',
          'binlog_stmt_cache',
          'connection_errors']
 
+# charts definitions in format:
+# CHARTS = {
+#    'chart_name_in_netdata': (
+#        "parameters defining chart (passed to CHART statement)",
+#        [ # dimensions (lines) definitions
+#            ("dimension_name", "dimension parameters (passed to DIMENSION statement)", "additional parameter (optional)")
+#        ])
+#    }
+
 CHARTS = {
     'net' : (
         "'' 'mysql Bandwidth' 'kilobits/s' bandwidth mysql.net area",
-        (
+        [
             ("Bytes_received", "in incremental 8 1024"),
             ("Bytes_sent",     "out incremental -8 1024")
-        )),
+        ]),
     'queries' : (
         "'' 'mysql Queries' 'queries/s' queries mysql.queries line",
-        (
+        [
             ("Queries",      "queries incremental 1 1"),
             ("Questions",    "questions incremental 1 1"),
             ("Slow_queries", "slow_queries incremental -1 1")
-        )),
+        ]),
     'handlers' : (
         "'' 'mysql Handlers' 'handlers/s' handlers mysql.handlers line",
-        (
+        [
             ("Handler_commit", "commit incremental 1 1"),
             ("Handler_delete", "delete incremental 1 1"),
             ("Handler_prepare", "prepare incremental 1 1"),
@@ -93,316 +118,305 @@ CHARTS = {
             ("Handler_savepoint_rollback", "savepoint_rollback incremental 1 1"),
             ("Handler_update", "update incremental 1 1"),
             ("Handler_write", "write incremental 1 1")
-        )),
+        ]),
     'table_locks' : (
         "'' 'mysql Tables Locks' 'locks/s' locks mysql.table_locks line",
-        (
+        [
             ("Table_locks_immediate", "immediate incremental 1 1"),
             ("Table_locks_waited", "waited incremental -1 1")
-        )),
+        ]),
     'join_issues' : (
         "'' 'mysql Select Join Issues' 'joins/s' issues mysql.join_issues line",
-        (
+        [
             ("Select_full_join", "full_join incremental 1 1"),
             ("Select_full_range_join", "full_range_join incremental 1 1"),
             ("Select_range", "range incremental 1 1"),
             ("Select_range_check", "range_check incremental 1 1"),
             ("Select_scan", "scan incremental 1 1"),
-        )),
+        ]),
     'sort_issues' : (
         "'' 'mysql Sort Issues' 'issues/s' issues mysql.sort.issues line",
-        (
+        [
             ("Sort_merge_passes", "merge_passes incremental 1 1"),
             ("Sort_range", "range incremental 1 1"),
             ("Sort_scan", "scan incremental 1 1"),
-        )),
+        ]),
     'tmp' : (
         "'' 'mysql Tmp Operations' 'counter' temporaries mysql.tmp line",
-        (
+        [
             ("Created_tmp_disk_tables", "disk_tables incremental 1 1"),
             ("Created_tmp_files", "files incremental 1 1"),
             ("Created_tmp_tables", "tables incremental 1 1"),
-        )),
+        ]),
     'connections' : (
         "'' 'mysql Connections' 'connections/s' connections mysql.connections line",
-        (
+        [
             ("Connections", "all incremental 1 1"),
             ("Aborted_connects", "aborted incremental 1 1"),
-        )),
+        ]),
     'binlog_cache' : (
         "'' 'mysql Binlog Cache' 'transactions/s' binlog mysql.binlog_cache line",
-        (
+        [
             ("Binlog_cache_disk_use", "disk incremental 1 1"),
             ("Binlog_cache_use", "all incremental 1 1"),
-        )),
+        ]),
     'threads' : (
         "'' 'mysql Threads' 'threads' threads mysql.threads line",
-        (
+        [
             ("Threads_connected", "connected absolute 1 1"),
             ("Threads_created", "created incremental 1 1"),
             ("Threads_cached", "cached absolute -1 1"),
             ("Threads_running", "running absolute 1 1"),
-        )),
+        ]),
     'thread_cache_misses' : (
         "'' 'mysql Threads Cache Misses' 'misses' threads mysql.thread_cache_misses area",
-        (
+        [
             ("Thread_cache_misses", "misses misses absolute 1 100"),
-        )),
+        ]),
     'innodb_io' : (
         "'' 'mysql InnoDB I/O Bandwidth' 'kilobytes/s' innodb mysql.innodb_io area",
-        (
+        [
             ("Innodb_data_read", "read incremental 1 1024"),
             ("Innodb_data_written", "write incremental -1 1024"),
-        )),
+        ]),
     'innodb_io_ops' : (
         "'' 'mysql InnoDB I/O Operations' 'operations/s' innodb mysql.innodb_io_ops line",
-        (
+        [
             ("Innodb_data_reads", "reads incremental 1 1"),
             ("Innodb_data_writes", "writes incremental -1 1"),
             ("Innodb_data_fsyncs", "fsyncs incremental 1 1"),
-        )),
+        ]),
     'innodb_io_pending_ops' : (
         "'' 'mysql InnoDB Pending I/O Operations' 'operations' innodb mysql.innodb_io_pending_ops line",
-        (
+        [
             ("Innodb_data_pending_reads", "reads absolute 1 1"),
             ("Innodb_data_pending_writes", "writes absolute -1 1"),
             ("Innodb_data_pending_fsyncs", "fsyncs absolute 1 1"),
-        )),
+        ]),
     'innodb_log' : (
         "'' 'mysql InnoDB Log Operations' 'operations/s' innodb mysql.innodb_log line",
-        (
+        [
             ("Innodb_log_waits", "waits incremental 1 1"),
             ("Innodb_log_write_requests", "write_requests incremental -1 1"),
             ("Innodb_log_writes", "incremental -1 1"),
-        )),
+        ]),
     'innodb_os_log' : (
         "'' 'mysql InnoDB OS Log Operations' 'operations' innodb mysql.innodb_os_log line",
-        (
+        [
             ("Innodb_os_log_fsyncs", "fsyncs incremental 1 1"),
             ("Innodb_os_log_pending_fsyncs", "pending_fsyncs absolute 1 1"),
             ("Innodb_os_log_pending_writes", "pending_writes absolute -1 1"),
-        )),
+        ]),
     'innodb_os_log_io' : (
         "'' 'mysql InnoDB OS Log Bandwidth' 'kilobytes/s' innodb mysql.innodb_os_log_io area",
-        (
+        [
             ("Innodb_os_log_written", "write incremental -1 1024"),
-        )),
+        ]),
     'innodb_cur_row_lock' : (
         "'' 'mysql InnoDB Current Row Locks' 'operations' innodb mysql.innodb_cur_row_lock area",
-        (
+        [
             ("Innodb_row_lock_current_waits", "current_waits absolute 1 1"),
-        )),
+        ]),
     'innodb_rows' : (
         "'' 'mysql InnoDB Row Operations' 'operations/s' innodb mysql.innodb_rows area",
-        (
+        [
             ("Innodb_rows_inserted", "read incremental 1 1"),
             ("Innodb_rows_read", "deleted incremental -1 1"),
             ("Innodb_rows_updated", "inserted incremental 1 1"),
             ("Innodb_rows_deleted", "updated incremental -1 1"),
-        )),
+        ]),
     'innodb_buffer_pool_pages' : (
         "'' 'mysql InnoDB Buffer Pool Pages' 'pages' innodb mysql.innodb_buffer_pool_pages line",
-        (
+        [
             ("Innodb_buffer_pool_pages_data", "data absolute 1 1"),
             ("Innodb_buffer_pool_pages_dirty", "dirty absolute -1 1"),
             ("Innodb_buffer_pool_pages_free", "free absolute 1 1"),
             ("Innodb_buffer_pool_pages_flushed", "flushed incremental -1 1"),
             ("Innodb_buffer_pool_pages_misc", "misc absolute -1 1"),
             ("Innodb_buffer_pool_pages_total", "total absolute 1 1"),
-        )),
+        ]),
     'innodb_buffer_pool_bytes' : (
         "'' 'mysql InnoDB Buffer Pool Bytes' 'MB' innodb mysql.innodb_buffer_pool_bytes area",
-        (
+        [
             ("Innodb_buffer_pool_bytes_data", "data absolute 1"),
             ("Innodb_buffer_pool_bytes_dirty", "dirty absolute -1"),
-        )),
+        ]),
     'innodb_buffer_pool_read_ahead' : (
         "'' 'mysql InnoDB Buffer Pool Read Ahead' 'operations/s' innodb mysql.innodb_buffer_pool_read_ahead area",
-        (
+        [
             ("Innodb_buffer_pool_read_ahead", "all incremental 1 1"),
             ("Innodb_buffer_pool_read_ahead_evicted", "evicted incremental -1 1"),
             ("Innodb_buffer_pool_read_ahead_rnd", "random incremental 1 1"),
-        )),
+        ]),
     'innodb_buffer_pool_reqs' : (
         "'' 'mysql InnoDB Buffer Pool Requests' 'requests/s' innodb mysql.innodb_buffer_pool_reqs area",
-        (
+        [
             ("Innodb_buffer_pool_read_requests", "reads incremental 1 1"),
             ("Innodb_buffer_pool_write_requests", "writes incremental -1 1"),
-        )),
+        ]),
     'innodb_buffer_pool_ops' : (
         "'' 'mysql InnoDB Buffer Pool Operations' 'operations/s' innodb mysql.innodb_buffer_pool_ops area",
-        (
+        [
             ("Innodb_buffer_pool_reads", "'disk reads' incremental 1 1"),
             ("Innodb_buffer_pool_wait_free", "'wait free' incremental -1 1"),
-        )),
+        ]),
     'qcache_ops' : (
         "'' 'mysql QCache Operations' 'queries/s' qcache mysql.qcache_ops line",
-        (
+        [
             ("Qcache_hits", "hits incremental 1 1"),
             ("Qcache_lowmem_prunes", "'lowmem prunes' incremental -1 1"),
             ("Qcache_inserts", "inserts incremental 1 1"),
             ("Qcache_not_cached", "'not cached' incremental -1 1"),
-        )),
+        ]),
     'qcache' : (
         "'' 'mysql QCache Queries in Cache' 'queries' qcache mysql.qcache line",
-        (
+        [
             ("Qcache_queries_in_cache", "queries absolute 1 1"),
-        )),
+        ]),
     'qcache_freemem' : (
         "'' 'mysql QCache Free Memory' 'MB' qcache mysql.qcache_freemem area",
-        (
+        [
             ("Qcache_free_memory", "free absolute 1"),
-        )),
+        ]),
     'qcache_memblocks' : (
         "'' 'mysql QCache Memory Blocks' 'blocks' qcache mysql.qcache_memblocks line",
-        (
+        [
             ("Qcache_free_blocks", "free absolute 1"),
             ("Qcache_total_blocks", "total absolute 1 1"),
-        )),
+        ]),
     'key_blocks' : (
         "'' 'mysql MyISAM Key Cache Blocks' 'blocks' myisam mysql.key_blocks line",
-        (
+        [
             ("Key_blocks_unused", "unused absolute 1 1"),
             ("Key_blocks_used", "used absolute -1 1"),
             ("Key_blocks_not_flushed", "'not flushed' absolute 1 1"),
-        )),
+        ]),
     'key_requests' : (
         "'' 'mysql MyISAM Key Cache Requests' 'requests/s' myisam mysql.key_requests area",
-        (
+        [
             ("Key_read_requests", "reads incremental 1 1"),
             ("Key_write_requests", "writes incremental -1 1"),
-        )),
+        ]),
     'key_disk_ops' : (
         "'' 'mysql MyISAM Key Cache Disk Operations' 'operations/s' myisam mysql.key_disk_ops area",
-        (
+        [
             ("Key_reads", "reads incremental 1 1"),
             ("Key_writes", "writes incremental -1 1"),
-        )),
+        ]),
     'files' : (
         "'' 'mysql Open Files' 'files' files mysql.files line",
-        (
+        [
             ("Open_files", "files absolute 1 1"),
-        )),
+        ]),
     'files_rate' : (
         "'' 'mysql Opened Files Rate' 'files/s' files mysql.files_rate line",
-        (
+        [
             ("Opened_files", "files incremental 1 1"),
-        )),
+        ]),
     'binlog_stmt_cache' : (
         "'' 'mysql Binlog Statement Cache' 'statements/s' binlog mysql.binlog_stmt_cache line",
-        (
+        [
             ("Binlog_stmt_cache_disk_use", "disk incremental 1 1"),
             ("Binlog_stmt_cache_use", "all incremental 1 1"),
-        )),
+        ]),
     'connection_errors' : (
         "'' 'mysql Connection Errors' 'connections/s' connections mysql.connection_errors line",
-        (
+        [
             ("Connection_errors_accept", "accept incremental 1 1"),
             ("Connection_errors_internal", "internal incremental 1 1"),
             ("Connection_errors_max_connections", "max incremental 1 1"),
             ("Connection_errors_peer_address", "peer_addr incremental 1 1"),
             ("Connection_errors_select", "select incremental 1 1"),
             ("Connection_errors_tcpwrap", "tcpwrap incremental 1 1")
-        ))
+        ])
 }
-mysql_def = {}
-valid = []
-connections = {}
-
-def get_data(config):
-    global connections
-    try:
-        cnx = connections[config['name']]
-    except KeyError as e:
-        stderr.write(NAME + ": reconnecting\n")
-        cnx = MySQLdb.connect(user=config['user'],
-                              passwd=config['password'],
-                              read_default_file=config['my.cnf'],
-                              unix_socket=config['socket'],
-                              host=config['host'],
-                              port=config['port'],
-                              connect_timeout=int(update_every))
-        connections[config['name']] = cnx
-
-    try:
-        with cnx.cursor() as cursor:
-            cursor.execute(QUERY)
-            raw_data = cursor.fetchall()
-    except Exception as e:
-        stderr.write(NAME + ": cannot execute query." + str(e) + "\n")
-        cnx.close()
-        del connections[config['name']]
-        return None
-    
-    return dict(raw_data)
 
 
-def check():
-    # TODO what are the default credentials
-    global valid, config
-    if type(config) is str:
-        from json import loads
-        cfg = loads(config.replace("'",'"').replace('\n',' '))
-        config = cfg
-    for i in range(len(config)):
-        if 'name' not in config[i]:
-            config[i]['name'] = "srv_"+str(i)
-        if 'user' not in config[i]:
-            config[i]['user'] = 'root'
-        if 'password' not in config[i]:
-            config[i]['password'] = ''
-        if 'my.cnf' in config[i]:
-            config[i]['socket'] = ''
-            config[i]['host'] = ''
-            config[i]['port'] = 0
-        elif 'socket' in config[i]:
-            config[i]['my.cnf'] = ''
-            config[i]['host'] = ''
-            config[i]['port'] = 0
-        elif 'host' in config[i]:
-            config[i]['my.cnf'] = ''
-            config[i]['socket'] = ''
-            if 'port' in config[i]:
-                config[i]['port'] = int(config[i]['port'])
+class Service(BaseService):
+    def __init__(self,configuration=None,name=None):
+        super().__init__(configuration=configuration)
+        self.name = name
+        self.configuration = self._parse_config(configuration)
+        self.connection = None
+        self.defs = {}
+
+    def _parse_config(self,configuration):
+        # parse configuration to collect data from mysql server
+        if self.name is None:
+            self.name = 'local'
+        if 'user' not in configuration:
+            configuration['user'] = 'root'
+        if 'password' not in configuration:
+            configuration['password'] = ''
+        if 'my.cnf' in configuration:
+            configuration['socket'] = ''
+            configuration['host'] = ''
+            configuration['port'] = 0
+        elif 'socket' in configuration:
+            configuration['my.cnf'] = ''
+            configuration['host'] = ''
+            configuration['port'] = 0
+        elif 'host' in configuration:
+            configuration['my.cnf'] = ''
+            configuration['socket'] = ''
+            if 'port' in configuration:
+                configuration['port'] = int(configuration['port'])
             else:
-                config[i]['port'] = 3306
+                configuration['port'] = 3306
 
-    for srv in config:
+        return configuration
+
+    def _connect(self):
         try:
-            cnx = MySQLdb.connect(user=srv['user'],
-                                  passwd=srv['password'],
-                                  read_default_file=srv['my.cnf'],
-                                  unix_socket=srv['socket'],
-                                  host=srv['host'],
-                                  port=srv['port'],
-                                  connect_timeout=int(update_every))
-            cnx.close()
+            self.connection = MySQLdb.connect(user=self.configuration['user'],
+                                              passwd=self.configuration['password'],
+                                              read_default_file=self.configuration['my.cnf'],
+                                              unix_socket=self.configuration['socket'],
+                                              host=self.configuration['host'],
+                                              port=self.configuration['port'],
+                                              connect_timeout=self.configuration['update_every'])
         except Exception as e:
-            stderr.write(NAME + " has problem connecting to server: "+str(e).replace("\n"," ")+"\n")
-            config.remove(srv)
+            self.error(NAME + " has problem connecting to server:", e)
+            raise RuntimeError #stop creating module, need to catch it in supervisor
+    
+    def _get_data(self):
+        if self.connection is None:
+            self._connect()
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(QUERY)
+                raw_data = cursor.fetchall()
+        except Exception as e:
+            self.error(NAME + ": cannot execute query.", e)
+            self.connection.close()
+            self.connection = None
+            return None
+        
+        return dict(raw_data)
 
-    if len(config) == 0:
-        return False
-    return True
+    def check(self):
+        try:
+            self.connection = self._connect()
+            return True
+        except RuntimeError:
+            self.connection = None
+            return False
 
-
-def create():
-    global config, mysql_def
-    for name in ORDER:
-        mysql_def[name] = []
-        for line in CHARTS[name][1]:
-            mysql_def[name].append(line[0])
-
-    idx = 0
-    for srv in config:
-        data = get_data(srv)
+    def create(self):
+        for name in ORDER:
+            self.defs[name] = []
+            for line in CHARTS[name][1]:
+                self.defs[name].append(line[0])
+   
+        idx = 0
+        data = self._get_data()
         for name in ORDER:
             header = "CHART mysql_" + \
-                     str(srv['name']) + "." + \
+                     str(self.name) + "." + \
                      name + " " + \
                      CHARTS[name][0] + " " + \
-                     str(priority + idx) + " " + \
-                     str(update_every)
+                     str(self.priority + idx) + " " + \
+                     str(self.update_every)
             content = ""
             # check if server has this datapoint
             for line in CHARTS[name][1]:
@@ -412,26 +426,21 @@ def create():
                 print(header)
                 print(content)
                 idx += 1
+    
+        if idx == 0:
+            return False
+        return True
 
-    if idx == 0:
-        return False
-    return True
-
-
-def update(interval):
-    global config
-    for srv in config:
-        data = get_data(srv)
+    def update(self,interval):
+        data = self._get_data()
         if data is None:
-            config.remove(srv)
-            # TODO notify user about problems with server
-            continue
+            return False
         try:
             data['Thread cache misses'] = int( int(data['Threads_created']) * 10000 / int(data['Connections']))
         except Exception:
             pass
-        for chart, dimensions in mysql_def.items():
-            header = "BEGIN mysql_" + str(srv['name']) + "." + chart + " " + str(interval) + '\n'
+        for chart, dimensions in self.defs.items():
+            header = "BEGIN mysql_" + str(self.name) + "." + chart + " " + str(interval) + '\n'
             lines = ""
             for d in dimensions:
                 try:
@@ -440,7 +449,5 @@ def update(interval):
                     pass
             if len(lines) > 0:
                 print(header + lines + "END")
-            
-    if len(config) == 0:
-        return False 
-    return True
+        
+        return True

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -343,7 +343,11 @@ class Service(BaseService):
         self.defs = {}
 
     def _parse_config(self, configuration):
-        # parse configuration to collect data from mysql server
+        """
+        Parse configuration to collect data from MySQL server
+        :param configuration: dict
+        :return: dict
+        """
         if self.name is None:
             self.name = 'local'
         if 'user' not in configuration:
@@ -369,6 +373,9 @@ class Service(BaseService):
         return configuration
 
     def _connect(self):
+        """
+        Try to connect to MySQL server
+        """
         try:
             self.connection = MySQLdb.connect(user=self.configuration['user'],
                                               passwd=self.configuration['password'],
@@ -382,6 +389,10 @@ class Service(BaseService):
             raise RuntimeError
 
     def _get_data(self):
+        """
+        Get raw data from MySQL server
+        :return: dict
+        """
         if self.connection is None:
             try:
                 self._connect()
@@ -400,6 +411,10 @@ class Service(BaseService):
         return dict(raw_data)
 
     def check(self):
+        """
+        Check if service is able to connect to server
+        :return: boolean
+        """
         try:
             self.connection = self._connect()
             return True
@@ -408,6 +423,10 @@ class Service(BaseService):
             return False
 
     def create(self):
+        """
+        Create graphs
+        :return: boolean
+        """
         for name in ORDER:
             self.defs[name] = []
             for line in CHARTS[name][1]:
@@ -437,6 +456,11 @@ class Service(BaseService):
         return True
 
     def update(self, interval):
+        """
+        Update data on graphs
+        :param interval: int
+        :return: boolean
+        """
         data = self._get_data()
         if data is None:
             return False

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -336,8 +336,7 @@ CHARTS = {
 
 class Service(BaseService):
     def __init__(self, configuration=None, name=None):
-        super(self.__class__, self).__init__(configuration=configuration)
-        self.name = name
+        super(self.__class__, self).__init__(configuration=configuration, name=name)
         self.configuration = self._parse_config(configuration)
         self.connection = None
         self.defs = {}

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -398,9 +398,9 @@ class Service(BaseService):
             except RuntimeError:
                 return None
         try:
-            with self.connection.cursor() as cursor:
-                cursor.execute(QUERY)
-                raw_data = cursor.fetchall()
+            cursor = self.connection.cursor()
+            cursor.execute(QUERY)
+            raw_data = cursor.fetchall()
         except Exception as e:
             self.error(NAME + ": cannot execute query.", e)
             self.connection.close()
@@ -433,6 +433,8 @@ class Service(BaseService):
 
         idx = 0
         data = self._get_data()
+        if data is None:
+            return False
         for name in ORDER:
             header = "CHART mysql_" + \
                      str(self.name) + "." + \

--- a/python.d/pip_install.sh
+++ b/python.d/pip_install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PIP=`which pip`
+
+$PIP install --target="python_modules" yaml
+
+$PIP install --target="python_modules" MySQL-python || echo "You need to install libmysqlclient-dev and python-dev"

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -1,0 +1,52 @@
+# Description: base for netdata python.d plugins
+# Author: Pawel Krupa (paulfantom)
+
+from time import time
+import sys
+
+
+class BaseService(object):
+    def __init__(self,name=None,configuration=None):
+        if configuration is None:
+            self.error("BaseService: no configuration parameters supplied. Cannot create Service.")
+            raise RuntimeError
+        else:
+            self._extract_base_config(configuration)
+            self._create_timetable()
+            self.execution_name = ""
+
+    def _extract_base_config(self,config):
+        self.update_every = int(config['update_every'])
+        self.priority = int(config['priority'])
+        self.retries = int(config['retries'])
+        self.retries_left = self.retries
+
+    def _create_timetable(self,freq=None):
+        if freq is None:
+            freq = self.update_every
+        now = time()
+        self.timetable = {'last' : now,
+                          'next' : now - (now % freq) + freq,
+                          'freq' : freq}
+
+
+    def error(self, msg, exception=""):
+        if exception != "":
+            exception = " " + str(exception).replace("\n"," ")
+        sys.stderr.write(str(msg)+exception+"\n")
+        sys.stderr.flush()
+
+    def check(self):
+        # TODO notify about not overriden function
+        self.error("Where is your check()?")
+        return False
+
+    def create(self):
+        # TODO notify about not overriden function
+        self.error("Where is your create()?")
+        return False
+
+    def update(self):
+        # TODO notify about not overriden function
+        self.error("Where is your update()?")
+        return False

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -16,6 +16,7 @@ class BaseService(object):
         :param configuration: dict
         :param name: str
         """
+        self.name = name
         if configuration is None:
             self.error("BaseService: no configuration parameters supplied. Cannot create Service.")
             raise RuntimeError
@@ -23,7 +24,7 @@ class BaseService(object):
             self._extract_base_config(configuration)
             self.timetable = {}
             self.create_timetable()
-            self.execution_name = ""
+            self.chart_name = ""
 
     def _extract_base_config(self, config):
         """

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -38,16 +38,13 @@ class BaseService(object):
         sys.stderr.flush()
 
     def check(self):
-        # TODO notify about not overridden function
-        self.error("Where is your check()?")
+        self.error("Service " + str(self.__name__) + "doesn't implement check() function")
         return False
 
     def create(self):
-        # TODO notify about not overridden function
-        self.error("Where is your create()?")
+        self.error("Service " + str(self.__name__) + "doesn't implement create() function?")
         return False
 
     def update(self):
-        # TODO notify about not overridden function
-        self.error("Where is your update()?")
+        self.error("Service " + str(self.__name__) + "doesn't implement update() function")
         return False

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -6,7 +6,7 @@ import sys
 
 
 class BaseService(object):
-    def __init__(self, configuration=None):
+    def __init__(self, configuration=None, name=None):
         if configuration is None:
             self.error("BaseService: no configuration parameters supplied. Cannot create Service.")
             raise RuntimeError

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -6,7 +6,16 @@ import sys
 
 
 class BaseService(object):
+    """
+    Prototype of Service class.
+    Implemented basic functionality to run jobs by `python.d.plugin`
+    """
     def __init__(self, configuration=None, name=None):
+        """
+        This needs to be initialized in child classes
+        :param configuration: dict
+        :param name: str
+        """
         if configuration is None:
             self.error("BaseService: no configuration parameters supplied. Cannot create Service.")
             raise RuntimeError
@@ -17,12 +26,29 @@ class BaseService(object):
             self.execution_name = ""
 
     def _extract_base_config(self, config):
+        """
+        Get basic parameters to run service
+        Minimum config:
+            config = {'update_every':1,
+                      'priority':100000,
+                      'retries':0}
+        :param config: dict
+        """
         self.update_every = int(config['update_every'])
         self.priority = int(config['priority'])
         self.retries = int(config['retries'])
         self.retries_left = self.retries
 
     def create_timetable(self, freq=None):
+        """
+        Create service timetable.
+        `freq` is optional
+        Example:
+            timetable = {'last': 1466370091.3767564,
+                         'next': 1466370092,
+                         'freq': 1}
+        :param freq: int
+        """
         if freq is None:
             freq = self.update_every
         now = time()
@@ -38,13 +64,25 @@ class BaseService(object):
         sys.stderr.flush()
 
     def check(self):
+        """
+        check() prototype
+        :return: boolean
+        """
         self.error("Service " + str(self.__name__) + "doesn't implement check() function")
         return False
 
     def create(self):
+        """
+        create() prototype
+        :return: boolean
+        """
         self.error("Service " + str(self.__name__) + "doesn't implement create() function?")
         return False
 
     def update(self):
+        """
+        update() prototype
+        :return: boolean
+        """
         self.error("Service " + str(self.__name__) + "doesn't implement update() function")
         return False

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -6,47 +6,48 @@ import sys
 
 
 class BaseService(object):
-    def __init__(self,name=None,configuration=None):
+    def __init__(self, configuration=None):
         if configuration is None:
             self.error("BaseService: no configuration parameters supplied. Cannot create Service.")
             raise RuntimeError
         else:
             self._extract_base_config(configuration)
-            self._create_timetable()
+            self.timetable = {}
+            self.create_timetable()
             self.execution_name = ""
 
-    def _extract_base_config(self,config):
+    def _extract_base_config(self, config):
         self.update_every = int(config['update_every'])
         self.priority = int(config['priority'])
         self.retries = int(config['retries'])
         self.retries_left = self.retries
 
-    def _create_timetable(self,freq=None):
+    def create_timetable(self, freq=None):
         if freq is None:
             freq = self.update_every
         now = time()
-        self.timetable = {'last' : now,
-                          'next' : now - (now % freq) + freq,
-                          'freq' : freq}
+        self.timetable = {'last': now,
+                          'next': now - (now % freq) + freq,
+                          'freq': freq}
 
-
-    def error(self, msg, exception=""):
+    @staticmethod
+    def error(msg, exception=""):
         if exception != "":
             exception = " " + str(exception).replace("\n"," ")
         sys.stderr.write(str(msg)+exception+"\n")
         sys.stderr.flush()
 
     def check(self):
-        # TODO notify about not overriden function
+        # TODO notify about not overridden function
         self.error("Where is your check()?")
         return False
 
     def create(self):
-        # TODO notify about not overriden function
+        # TODO notify about not overridden function
         self.error("Where is your create()?")
         return False
 
     def update(self):
-        # TODO notify about not overriden function
+        # TODO notify about not overridden function
         self.error("Where is your update()?")
         return False


### PR DESCRIPTION
Effect of talks from #555.

Major changes:
- moved configuration schema to YAML so `pyyaml` is needed.
- modules present only definition of a service, `python.d.plugin` reads YAML configuration and runs as many jobs as needed.
- every Service class must be a child of BaseService. BaseService handles `update_every`, `retries`, `priority`, and dynamically created `timetable`.
- rewritten `mysql.chart.py` and `example.chart.py` to support those changes.

Minor changes:
- better handling of disabled modules
- probably some more, but I don't remember now

I have tested some cases, but probably not enough.