### PR TITLE
Adding various applications to apps_groups.conf

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -79,7 +79,9 @@ fail2ban: fail2ban*
 httpd: apache* httpd nginx* lighttpd
 proxy: squid* c-icap squidGuard varnish*
 php: php*
-ftpd: proftpd in.tftpd
+ftpd: proftpd in.tftpd vsftpd
+uwsgi: uwsgi
+unicorn: *unicorn*
 
 # -----------------------------------------------------------------------------
 # database servers
@@ -102,6 +104,7 @@ wifi: hostapd wpa_supplicant
 # -----------------------------------------------------------------------------
 # high availability and balancers
 
+camo: *camo*
 balancer: ipvs_* haproxy
 ha: corosync hs_logd ha_logd stonithd
 
@@ -110,12 +113,14 @@ ha: corosync hs_logd ha_logd stonithd
 
 pbx: asterisk safe_asterisk *vicidial*
 sip: opensips* stund
+murmur: murmurd
+vines: *vines*
 
 # -----------------------------------------------------------------------------
 # monitoring
 
 logs: ulogd* syslog* rsyslog* logrotate
-nms: snmpd vnstatd smokeping zabbix* monit munin* mon openhpid watchdog
+nms: snmpd vnstatd smokeping zabbix* monit munin* mon openhpid watchdog tailon
 splunk: splunkd
 
 # -----------------------------------------------------------------------------
@@ -208,4 +213,5 @@ X: X lightdm xdm pulseaudio gkrellm xfwm4 xfdesktop xfce* Thunar xfsettingsd xfc
 # other application servers
 
 crsproxy: crsproxy
+sidekiq: *sidekiq*
 java: java


### PR DESCRIPTION
As I'm monitoring those applications on netdata for months now, I would like to add them to the main repository.

- vsftpd (ftp server)
- uwsgi (python webserver)
- unicorn (ruby webserver)
- camo (assets https proxy)
- murmurd (vocal chat server)
- vines (xmpp chat server for ruby)
- tailon (webapp reading log files)
- sidekiq (background processor for ruby)

Thank you!