### PR TITLE
switch to nanosleep() by default; fix for mysql not reading Handler_X in older systems

### DIFF
--- a/charts.d/mysql.chart.sh
+++ b/charts.d/mysql.chart.sh
@@ -18,7 +18,8 @@ mysql_get() {
 	mysql_data=()
 	IFS=$'\t'$'\n'
 	#arr=($("${@}" -e "SHOW GLOBAL STATUS WHERE value REGEXP '^[0-9]';" | egrep "^(Bytes|Slow_|Que|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)" ))
-	arr=($("${@}" -N -e "SHOW GLOBAL STATUS;" | egrep "^(Bytes|Slow_|Que|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)[^ ]+\s[0-9]" ))
+	#arr=($("${@}" -N -e "SHOW GLOBAL STATUS;" | egrep "^(Bytes|Slow_|Que|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)[^ ]+\s[0-9]" ))
+	arr=($("${@}" -N -e "SHOW GLOBAL STATUS;" | egrep "^(Bytes|Slow_|Que|Handl|Table|Selec|Sort_|Creat|Conne|Abort|Binlo|Threa|Innod|Qcach|Key_|Open)[^[:space:]]+[[:space:]]+[0-9]+" ))
 	IFS="${oIFS}"
 
 	[ "${#arr[@]}" -lt 3 ] && return 1

--- a/src/common.c
+++ b/src/common.c
@@ -29,15 +29,14 @@ unsigned long long timems(void) {
 
 int usecsleep(unsigned long long usec) {
 
-#ifdef NETDATA_WITH_NANOSLEEP
+#ifndef NETDATA_WITH_USLEEP
 	// we expect microseconds (1.000.000 per second)
 	// but timespec is nanoseconds (1.000.000.000 per second)
 	struct timespec req = { .tv_sec = usec / 1000000, .tv_nsec = (usec % 1000000) * 1000 }, rem;
 
 	while(nanosleep(&req, &rem) == -1) {
-		error("nanosleep() failed for %llu microseconds.", usec);
-
 		if(likely(errno == EINTR)) {
+			info("nanosleep() interrupted (while sleeping for %llu microseconds).", usec);
 			req.tv_sec = rem.tv_sec;
 			req.tv_nsec = rem.tv_nsec;
 		}


### PR DESCRIPTION
usleep() is deprecated by POSIX.
Now netdata uses nanosleep().