### PR TITLE
New collector for httpd mod_cache request ratio

### DIFF
--- a/charts.d/Makefile.am
+++ b/charts.d/Makefile.am
@@ -13,6 +13,7 @@ dist_charts_SCRIPTS = \
 	example.chart.sh \
 	exim.chart.sh \
 	hddtemp.chart.sh \
+	httpdmodcache.chart.sh \
 	load_average.chart.sh \
 	mem_apps.chart.sh \
 	mysql.chart.sh \

--- a/charts.d/README.md
+++ b/charts.d/README.md
@@ -215,6 +215,23 @@ hddtemp_disks=()
 
 ---
 
+# httpdmodcache
+
+The plugin will collect cache hit/miss ratios from Apache
+
+1. **percentage of requests served by mod_cache**
+
+### configuration
+
+the logfile needs to be readable by the netdata user.
+
+```sh
+# Apache log file with cache-status information
+httpdmodcache_logfile="/var/log/httpd/cache.log"
+```
+
+---
+
 # postfix
 
 The plugin will collect the postfix queue size.

--- a/charts.d/httpdmodcache.chart.sh
+++ b/charts.d/httpdmodcache.chart.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Adds graph with percentage count of traffic served through mod_cache. Will only
+# sample the last 10 000 log lines every `httpdmodcache_update_every`.
+#
+# In your configuration file, set `httpdmodcache_logfile` to a logfile containing
+# cache-status information from Apache. Make sure this file is readable by netdata.
+# See https://httpd.apache.org/docs/current/mod/mod_cache.html#status for details.
+
+httpdmodcache_logfile=""
+httpdmodcache_update_every=5
+httpdmodcache_priority=60000
+
+httpdmodcache_get_hitcount() {
+    tail --lines=10000 "$httpdmodcache_logfile" | grep --count "cache hit"  | tr -d "\n"
+}
+
+httpdmodcache_get_misscount() {
+    tail --lines=10000 "$httpdmodcache_logfile" | grep --count "cache miss" | tr -d "\n"
+}
+
+httpdmodcache_check() {
+	if [ ! -f "$httpdmodcache_logfile" ]
+	then
+		return 1
+	fi
+	return 0
+}
+
+httpdmodcache_create() {
+	# create the charts
+	cat <<EOF
+CHART httpdmodcache.cache '' "httpd cached responses" "percent cached" cached httpdmodcache.cache stacked $((httpdmodcache_priority + 1)) $((httpdmodcache_update_every))
+DIMENSION hit 'cache' percentage-of-absolute-row 1 1
+DIMENSION miss '' percentage-of-absolute-row 1 1
+EOF
+
+	return 0
+}
+
+httpdmodcache_update() {
+    LOCALE=C
+    local httpdmodcache_hitcount=$(httpdmodcache_get_hitcount)
+    local httpdmodcache_misscount=$(httpdmodcache_get_misscount)
+
+    # Variables only contains counts, so no need to escape them.
+    local httpdmodcache_total=$(echo "$httpdmodcache_hitcount + $httpdmodcache_misscount" | bc)
+    local httpdmodcache_hitperc=$(echo "scale=4; ($httpdmodcache_hitcount / $httpdmodcache_total) * 100" | bc | awk '{printf "%.2f", $0}')
+    local httpdmodcache_missperc=$(echo "scale=4; ($httpdmodcache_misscount / $httpdmodcache_total) * 100" | bc | awk '{printf "%.2f", $0}')
+
+    cat <<VALUESEOF
+BEGIN httpdmodcache.cache $1
+SET hit = $httpdmodcache_hitperc
+SET miss = $httpdmodcache_missperc
+END
+VALUESEOF
+
+    return 0
+}


### PR DESCRIPTION
Shows a stacked graph detailing which percentage of requests are served from httpd’s mod_cache (hits) or has to be sent upstream (misses).

Samples the last 10 000 lines from a given Apache log with [cache-status information](https://httpd.apache.org/docs/current/mod/mod_cache.html#status). (Information not exposed in Apache’s `/server-status` page.) Shown as percentage of last 10 000 requests rather than totals as it’s a metric where you’d only be interested in changes in trends.

Important metric to keep an eye on on slow VPS servers where upstream requests will be thousands of times slower to process than cached responses.

