### PR TITLE
Wrappers around charts creation + LogService

### DIFF
--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -10,6 +10,7 @@ dist_python_SCRIPTS = \
 	phpfpm.chart.py \
 	apache.chart.py \
 	nginx.chart.py \
+	apache_cache.chart.py \
 	python-modules-installer.sh \
 	$(NULL)
 

--- a/python.d/apache.chart.py
+++ b/python.d/apache.chart.py
@@ -71,7 +71,7 @@ class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
         if len(self.url) == 0:
-            self.url = "http://www.apache.org/server-status?auto"
+            self.url = "http://localhost/server-status?auto"
         self.order = ORDER
         self.definitions = CHARTS
         self.assignment = {"BytesPerReq": 'size_req',

--- a/python.d/apache.chart.py
+++ b/python.d/apache.chart.py
@@ -22,58 +22,47 @@ ORDER = ['requests', 'connections', 'conns_async', 'net', 'workers', 'reqpersec'
 
 CHARTS = {
     'bytesperreq': {
-        'options': "'' 'apache Lifetime Avg. Response Size' 'bytes/request' statistics apache.bytesperreq area",
+        'options': [None, 'apache Lifetime Avg. Response Size', 'bytes/request', 'statistics', 'apache.bytesperreq', 'area'],
         'lines': [
-            {"name": "size_req",
-             "options": "'' absolute 1 1"}
+            ["size_req"]
         ]},
     'workers': {
-        'options': "'' 'apache Workers' 'workers' workers apache.workers stacked",
+        'options': [None, 'apache Workers', 'workers', 'workers', 'apache.workers', 'stacked'],
         'lines': [
-            {"name": "idle",
-             "options": "'' absolute 1 1"},
-            {"name": "busy",
-             "options": "'' absolute 1 1"}
+            ["idle"],
+            ["busy"]
         ]},
     'reqpersec': {
-        'options': "'' 'apache Lifetime Avg. Requests/s' 'requests/s' statistics apache.reqpersec area",
+        'options': [None, 'apache Lifetime Avg. Requests/s', 'requests/s', 'statistics', 'apache.reqpersec', 'area'],
         'lines': [
-            {"name": "requests_sec",
-             "options": "'' absolute 1 1"}
+            ["requests_sec"]
         ]},
     'bytespersec': {
-        'options': "'' 'apache Lifetime Avg. Bandwidth/s' 'kilobytes/s' statistics apache.bytesperreq area",
+        'options': [None, 'apache Lifetime Avg. Bandwidth/s', 'kilobytes/s', 'statistics', 'apache.bytesperreq', 'area'],
         'lines': [
-            {"name": "size_sec",
-             "options": "'' absolute 1 1000"}
+            ["size_sec", None, 'absolute', 1, 1000]
         ]},
     'requests': {
-        'options': "'' 'apache Requests' 'requests/s' requests apache.requests line",
+        'options': [None, 'apache Requests', 'requests/s', 'requests', 'apache.requests', 'line'],
         'lines': [
-            {"name": "requests",
-             "options": "'' incremental 1 1"}
+            ["requests", None, 'incremental']
         ]},
     'net': {
-        'options': "'' 'apache Bandwidth' 'kilobytes/s' bandwidth apache.net area",
+        'options': [None, 'apache Bandwidth', 'kilobytes/s', 'bandwidth', 'apache.net', 'area'],
         'lines': [
-            {"name": "sent",
-             "options": "'' incremental 1 1"}
+            ["sent", None, 'incremental']
         ]},
     'connections': {
-        'options': "'' 'apache Connections' 'connections' connections apache.connections line",
+        'options': [None, 'apache Connections', 'connections', 'connections', 'apache.connections', 'line'],
         'lines': [
-            {"name": "connections",
-             "options": "'' absolute 1 1"}
+            ["connections"]
         ]},
     'conns_async': {
-        'options': "'' 'apache Async Connections' 'connections' connections apache.conns_async stacked",
+        'options': [None, 'apache Async Connections', 'connections', 'connections', 'apache.conns_async', 'stacked'],
         'lines': [
-            {"name": "keepalive",
-             "options": "'' absolute 1 1"},
-            {"name": "closing",
-             "options": "'' absolute 1 1"},
-            {"name": "writing",
-             "options": "'' absolute 1 1"}
+            ["keepalive"],
+            ["closing"],
+            ["writing"]
         ]}
 }
 
@@ -82,9 +71,9 @@ class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
         if len(self.url) == 0:
-            self.url = "http://localhost/server-status?auto"
+            self.url = "http://www.apache.org/server-status?auto"
         self.order = ORDER
-        self.charts = CHARTS
+        self.definitions = CHARTS
         self.assignment = {"BytesPerReq": 'size_req',
                            "IdleWorkers": 'idle',
                            "BusyWorkers": 'busy',

--- a/python.d/apache_cache.chart.py
+++ b/python.d/apache_cache.chart.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Description: apache cache netdata python.d plugin
+# Author: Pawel Krupa (paulfantom)
+
+from base import LogService
+
+priority = 60000
+retries = 5
+
+ORDER = ['cache']
+CHARTS = {
+    'cache': {
+        'options': [None, 'apache cached responses', 'percent cached', 'cached', 'apache_cache.cache', 'stacked'],
+        'lines': [
+            ["hit", 'cache', "percentage-of-absolute-row"],
+            ["miss", None, "percentage-of-absolute-row"]
+        ]}
+}
+
+
+class Service(LogService):
+    def __init__(self, configuration=None, name=None):
+        LogService.__init__(self, configuration=configuration, name=name)
+        if len(self.log_path) == 0:
+            self.log_path = "/var/log/httpd/cache.log"
+        self.order = ORDER
+        self.definitions = CHARTS
+
+    def _formatted_data(self):
+        """
+        Parse new log lines
+        :return: dict
+        """
+        try:
+            raw = self._get_data()
+        except (ValueError, AttributeError):
+            return None
+
+        hit = 0
+        miss = 0
+        for line in raw:
+            if "cache hit" in line:
+                hit += 1
+            elif "cache miss" in line:
+                miss += 1
+
+        if hit + miss == 0:
+            return None
+
+        return {'hit': int(hit/float(hit+miss) * 100),
+                'miss': int(miss/float(hit+miss) * 100)}

--- a/python.d/apache_cache.chart.py
+++ b/python.d/apache_cache.chart.py
@@ -41,7 +41,6 @@ class Service(LogService):
 
         hit = 0
         miss = 0
-
         for line in raw:
             if "cache hit" in line:
                 hit += 1
@@ -52,6 +51,5 @@ class Service(LogService):
         if total == 0:
             return None
 
-        hit_percent = int(hit/float(total) * 100)
-        return {'hit': hit_percent,
-                'miss': 100 - hit_percent}
+        return {'hit': int(hit/float(total) * 100),
+                'miss': int(miss/float(total) * 100)}

--- a/python.d/nginx.chart.py
+++ b/python.d/nginx.chart.py
@@ -22,34 +22,27 @@ ORDER = ['connections', 'requests', 'connection_status', 'connect_rate']
 
 CHARTS = {
     'connections': {
-        'options': "'' 'nginx Active Connections' 'connections' nginx nginx.connections line",
+        'options': [None, 'nginx Active Connections', 'connections', 'nginx', 'nginx.connections', 'line'],
         'lines': [
-            {"name": "active",
-             "options": "'' absolute 1 1"}
+            ["active"]
         ]},
     'requests': {
-        'options': "'' 'nginx Requests' 'requests/s' nginx nginx.requests line",
+        'options': [None, 'nginx Requests', 'requests/s', 'nginx', 'nginx.requests', 'line'],
         'lines': [
-            {"name": "requests",
-             "options": "'' incremental 1 1"}
+            ["requests", None, 'incremental']
         ]},
     'connection_status': {
-        'options': "'' 'nginx Active Connections by Status' 'connections' nginx nginx.connection.status line",
+        'options': [None, 'nginx Active Connections by Status', 'connections', 'nginx', 'nginx.connection.status', 'line'],
         'lines': [
-            {"name": "reading",
-             "options": "'' absolute 1 1"},
-            {"name": "writing",
-             "options": "'' absolute 1 1"},
-            {"name": "waiting",
-             "options": "idle absolute 1 1"}
+            ["reading"],
+            ["writing"],
+            ["waiting", "idle"]
         ]},
     'connect_rate': {
-        'options': "'' 'nginx Connections Rate' 'connections/s' nginx nginx.performance line",
+        'options': [None, 'nginx Connections Rate', 'connections/s', 'nginx', 'nginx.performance', 'line'],
         'lines': [
-            {"name": "accepts",
-             "options": "accepted incremental 1 1"},
-            {"name": "handled",
-             "options": "'' incremental 1 1"}
+            ["accepts", "accepted", "incremental"],
+            ["handled", None, "incremental"]
         ]}
 }
 
@@ -60,7 +53,7 @@ class Service(UrlService):
         if len(self.url) == 0:
             self.url = "http://localhost/stub_status"
         self.order = ORDER
-        self.charts = CHARTS
+        self.definitions = CHARTS
 
     def _formatted_data(self):
         """

--- a/python.d/phpfpm.chart.py
+++ b/python.d/phpfpm.chart.py
@@ -22,29 +22,22 @@ ORDER = ['connections', 'requests', 'performance']
 
 CHARTS = {
     'connections': {
-        'options': "'' 'PHP-FPM Active Connections' 'connections' phpfpm phpfpm.connections line",
+        'options': [None, 'PHP-FPM Active Connections', 'connections', 'phpfpm', 'phpfpm.connections', 'line'],
         'lines': [
-            {"name": "active",
-             "options": "'' absolute 1 1"},
-            {"name": "maxActive",
-             "options": "'max active' absolute 1 1"},
-            {"name": "idle",
-             "options": "'' absolute 1 1"}
+            ["active"],
+            ["maxActive", 'max active'],
+            ["idle"]
         ]},
     'requests': {
-        'options': "'' 'PHP-FPM Requests' 'requests/s' phpfpm phpfpm.requests line",
+        'options': [None, 'PHP-FPM Requests', 'requests/s', 'phpfpm', 'phpfpm.requests', 'line'],
         'lines': [
-            {"name": "requests",
-             "options": "'' incremental 1 1"}
+            ["requests", None, "incremental"]
         ]},
     'performance': {
-
-        'options': "'' 'PHP-FPM Performance' 'status' phpfpm phpfpm.performance line",
+        'options': [None, 'PHP-FPM Performance', 'status', 'phpfpm', 'phpfpm.performance', 'line'],
         'lines': [
-            {"name": "reached",
-             "options": "'max children reached' absolute 1 1"},
-            {"name": "slow",
-             "options": "'slow requests' absolute 1 1"}
+            ["reached", 'max children reached'],
+            ["slow", 'slow requests']
         ]}
 }
 
@@ -55,7 +48,7 @@ class Service(UrlService):
         if len(self.url) == 0:
             self.url = "http://localhost/status"
         self.order = ORDER
-        self.charts = CHARTS
+        self.definitions = CHARTS
         self.assignment = {"active processes": 'active',
                            "max active processes": 'maxActive',
                            "idle processes": 'idle',

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -437,16 +437,20 @@ class LogService(SimpleService):
         #    self._log_reader = Popen(['tail', '-F', self.log_path], stdout=PIPE, stderr=STDOUT)
         lines = []
         last = 0
+        total = 0
         try:
             with open(self.log_path) as fp:
                 for i, line in enumerate(fp):
                     if i > self._last_line:
                         lines.append(line)
                         last = i
+                    total += 1
         except Exception as e:
             msg.error(self.__module__, str(e))
         if last != 0:
             self._last_line = last
+        elif self._last_line > total:
+            self._last_line = 0
 
         if len(lines) != 0:
             return lines

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -453,16 +453,14 @@ class LogService(SimpleService):
         return None
 
     def check(self):
-        if self.name is None or self.name == str(None):
-            self.error("Log service doesn't have name.")
-            return False
+        if self.name is not None or self.name != str(None):
+            self.name = ""
         else:
             self.name = str(self.name)
         try:
             self.log_path = str(self.configuration['path'])
         except (KeyError, TypeError):
-            self.error("Malformed path to log: '" + self.log_path + "'")
-            return False
+            self.error("No path to log specified. Using: '" + self.log_path + "'")
 
         # FIXME Remove preventing of frequent log parsing
         if self.update_every < 3:
@@ -471,5 +469,5 @@ class LogService(SimpleService):
         if os.access(self.log_path, os.R_OK):
             return True
         else:
-            self.error("Cannot access file. No read permission.")
+            self.error("Cannot access file: '" + self.log_path + "'")
             return False

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -295,25 +295,10 @@ class BaseService(threading.Thread):
         return False
 
 
-class UrlService(BaseService):
+class SimpleService(BaseService):
     def __init__(self, configuration=None, name=None):
-        self.charts = {}
-        # charts definitions in format:
-        # charts = {
-        #    'chart_name_in_netdata': {
-        #        'options': "parameters defining chart (passed to CHART statement)",
-        #        'lines': [
-        #           { 'name': 'dimension_name',
-        #             'options': 'dimension parameters (passed to DIMENSION statement)"
-        #           }
-        #        ]}
-        #    }
         self.order = []
         self.definitions = {}
-        # definitions are created dynamically in create() method based on 'charts' dictionary. format:
-        # definitions = {
-        #     'chart_name_in_netdata' : [ charts['chart_name_in_netdata']['lines']['name'] ]
-        # }
         self.url = ""
         BaseService.__init__(self, configuration=configuration, name=name)
 
@@ -322,18 +307,7 @@ class UrlService(BaseService):
         Get raw data from http request
         :return: str
         """
-        raw = None
-        try:
-            f = urlopen(self.url, timeout=self.update_every)
-            raw = f.read().decode('utf-8')
-        except Exception as e:
-            msg.error(self.__module__, str(e))
-        finally:
-            try:
-                f.close()
-            except:
-                pass
-        return raw
+        return ""
 
     def _formatted_data(self):
         """
@@ -407,3 +381,31 @@ class UrlService(BaseService):
         self.commit()
 
         return updated
+
+
+class UrlService(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        # definitions are created dynamically in create() method based on 'charts' dictionary. format:
+        # definitions = {
+        #     'chart_name_in_netdata' : [ charts['chart_name_in_netdata']['lines']['name'] ]
+        # }
+        self.url = ""
+        SimpleService.__init__(self, configuration=configuration, name=name)
+
+    def _get_data(self):
+        """
+        Get raw data from http request
+        :return: str
+        """
+        raw = None
+        try:
+            f = urlopen(self.url, timeout=self.update_every)
+            raw = f.read().decode('utf-8')
+        except Exception as e:
+            msg.error(self.__module__, str(e))
+        finally:
+            try:
+                f.close()
+            except:
+                pass
+        return raw

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -299,7 +299,6 @@ class SimpleService(BaseService):
     def __init__(self, configuration=None, name=None):
         self.order = []
         self.definitions = {}
-        self.url = ""
         BaseService.__init__(self, configuration=configuration, name=name)
 
     def _get_data(self):
@@ -315,25 +314,6 @@ class SimpleService(BaseService):
         :return: dict
         """
         return {}
-
-    def check(self):
-        """
-        Format configuration data and try to connect to server
-        :return: boolean
-        """
-        if self.name is None or self.name == str(None):
-            self.name = 'local'
-        else:
-            self.name = str(self.name)
-        try:
-            self.url = str(self.configuration['url'])
-        except (KeyError, TypeError):
-            pass
-
-        if self._formatted_data() is not None:
-            return True
-        else:
-            return False
 
     def create(self):
         """
@@ -409,3 +389,22 @@ class UrlService(SimpleService):
             except:
                 pass
         return raw
+
+    def check(self):
+        """
+        Format configuration data and try to connect to server
+        :return: boolean
+        """
+        if self.name is None or self.name == str(None):
+            self.name = 'local'
+        else:
+            self.name = str(self.name)
+        try:
+            self.url = str(self.configuration['url'])
+        except (KeyError, TypeError):
+            pass
+
+        if self._formatted_data() is not None:
+            return True
+        else:
+            return False

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -315,6 +315,12 @@ class SimpleService(BaseService):
         """
         return {}
 
+    def check(self):
+        """
+        :return:
+        """
+        return True
+
     def create(self):
         """
         Create charts


### PR DESCRIPTION
Rewritten `nginx`, `phpfpm` and `apache` modules to use wrappers on chart creation (methods: `chart`,  `dimension`, `begin`, `set`, `end`).

Created intermediate class `SimpleService` which is now a base for `UrlService`.
As requested in #628, new `LogService` prototype was created which is also a child of `SimpleService`
Wrote new `apache_cache` module to parse apache mod_cache log file.

I have done some basic test, but not on `apache_cache`. Probably needs some more testing, which I will do when I find some time.
