### PR TITLE
runscript is deprecated, use openrc-run instead

### DIFF
--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 
 # The user netdata is configured to run as.
 # If you edit its configuration file to set a different


### PR DESCRIPTION
Discovered due to a Gentoo QA notice:
```text
 * QA Notice: #!/sbin/runscript is deprecated, use #!/sbin/openrc-run instead:
 *    //etc/init.d/netdata
```