### PR TITLE
Simplify mysql.chart.py

### DIFF
--- a/python.d/apache.chart.py
+++ b/python.d/apache.chart.py
@@ -86,7 +86,7 @@ class Service(UrlService):
                            "ConnsAsyncClosing": 'closing',
                            "ConnsAsyncWriting": 'writing'}
 
-    def _formatted_data(self):
+    def _format_data(self):
         """
         Format data received from http request
         :return: dict

--- a/python.d/apache_cache.chart.py
+++ b/python.d/apache_cache.chart.py
@@ -28,7 +28,7 @@ class Service(LogService):
         self.order = ORDER
         self.definitions = CHARTS
 
-    def _formatted_data(self):
+    def _format_data(self):
         """
         Parse new log lines
         :return: dict

--- a/python.d/apache_cache.chart.py
+++ b/python.d/apache_cache.chart.py
@@ -14,7 +14,8 @@ CHARTS = {
         'options': [None, 'apache cached responses', 'percent cached', 'cached', 'apache_cache.cache', 'stacked'],
         'lines': [
             ["hit", 'cache', "percentage-of-absolute-row"],
-            ["miss", None, "percentage-of-absolute-row"]
+            ["miss", None, "percentage-of-absolute-row"],
+            ["other", None, "percentage-of-absolute-row"]
         ]}
 }
 
@@ -41,11 +42,15 @@ class Service(LogService):
 
         hit = 0
         miss = 0
+        other = 0
         for line in raw:
             if "cache hit" in line:
                 hit += 1
             elif "cache miss" in line:
                 miss += 1
+            else:
+                other += 1
 
         return {'hit': hit,
-                'miss': miss}
+                'miss': miss,
+                'other': other}

--- a/python.d/apache_cache.chart.py
+++ b/python.d/apache_cache.chart.py
@@ -47,9 +47,5 @@ class Service(LogService):
             elif "cache miss" in line:
                 miss += 1
 
-        total = hit + miss
-        if total == 0:
-            return None
-
-        return {'hit': int(hit/float(total) * 100),
-                'miss': int(miss/float(total) * 100)}
+        return {'hit': hit,
+                'miss': miss}

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -153,8 +153,8 @@ CHARTS = {
             ["Innodb_data_written", "write", "incremental", -1, 1024]
         ]},
     'innodb_io_ops': {
-        'lines': [None, 'mysql InnoDB I/O Operations', 'operations/s', 'innodb', 'mysql.innodb_io_ops', 'line'],
-        'options': [
+        'options': [None, 'mysql InnoDB I/O Operations', 'operations/s', 'innodb', 'mysql.innodb_io_ops', 'line'],
+        'lines': [
             ["Innodb_data_reads", "reads"],
             ["Innodb_data_writes", "writes", "incremental", -1, 1],
             ["Innodb_data_fsyncs", "fsyncs"]
@@ -358,7 +358,7 @@ class Service(SimpleService):
             self.error(NAME + " has problem connecting to server:", e)
             raise RuntimeError
 
-    def _get_data(self):
+    def _format_data(self):
         """
         Get raw data from MySQL server
         :return: dict
@@ -380,9 +380,6 @@ class Service(SimpleService):
 
         return dict(raw_data)
 
-    def _formatted_data(self):
-        return self._get_data()
-
     def check(self):
         """
         Check if service is able to connect to server
@@ -394,64 +391,3 @@ class Service(SimpleService):
         except RuntimeError:
             self.connection = None
             return False
-
-    # def create(self):
-    #     """
-    #     Create graphs
-    #     :return: boolean
-    #     """
-    #     for name in ORDER:
-    #         self.defs[name] = []
-    #         for line in CHARTS[name][1]:
-    #             self.defs[name].append(line[0])
-    #
-    #     idx = 0
-    #     data = self._get_data()
-    #     if data is None:
-    #         return False
-    #     for name in ORDER:
-    #         header = "CHART mysql_" + \
-    #                  str(self.name) + "." + \
-    #                  name + " " + \
-    #                  CHARTS[name][0] + " " + \
-    #                  str(self.priority + idx) + " " + \
-    #                  str(self.update_every)
-    #         content = ""
-    #         # check if server has this data point
-    #         for line in CHARTS[name][1]:
-    #             if line[0] in data:
-    #                 content += "DIMENSION " + line[0] + " " + line[1] + "\n"
-    #         if len(content) > 0:
-    #             print(header)
-    #             print(content)
-    #             idx += 1
-    #
-    #     if idx == 0:
-    #         return False
-    #     return True
-    #
-    # def update(self, interval):
-    #     """
-    #     Update data on graphs
-    #     :param interval: int
-    #     :return: boolean
-    #     """
-    #     data = self._get_data()
-    #     if data is None:
-    #         return False
-    #     try:
-    #         data['Thread cache misses'] = int(int(data['Threads_created']) * 10000 / int(data['Connections']))
-    #     except Exception:
-    #         pass
-    #     for chart, dimensions in self.defs.items():
-    #         header = "BEGIN mysql_" + str(self.name) + "." + chart + " " + str(interval) + '\n'
-    #         lines = ""
-    #         for d in dimensions:
-    #             try:
-    #                 lines += "SET " + d + " = " + data[d] + '\n'
-    #             except KeyError:
-    #                 pass
-    #         if len(lines) > 0:
-    #             print(header + lines + "END")
-    #
-    #     return True

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -3,8 +3,8 @@
 # Author: Pawel Krupa (paulfantom)
 
 import os
-import sys
-from base import BaseService
+from base import SimpleService
+import msg
 
 NAME = os.path.basename(__file__).replace(".chart.py", "")
 
@@ -13,15 +13,15 @@ try:
     import MySQLdb
 
     # https://github.com/PyMySQL/mysqlclient-python
-    sys.stderr.write(NAME + ": using MySQLdb\n")
+    msg.info("using MySQLdb")
 except ImportError:
     try:
         import pymysql as MySQLdb
 
         # https://github.com/PyMySQL/PyMySQL
-        sys.stderr.write(NAME + ": using pymysql\n")
+        msg.info("using pymysql")
     except ImportError:
-        sys.stderr.write(NAME + ": You need to install MySQLdb or PyMySQL module to use mysql.chart.py plugin\n")
+        msg.error("MySQLdb or PyMySQL module is needed to use mysql.chart.py plugin")
         raise ImportError
 
 # default module values (can be overridden per job in `config`)
@@ -44,303 +44,275 @@ config = {
 # query executed on MySQL server
 QUERY = "SHOW GLOBAL STATUS"
 
-# charts order (can be overridden if you want less charts, or different order)
 ORDER = ['net',
          'queries',
          'handlers',
          'table_locks',
-         'join_issues',
-         'sort_issues',
+         'join_issues', 'sort_issues',
          'tmp',
-         'connections',
-         'binlog_cache',
-         'threads',
-         'thread_cache_misses',
-         'innodb_io',
-         'innodb_io_ops',
-         'innodb_io_pending_ops',
-         'innodb_log',
-         'innodb_os_log',
-         'innodb_os_log_io',
-         'innodb_cur_row_lock',
-         'innodb_rows',
-         'innodb_buffer_pool_pages',
-         'innodb_buffer_pool_bytes',
-         'innodb_buffer_pool_read_ahead',
-         'innodb_buffer_pool_reqs',
-         'innodb_buffer_pool_ops',
-         'qcache_ops',
-         'qcache',
-         'qcache_freemem',
-         'qcache_memblocks',
-         'key_blocks',
-         'key_requests',
-         'key_disk_ops',
-         'files',
-         'files_rate',
-         'binlog_stmt_cache',
-         'connection_errors']
-
-# charts definitions in format:
-# CHARTS = {
-#    'chart_name_in_netdata': (
-#        "parameters defining chart (passed to CHART statement)",
-#        [ # dimensions (lines) definitions
-#            ("dimension_name", "dimension parameters (passed to DIMENSION statement)")
-#        ])
-#    }
+         'connections', 'connection_errors',
+         'binlog_cache', 'binlog_stmt_cache',
+         'threads', 'thread_cache_misses',
+         'innodb_io', 'innodb_io_ops', 'innodb_io_pending_ops', 'innodb_log', 'innodb_os_log', 'innodb_os_log_io',
+         'innodb_cur_row_lock', 'innodb_rows', 'innodb_buffer_pool_pages', 'innodb_buffer_pool_bytes',
+         'innodb_buffer_pool_read_ahead', 'innodb_buffer_pool_reqs', 'innodb_buffer_pool_ops',
+         'qcache_ops', 'qcache', 'qcache_freemem', 'qcache_memblocks',
+         'key_blocks', 'key_requests', 'key_disk_ops',
+         'files', 'files_rate']
 
 CHARTS = {
-    'net': (
-        "'' 'mysql Bandwidth' 'kilobits/s' bandwidth mysql.net area",
-        [
-            ("Bytes_received", "in incremental 8 1024"),
-            ("Bytes_sent", "out incremental -8 1024")
-        ]),
-    'queries': (
-        "'' 'mysql Queries' 'queries/s' queries mysql.queries line",
-        [
-            ("Queries", "queries incremental 1 1"),
-            ("Questions", "questions incremental 1 1"),
-            ("Slow_queries", "slow_queries incremental -1 1")
-        ]),
-    'handlers': (
-        "'' 'mysql Handlers' 'handlers/s' handlers mysql.handlers line",
-        [
-            ("Handler_commit", "commit incremental 1 1"),
-            ("Handler_delete", "delete incremental 1 1"),
-            ("Handler_prepare", "prepare incremental 1 1"),
-            ("Handler_read_first", "read_first incremental 1 1"),
-            ("Handler_read_key", "read_key incremental 1 1"),
-            ("Handler_read_next", "read_next incremental 1 1"),
-            ("Handler_read_prev", "read_prev incremental 1 1"),
-            ("Handler_read_rnd", "read_rnd incremental 1 1"),
-            ("Handler_read_rnd_next", "read_rnd_next incremental 1 1"),
-            ("Handler_rollback", "rollback incremental 1 1"),
-            ("Handler_savepoint", "savepoint incremental 1 1"),
-            ("Handler_savepoint_rollback", "savepoint_rollback incremental 1 1"),
-            ("Handler_update", "update incremental 1 1"),
-            ("Handler_write", "write incremental 1 1")
-        ]),
-    'table_locks': (
-        "'' 'mysql Tables Locks' 'locks/s' locks mysql.table_locks line",
-        [
-            ("Table_locks_immediate", "immediate incremental 1 1"),
-            ("Table_locks_waited", "waited incremental -1 1")
-        ]),
-    'join_issues': (
-        "'' 'mysql Select Join Issues' 'joins/s' issues mysql.join_issues line",
-        [
-            ("Select_full_join", "full_join incremental 1 1"),
-            ("Select_full_range_join", "full_range_join incremental 1 1"),
-            ("Select_range", "range incremental 1 1"),
-            ("Select_range_check", "range_check incremental 1 1"),
-            ("Select_scan", "scan incremental 1 1"),
-        ]),
-    'sort_issues': (
-        "'' 'mysql Sort Issues' 'issues/s' issues mysql.sort.issues line",
-        [
-            ("Sort_merge_passes", "merge_passes incremental 1 1"),
-            ("Sort_range", "range incremental 1 1"),
-            ("Sort_scan", "scan incremental 1 1"),
-        ]),
-    'tmp': (
-        "'' 'mysql Tmp Operations' 'counter' temporaries mysql.tmp line",
-        [
-            ("Created_tmp_disk_tables", "disk_tables incremental 1 1"),
-            ("Created_tmp_files", "files incremental 1 1"),
-            ("Created_tmp_tables", "tables incremental 1 1"),
-        ]),
-    'connections': (
-        "'' 'mysql Connections' 'connections/s' connections mysql.connections line",
-        [
-            ("Connections", "all incremental 1 1"),
-            ("Aborted_connects", "aborted incremental 1 1"),
-        ]),
-    'binlog_cache': (
-        "'' 'mysql Binlog Cache' 'transactions/s' binlog mysql.binlog_cache line",
-        [
-            ("Binlog_cache_disk_use", "disk incremental 1 1"),
-            ("Binlog_cache_use", "all incremental 1 1"),
-        ]),
-    'threads': (
-        "'' 'mysql Threads' 'threads' threads mysql.threads line",
-        [
-            ("Threads_connected", "connected absolute 1 1"),
-            ("Threads_created", "created incremental 1 1"),
-            ("Threads_cached", "cached absolute -1 1"),
-            ("Threads_running", "running absolute 1 1"),
-        ]),
-    'thread_cache_misses': (
-        "'' 'mysql Threads Cache Misses' 'misses' threads mysql.thread_cache_misses area",
-        [
-            ("Thread_cache_misses", "misses misses absolute 1 100"),
-        ]),
-    'innodb_io': (
-        "'' 'mysql InnoDB I/O Bandwidth' 'kilobytes/s' innodb mysql.innodb_io area",
-        [
-            ("Innodb_data_read", "read incremental 1 1024"),
-            ("Innodb_data_written", "write incremental -1 1024"),
-        ]),
-    'innodb_io_ops': (
-        "'' 'mysql InnoDB I/O Operations' 'operations/s' innodb mysql.innodb_io_ops line",
-        [
-            ("Innodb_data_reads", "reads incremental 1 1"),
-            ("Innodb_data_writes", "writes incremental -1 1"),
-            ("Innodb_data_fsyncs", "fsyncs incremental 1 1"),
-        ]),
-    'innodb_io_pending_ops': (
-        "'' 'mysql InnoDB Pending I/O Operations' 'operations' innodb mysql.innodb_io_pending_ops line",
-        [
-            ("Innodb_data_pending_reads", "reads absolute 1 1"),
-            ("Innodb_data_pending_writes", "writes absolute -1 1"),
-            ("Innodb_data_pending_fsyncs", "fsyncs absolute 1 1"),
-        ]),
-    'innodb_log': (
-        "'' 'mysql InnoDB Log Operations' 'operations/s' innodb mysql.innodb_log line",
-        [
-            ("Innodb_log_waits", "waits incremental 1 1"),
-            ("Innodb_log_write_requests", "write_requests incremental -1 1"),
-            ("Innodb_log_writes", "incremental -1 1"),
-        ]),
-    'innodb_os_log': (
-        "'' 'mysql InnoDB OS Log Operations' 'operations' innodb mysql.innodb_os_log line",
-        [
-            ("Innodb_os_log_fsyncs", "fsyncs incremental 1 1"),
-            ("Innodb_os_log_pending_fsyncs", "pending_fsyncs absolute 1 1"),
-            ("Innodb_os_log_pending_writes", "pending_writes absolute -1 1"),
-        ]),
-    'innodb_os_log_io': (
-        "'' 'mysql InnoDB OS Log Bandwidth' 'kilobytes/s' innodb mysql.innodb_os_log_io area",
-        [
-            ("Innodb_os_log_written", "write incremental -1 1024"),
-        ]),
-    'innodb_cur_row_lock': (
-        "'' 'mysql InnoDB Current Row Locks' 'operations' innodb mysql.innodb_cur_row_lock area",
-        [
-            ("Innodb_row_lock_current_waits", "current_waits absolute 1 1"),
-        ]),
-    'innodb_rows': (
-        "'' 'mysql InnoDB Row Operations' 'operations/s' innodb mysql.innodb_rows area",
-        [
-            ("Innodb_rows_inserted", "read incremental 1 1"),
-            ("Innodb_rows_read", "deleted incremental -1 1"),
-            ("Innodb_rows_updated", "inserted incremental 1 1"),
-            ("Innodb_rows_deleted", "updated incremental -1 1"),
-        ]),
-    'innodb_buffer_pool_pages': (
-        "'' 'mysql InnoDB Buffer Pool Pages' 'pages' innodb mysql.innodb_buffer_pool_pages line",
-        [
-            ("Innodb_buffer_pool_pages_data", "data absolute 1 1"),
-            ("Innodb_buffer_pool_pages_dirty", "dirty absolute -1 1"),
-            ("Innodb_buffer_pool_pages_free", "free absolute 1 1"),
-            ("Innodb_buffer_pool_pages_flushed", "flushed incremental -1 1"),
-            ("Innodb_buffer_pool_pages_misc", "misc absolute -1 1"),
-            ("Innodb_buffer_pool_pages_total", "total absolute 1 1"),
-        ]),
-    'innodb_buffer_pool_bytes': (
-        "'' 'mysql InnoDB Buffer Pool Bytes' 'MB' innodb mysql.innodb_buffer_pool_bytes area",
-        [
-            ("Innodb_buffer_pool_bytes_data", "data absolute 1"),
-            ("Innodb_buffer_pool_bytes_dirty", "dirty absolute -1"),
-        ]),
-    'innodb_buffer_pool_read_ahead': (
-        "'' 'mysql InnoDB Buffer Pool Read Ahead' 'operations/s' innodb mysql.innodb_buffer_pool_read_ahead area",
-        [
-            ("Innodb_buffer_pool_read_ahead", "all incremental 1 1"),
-            ("Innodb_buffer_pool_read_ahead_evicted", "evicted incremental -1 1"),
-            ("Innodb_buffer_pool_read_ahead_rnd", "random incremental 1 1"),
-        ]),
-    'innodb_buffer_pool_reqs': (
-        "'' 'mysql InnoDB Buffer Pool Requests' 'requests/s' innodb mysql.innodb_buffer_pool_reqs area",
-        [
-            ("Innodb_buffer_pool_read_requests", "reads incremental 1 1"),
-            ("Innodb_buffer_pool_write_requests", "writes incremental -1 1"),
-        ]),
-    'innodb_buffer_pool_ops': (
-        "'' 'mysql InnoDB Buffer Pool Operations' 'operations/s' innodb mysql.innodb_buffer_pool_ops area",
-        [
-            ("Innodb_buffer_pool_reads", "'disk reads' incremental 1 1"),
-            ("Innodb_buffer_pool_wait_free", "'wait free' incremental -1 1"),
-        ]),
-    'qcache_ops': (
-        "'' 'mysql QCache Operations' 'queries/s' qcache mysql.qcache_ops line",
-        [
-            ("Qcache_hits", "hits incremental 1 1"),
-            ("Qcache_lowmem_prunes", "'lowmem prunes' incremental -1 1"),
-            ("Qcache_inserts", "inserts incremental 1 1"),
-            ("Qcache_not_cached", "'not cached' incremental -1 1"),
-        ]),
-    'qcache': (
-        "'' 'mysql QCache Queries in Cache' 'queries' qcache mysql.qcache line",
-        [
-            ("Qcache_queries_in_cache", "queries absolute 1 1"),
-        ]),
-    'qcache_freemem': (
-        "'' 'mysql QCache Free Memory' 'MB' qcache mysql.qcache_freemem area",
-        [
-            ("Qcache_free_memory", "free absolute 1"),
-        ]),
-    'qcache_memblocks': (
-        "'' 'mysql QCache Memory Blocks' 'blocks' qcache mysql.qcache_memblocks line",
-        [
-            ("Qcache_free_blocks", "free absolute 1"),
-            ("Qcache_total_blocks", "total absolute 1 1"),
-        ]),
-    'key_blocks': (
-        "'' 'mysql MyISAM Key Cache Blocks' 'blocks' myisam mysql.key_blocks line",
-        [
-            ("Key_blocks_unused", "unused absolute 1 1"),
-            ("Key_blocks_used", "used absolute -1 1"),
-            ("Key_blocks_not_flushed", "'not flushed' absolute 1 1"),
-        ]),
-    'key_requests': (
-        "'' 'mysql MyISAM Key Cache Requests' 'requests/s' myisam mysql.key_requests area",
-        [
-            ("Key_read_requests", "reads incremental 1 1"),
-            ("Key_write_requests", "writes incremental -1 1"),
-        ]),
-    'key_disk_ops': (
-        "'' 'mysql MyISAM Key Cache Disk Operations' 'operations/s' myisam mysql.key_disk_ops area",
-        [
-            ("Key_reads", "reads incremental 1 1"),
-            ("Key_writes", "writes incremental -1 1"),
-        ]),
-    'files': (
-        "'' 'mysql Open Files' 'files' files mysql.files line",
-        [
-            ("Open_files", "files absolute 1 1"),
-        ]),
-    'files_rate': (
-        "'' 'mysql Opened Files Rate' 'files/s' files mysql.files_rate line",
-        [
-            ("Opened_files", "files incremental 1 1"),
-        ]),
-    'binlog_stmt_cache': (
-        "'' 'mysql Binlog Statement Cache' 'statements/s' binlog mysql.binlog_stmt_cache line",
-        [
-            ("Binlog_stmt_cache_disk_use", "disk incremental 1 1"),
-            ("Binlog_stmt_cache_use", "all incremental 1 1"),
-        ]),
-    'connection_errors': (
-        "'' 'mysql Connection Errors' 'connections/s' connections mysql.connection_errors line",
-        [
-            ("Connection_errors_accept", "accept incremental 1 1"),
-            ("Connection_errors_internal", "internal incremental 1 1"),
-            ("Connection_errors_max_connections", "max incremental 1 1"),
-            ("Connection_errors_peer_address", "peer_addr incremental 1 1"),
-            ("Connection_errors_select", "select incremental 1 1"),
-            ("Connection_errors_tcpwrap", "tcpwrap incremental 1 1")
-        ])
+    'net': {
+        'options': [None, 'mysql Bandwidth', 'kilobits/s', 'bandwidth', 'mysql.net', 'area'],
+        'lines': [
+            ["Bytes_received", "in", "incremental", 8, 1024],
+            ["Bytes_sent", "out", "incremental", -8, 1024]
+        ]},
+    'queries': {
+        'options': [None, 'mysql Queries', 'queries/s', 'queries', 'mysql.queries', 'line'],
+        'lines': [
+            ["Queries", "queries"],
+            ["Questions", "questions"],
+            ["Slow_queries", "slow_queries"]
+        ]},
+    'handlers': {
+        'options': [None, 'mysql Handlers', 'handlers/s', 'handlers', 'mysql.handlers', 'line'],
+        'lines': [
+            ["Handler_commit", "commit"],
+            ["Handler_delete", "delete"],
+            ["Handler_prepare", "prepare"],
+            ["Handler_read_first", "read_first"],
+            ["Handler_read_key", "read_key"],
+            ["Handler_read_next", "read_next"],
+            ["Handler_read_prev", "read_prev"],
+            ["Handler_read_rnd", "read_rnd"],
+            ["Handler_read_rnd_next", "read_rnd_next"],
+            ["Handler_rollback", "rollback"],
+            ["Handler_savepoint", "savepoint"],
+            ["Handler_savepoint_rollback", "savepoint_rollback"],
+            ["Handler_update", "update"],
+            ["Handler_write", "write"]
+        ]},
+    'table_locks': {
+        'options': [None, 'mysql Tables Locks', 'locks/s', 'locks', 'mysql.table_locks', 'line'],
+        'lines': [
+            ["Table_locks_immediate", "immediate"],
+            ["Table_locks_waited", "waited", "incremental", -1, 1]
+        ]},
+    'join_issues': {
+        'options': [None, 'mysql Select Join Issues', 'joins/s', 'issues', 'mysql.join_issues', 'line'],
+        'lines': [
+            ["Select_full_join", "full_join"],
+            ["Select_full_range_join", "full_range_join"],
+            ["Select_range", "range"],
+            ["Select_range_check", "range_check"],
+            ["Select_scan", "scan"]
+        ]},
+    'sort_issues': {
+        'options': [None, 'mysql Sort Issues', 'issues/s', 'issues', 'mysql.sort.issues', 'line'],
+        'lines': [
+            ["Sort_merge_passes", "merge_passes"],
+            ["Sort_range", "range"],
+            ["Sort_scan", "scan"]
+        ]},
+    'tmp': {
+        'options': [None, 'mysql Tmp Operations', 'counter', 'temporaries', 'mysql.tmp', 'line'],
+        'lines': [
+            ["Created_tmp_disk_tables", "disk_tables"],
+            ["Created_tmp_files", "files"],
+            ["Created_tmp_tables", "tables"]
+        ]},
+    'connections': {
+        'options': [None, 'mysql Connections', 'connections/s', 'connections', 'mysql.connections', 'line'],
+        'lines': [
+            ["Connections", "all"],
+            ["Aborted_connects", "aborted"]
+        ]},
+    'binlog_cache': {
+        'options': [None, 'mysql Binlog Cache', 'transactions/s', 'binlog', 'mysql.binlog_cache', 'line'],
+        'lines': [
+            ["Binlog_cache_disk_use", "disk"],
+            ["Binlog_cache_use", "all"]
+        ]},
+    'threads': {
+        'options': [None, 'mysql Threads', 'threads', 'threads', 'mysql.threads', 'line'],
+        'lines': [
+            ["Threads_connected", "connected", "absolute"],
+            ["Threads_created", "created"],
+            ["Threads_cached", "cached", "absolute", -1, 1],
+            ["Threads_running", "running", "absolute"],
+        ]},
+    'thread_cache_misses': {
+        'options': [None, 'mysql Threads Cache Misses', 'misses', 'threads', 'mysql.thread_cache_misses', 'area'],
+        'lines': [
+            ["Thread_cache_misses", "misses", "misses", "absolute", 1, 100]
+        ]},
+    'innodb_io': {
+        'options': [None, 'mysql InnoDB I/O Bandwidth', 'kilobytes/s', 'innodb', 'mysql.innodb_io', 'area'],
+        'lines': [
+            ["Innodb_data_read", "read", "incremental", 1, 1024],
+            ["Innodb_data_written", "write", "incremental", -1, 1024]
+        ]},
+    'innodb_io_ops': {
+        'lines': [None, 'mysql InnoDB I/O Operations', 'operations/s', 'innodb', 'mysql.innodb_io_ops', 'line'],
+        'options': [
+            ["Innodb_data_reads", "reads"],
+            ["Innodb_data_writes", "writes", "incremental", -1, 1],
+            ["Innodb_data_fsyncs", "fsyncs"]
+        ]},
+    'innodb_io_pending_ops': {
+        'options': [None, 'mysql InnoDB Pending I/O Operations', 'operations', 'innodb', 'mysql.innodb_io_pending_ops', 'line'],
+        'lines': [
+            ["Innodb_data_pending_reads", "reads", "absolute"],
+            ["Innodb_data_pending_writes", "writes", "absolute", -1, 1],
+            ["Innodb_data_pending_fsyncs", "fsyncs"]
+        ]},
+    'innodb_log': {
+        'options': [None, 'mysql InnoDB Log Operations', 'operations/s', 'innodb', 'mysql.innodb_log', 'line'],
+        'lines': [
+            ["Innodb_log_waits", "waits"],
+            ["Innodb_log_write_requests", "write_requests", "incremental", -1, 1],
+            ["Innodb_log_writes", "incremental", -1, 1],
+        ]},
+    'innodb_os_log': {
+        'options': [None, 'mysql InnoDB OS Log Operations', 'operations', 'innodb', 'mysql.innodb_os_log', 'line'],
+        'lines': [
+            ["Innodb_os_log_fsyncs", "fsyncs"],
+            ["Innodb_os_log_pending_fsyncs", "pending_fsyncs", "absolute"],
+            ["Innodb_os_log_pending_writes", "pending_writes", "absolute", -1, 1],
+        ]},
+    'innodb_os_log_io': {
+        'options': [None, 'mysql InnoDB OS Log Bandwidth', 'kilobytes/s', 'innodb', 'mysql.innodb_os_log_io', 'area'],
+        'lines': [
+            ["Innodb_os_log_written", "write", "incremental", -1, 1024],
+        ]},
+    'innodb_cur_row_lock': {
+        'options': [None, 'mysql InnoDB Current Row Locks', 'operations', 'innodb', 'mysql.innodb_cur_row_lock', 'area'],
+        'lines': [
+            ["Innodb_row_lock_current_waits", "current_waits", "absolute"]
+        ]},
+    'innodb_rows': {
+        'options': [None, 'mysql InnoDB Row Operations', 'operations/s', 'innodb', 'mysql.innodb_rows', 'area'],
+        'lines': [
+            ["Innodb_rows_inserted", "read"],
+            ["Innodb_rows_read", "deleted", "incremental", -1, 1],
+            ["Innodb_rows_updated", "inserted", "incremental", 1, 1],
+            ["Innodb_rows_deleted", "updated", "incremental", -1, 1],
+        ]},
+    'innodb_buffer_pool_pages': {
+        'options': [None, 'mysql InnoDB Buffer Pool Pages', 'pages', 'innodb', 'mysql.innodb_buffer_pool_pages', 'line'],
+        'lines': [
+            ["Innodb_buffer_pool_pages_data", "data", "absolute"],
+            ["Innodb_buffer_pool_pages_dirty", "dirty", "absolute", -1, 1],
+            ["Innodb_buffer_pool_pages_free", "free", "absolute"],
+            ["Innodb_buffer_pool_pages_flushed", "flushed", "incremental", -1, 1],
+            ["Innodb_buffer_pool_pages_misc", "misc", "absolute", -1, 1],
+            ["Innodb_buffer_pool_pages_total", "total", "absolute"]
+        ]},
+    'innodb_buffer_pool_bytes': {
+        'options': [None, 'mysql InnoDB Buffer Pool Bytes', 'MB', 'innodb', 'mysql.innodb_buffer_pool_bytes', 'area'],
+        'lines': [
+            ["Innodb_buffer_pool_bytes_data", "data", "absolute"],
+            ["Innodb_buffer_pool_bytes_dirty", "dirty", "absolute", -1, 1]
+        ]},
+    'innodb_buffer_pool_read_ahead': {
+        'options': [None, 'mysql InnoDB Buffer Pool Read Ahead', 'operations/s', 'innodb', 'mysql.innodb_buffer_pool_read_ahead', 'area'],
+        'lines': [
+            ["Innodb_buffer_pool_read_ahead", "all"],
+            ["Innodb_buffer_pool_read_ahead_evicted", "evicted", "incremental", -1, 1],
+            ["Innodb_buffer_pool_read_ahead_rnd", "random"]
+        ]},
+    'innodb_buffer_pool_reqs': {
+        'options': [None, 'mysql InnoDB Buffer Pool Requests', 'requests/s', 'innodb', 'mysql.innodb_buffer_pool_reqs', 'area'],
+        'lines': [
+            ["Innodb_buffer_pool_read_requests", "reads"],
+            ["Innodb_buffer_pool_write_requests", "writes", "incremental", -1, 1]
+        ]},
+    'innodb_buffer_pool_ops': {
+        'options': [None, 'mysql InnoDB Buffer Pool Operations', 'operations/s', 'innodb', 'mysql.innodb_buffer_pool_ops', 'area'],
+        'lines': [
+            ["Innodb_buffer_pool_reads", "disk reads"],
+            ["Innodb_buffer_pool_wait_free", "wait free", "incremental", -1, 1]
+        ]},
+    'qcache_ops': {
+        'options': [None, 'mysql QCache Operations', 'queries/s', 'qcache', 'mysql.qcache_ops', 'line'],
+        'lines': [
+            ["Qcache_hits", "hits"],
+            ["Qcache_lowmem_prunes", "lowmem prunes", "incremental", -1, 1],
+            ["Qcache_inserts", "inserts"],
+            ["Qcache_not_cached", "not cached", "incremental", -1, 1]
+        ]},
+    'qcache': {
+        'options': [None, 'mysql QCache Queries in Cache', 'queries', 'qcache', 'mysql.qcache', 'line'],
+        'lines': [
+            ["Qcache_queries_in_cache", "queries", "absolute"]
+        ]},
+    'qcache_freemem': {
+        'options': [None, 'mysql QCache Free Memory', 'MB', 'qcache', 'mysql.qcache_freemem', 'area'],
+        'lines': [
+            ["Qcache_free_memory", "free", "absolute"]
+        ]},
+    'qcache_memblocks': {
+        'options': [None, 'mysql QCache Memory Blocks', 'blocks', 'qcache', 'mysql.qcache_memblocks', 'line'],
+        'lines': [
+            ["Qcache_free_blocks", "free", "absolute"],
+            ["Qcache_total_blocks", "total", "absolute"]
+        ]},
+    'key_blocks': {
+        'options': [None, 'mysql MyISAM Key Cache Blocks', 'blocks', 'myisam', 'mysql.key_blocks', 'line'],
+        'lines': [
+            ["Key_blocks_unused", "unused", "absolute"],
+            ["Key_blocks_used", "used", "absolute", -1, 1],
+            ["Key_blocks_not_flushed", "not flushed", "absolute"]
+        ]},
+    'key_requests': {
+        'options': [None, 'mysql MyISAM Key Cache Requests', 'requests/s', 'myisam', 'mysql.key_requests', 'area'],
+        'lines': [
+            ["Key_read_requests", "reads"],
+            ["Key_write_requests", "writes", "incremental", -1, 1]
+        ]},
+    'key_disk_ops': {
+        'options': [None, 'mysql MyISAM Key Cache Disk Operations', 'operations/s', 'myisam', 'mysql.key_disk_ops', 'area'],
+        'lines': [
+            ["Key_reads", "reads"],
+            ["Key_writes", "writes", "incremental", -1, 1]
+        ]},
+    'files': {
+        'options': [None, 'mysql Open Files', 'files', 'files', 'mysql.files', 'line'],
+        'lines': [
+            ["Open_files", "files", "absolute"]
+        ]},
+    'files_rate': {
+        'options': [None, 'mysql Opened Files Rate', 'files/s', 'files', 'mysql.files_rate', 'line'],
+        'lines': [
+            ["Opened_files", "files"]
+        ]},
+    'binlog_stmt_cache': {
+        'options': [None, 'mysql Binlog Statement Cache', 'statements/s', 'binlog', 'mysql.binlog_stmt_cache', 'line'],
+        'lines': [
+            ["Binlog_stmt_cache_disk_use", "disk"],
+            ["Binlog_stmt_cache_use", "all"]
+        ]},
+    'connection_errors': {
+        'options': [None, 'mysql Connection Errors', 'connections/s', 'connections', 'mysql.connection_errors', 'line'],
+        'lines': [
+            ["Connection_errors_accept", "accept"],
+            ["Connection_errors_internal", "internal"],
+            ["Connection_errors_max_connections", "max"],
+            ["Connection_errors_peer_address", "peer_addr"],
+            ["Connection_errors_select", "select"],
+            ["Connection_errors_tcpwrap", "tcpwrap"]
+        ]}
+
 }
 
 
-class Service(BaseService):
+class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
-        super(self.__class__, self).__init__(configuration=configuration, name=name)
-        self.configuration = self._parse_config(configuration)
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self._parse_config(configuration)
+        self.order = ORDER
+        self.definitions = CHARTS
         self.connection = None
-        self.defs = {}
 
     def _parse_config(self, configuration):
         """
@@ -351,26 +323,24 @@ class Service(BaseService):
         if self.name is None:
             self.name = 'local'
         if 'user' not in configuration:
-            configuration['user'] = 'root'
+            self.configuration['user'] = 'root'
         if 'password' not in configuration:
-            configuration['password'] = ''
+            self.configuration['password'] = ''
         if 'my.cnf' in configuration:
-            configuration['socket'] = ''
-            configuration['host'] = ''
-            configuration['port'] = 0
+            self.configuration['socket'] = ''
+            self.configuration['host'] = ''
+            self.configuration['port'] = 0
         elif 'socket' in configuration:
-            configuration['my.cnf'] = ''
-            configuration['host'] = ''
-            configuration['port'] = 0
+            self.configuration['my.cnf'] = ''
+            self.configuration['host'] = ''
+            self.configuration['port'] = 0
         elif 'host' in configuration:
-            configuration['my.cnf'] = ''
-            configuration['socket'] = ''
+            self.configuration['my.cnf'] = ''
+            self.configuration['socket'] = ''
             if 'port' in configuration:
-                configuration['port'] = int(configuration['port'])
+                self.configuration['port'] = int(configuration['port'])
             else:
-                configuration['port'] = 3306
-
-        return configuration
+                self.configuration['port'] = 3306
 
     def _connect(self):
         """
@@ -410,6 +380,9 @@ class Service(BaseService):
 
         return dict(raw_data)
 
+    def _formatted_data(self):
+        return self._get_data()
+
     def check(self):
         """
         Check if service is able to connect to server
@@ -422,63 +395,63 @@ class Service(BaseService):
             self.connection = None
             return False
 
-    def create(self):
-        """
-        Create graphs
-        :return: boolean
-        """
-        for name in ORDER:
-            self.defs[name] = []
-            for line in CHARTS[name][1]:
-                self.defs[name].append(line[0])
-
-        idx = 0
-        data = self._get_data()
-        if data is None:
-            return False
-        for name in ORDER:
-            header = "CHART mysql_" + \
-                     str(self.name) + "." + \
-                     name + " " + \
-                     CHARTS[name][0] + " " + \
-                     str(self.priority + idx) + " " + \
-                     str(self.update_every)
-            content = ""
-            # check if server has this data point
-            for line in CHARTS[name][1]:
-                if line[0] in data:
-                    content += "DIMENSION " + line[0] + " " + line[1] + "\n"
-            if len(content) > 0:
-                print(header)
-                print(content)
-                idx += 1
-
-        if idx == 0:
-            return False
-        return True
-
-    def update(self, interval):
-        """
-        Update data on graphs
-        :param interval: int
-        :return: boolean
-        """
-        data = self._get_data()
-        if data is None:
-            return False
-        try:
-            data['Thread cache misses'] = int(int(data['Threads_created']) * 10000 / int(data['Connections']))
-        except Exception:
-            pass
-        for chart, dimensions in self.defs.items():
-            header = "BEGIN mysql_" + str(self.name) + "." + chart + " " + str(interval) + '\n'
-            lines = ""
-            for d in dimensions:
-                try:
-                    lines += "SET " + d + " = " + data[d] + '\n'
-                except KeyError:
-                    pass
-            if len(lines) > 0:
-                print(header + lines + "END")
-
-        return True
+    # def create(self):
+    #     """
+    #     Create graphs
+    #     :return: boolean
+    #     """
+    #     for name in ORDER:
+    #         self.defs[name] = []
+    #         for line in CHARTS[name][1]:
+    #             self.defs[name].append(line[0])
+    #
+    #     idx = 0
+    #     data = self._get_data()
+    #     if data is None:
+    #         return False
+    #     for name in ORDER:
+    #         header = "CHART mysql_" + \
+    #                  str(self.name) + "." + \
+    #                  name + " " + \
+    #                  CHARTS[name][0] + " " + \
+    #                  str(self.priority + idx) + " " + \
+    #                  str(self.update_every)
+    #         content = ""
+    #         # check if server has this data point
+    #         for line in CHARTS[name][1]:
+    #             if line[0] in data:
+    #                 content += "DIMENSION " + line[0] + " " + line[1] + "\n"
+    #         if len(content) > 0:
+    #             print(header)
+    #             print(content)
+    #             idx += 1
+    #
+    #     if idx == 0:
+    #         return False
+    #     return True
+    #
+    # def update(self, interval):
+    #     """
+    #     Update data on graphs
+    #     :param interval: int
+    #     :return: boolean
+    #     """
+    #     data = self._get_data()
+    #     if data is None:
+    #         return False
+    #     try:
+    #         data['Thread cache misses'] = int(int(data['Threads_created']) * 10000 / int(data['Connections']))
+    #     except Exception:
+    #         pass
+    #     for chart, dimensions in self.defs.items():
+    #         header = "BEGIN mysql_" + str(self.name) + "." + chart + " " + str(interval) + '\n'
+    #         lines = ""
+    #         for d in dimensions:
+    #             try:
+    #                 lines += "SET " + d + " = " + data[d] + '\n'
+    #             except KeyError:
+    #                 pass
+    #         if len(lines) > 0:
+    #             print(header + lines + "END")
+    #
+    #     return True

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -2,11 +2,8 @@
 # Description: MySQL netdata python.d plugin
 # Author: Pawel Krupa (paulfantom)
 
-import os
 from base import SimpleService
 import msg
-
-NAME = os.path.basename(__file__).replace(".chart.py", "")
 
 # import 3rd party library to handle MySQL communication
 try:
@@ -355,7 +352,7 @@ class Service(SimpleService):
                                               port=self.configuration['port'],
                                               connect_timeout=self.update_every)
         except Exception as e:
-            self.error(NAME + " has problem connecting to server:", e)
+            self.error("problem connecting to server:", e)
             raise RuntimeError
 
     def _format_data(self):
@@ -373,7 +370,7 @@ class Service(SimpleService):
             cursor.execute(QUERY)
             raw_data = cursor.fetchall()
         except Exception as e:
-            self.error(NAME + ": cannot execute query.", e)
+            self.error("cannot execute query.", e)
             self.connection.close()
             self.connection = None
             return None

--- a/python.d/nginx.chart.py
+++ b/python.d/nginx.chart.py
@@ -55,7 +55,7 @@ class Service(UrlService):
         self.order = ORDER
         self.definitions = CHARTS
 
-    def _formatted_data(self):
+    def _format_data(self):
         """
         Format data received from http request
         :return: dict

--- a/python.d/phpfpm.chart.py
+++ b/python.d/phpfpm.chart.py
@@ -56,7 +56,7 @@ class Service(UrlService):
                            "max children reached": 'reached',
                            "slow requests": 'slow'}
 
-    def _formatted_data(self):
+    def _format_data(self):
         """
         Format data received from http request
         :return: dict

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -428,9 +428,6 @@ class LogService(SimpleService):
         self._last_position = 0
         # self._log_reader = None
         SimpleService.__init__(self, configuration=configuration, name=name)
-        # FIXME Remove preventing of frequent log parsing
-        if self.timetable['freq'] < 3:
-            self.timetable['freq'] = 3
         self.retries = 100000  # basically always retry
 
     def _get_data(self):

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -438,6 +438,8 @@ class LogService(SimpleService):
         try:
             if os.path.getsize(self.log_path) < self._last_position:
                 self._last_position = 0
+            elif os.path.getsize(self.log_path) == self._last_position:
+                return None
             with open(self.log_path, "r") as fp:
                 fp.seek(self._last_position)
                 for i, line in enumerate(fp):

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -310,7 +310,7 @@ class SimpleService(BaseService):
         """
         return ""
 
-    def _formatted_data(self):
+    def _format_data(self):
         """
         Format data received from http request
         :return: dict
@@ -328,7 +328,7 @@ class SimpleService(BaseService):
         Create charts
         :return: boolean
         """
-        data = self._formatted_data()
+        data = self._format_data()
         if data is None:
             return False
 
@@ -351,7 +351,7 @@ class SimpleService(BaseService):
         :param interval: int
         :return: boolean
         """
-        data = self._formatted_data()
+        data = self._format_data()
         if data is None:
             return False
 
@@ -412,7 +412,7 @@ class UrlService(SimpleService):
         except (KeyError, TypeError):
             pass
 
-        if self._formatted_data() is not None:
+        if self._format_data() is not None:
             return True
         else:
             return False


### PR DESCRIPTION
I have rewritten `mysql.chart.py` to use the same schema as in other modules. 
Also implemented features discussed in #632.

Tested and ready to be merged.

Using `SimpleService` class simplifies writing new python modules thus I plan to rewrite most of bash counterparts to python by the next weekend.