### PR TITLE
timer updates (usleep() - the default, new timer: nanosleep())

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2320,7 +2320,7 @@ int main(int argc, char **argv)
 #ifndef PROFILING_MODE
 		// delay until it is our time to run
 		while((sunow = timems()) < sunext)
-			usleep((useconds_t)(sunext - sunow));
+			usecsleep(sunext - sunow);
 
 		// find the next time we need to run
 		while(timems() > sunext)

--- a/src/common.h
+++ b/src/common.h
@@ -46,6 +46,7 @@ extern void get_HZ(void);
 extern pid_t gettid(void);
 
 extern unsigned long long timems(void);
+extern int usecsleep(unsigned long long usec);
 
 extern char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
 

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -90,7 +90,7 @@ void *proc_main(void *ptr)
 
 		// delay until it is our time to run
 		while((sunow = timems()) < sunext)
-			usleep((useconds_t)(sunext - sunow));
+			usecsleep(sunext - sunow);
 
 		// find the next time we need to run
 		while(timems() > sunext)

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -860,7 +860,7 @@ unsigned long long rrdset_done(RRDSET *st)
 		// calculate the proper last_collected_time, using usec_since_last_update
 		unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec + st->usec_since_last_update;
 		st->last_collected_time.tv_sec = (time_t) (ut / 1000000ULL);
-		st->last_collected_time.tv_usec = (useconds_t) (ut % 1000000ULL);
+		st->last_collected_time.tv_usec = (suseconds_t) (ut % 1000000ULL);
 	}
 
 	// if this set has not been updated in the past
@@ -870,7 +870,7 @@ unsigned long long rrdset_done(RRDSET *st)
 		// set a fake last_updated, in the past using usec_since_last_update
 		unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;
 		st->last_updated.tv_sec = (time_t) (ut / 1000000ULL);
-		st->last_updated.tv_usec = (useconds_t) (ut % 1000000ULL);
+		st->last_updated.tv_usec = (suseconds_t) (ut % 1000000ULL);
 
 		// the first entry should not be stored
 		store_this_entry = 0;
@@ -890,7 +890,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
 		unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;
 		st->last_updated.tv_sec = (time_t) (ut / 1000000ULL);
-		st->last_updated.tv_usec = (useconds_t) (ut % 1000000ULL);
+		st->last_updated.tv_usec = (suseconds_t) (ut % 1000000ULL);
 
 		// the first entry should not be stored
 		store_this_entry = 0;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1275,7 +1275,7 @@ void *cgroups_main(void *ptr)
 
 		// delay until it is our time to run
 		while((sunow = timems()) < sunext)
-			usleep((useconds_t)(sunext - sunow));
+			usecsleep(sunext - sunow);
 
 		// find the next time we need to run
 		while(timems() > sunext)


### PR DESCRIPTION
1. portability: `usleep()` may not handle more than 999999 microseconds. The new code works properly.
2. added the option to compile with `-DNETDATA_WITH_NANOSLEEP=1` that uses `nanosleep()` instead.

cc #644 