### PR TITLE
Update netdata.spec.in

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -58,9 +58,9 @@ rm -rf $RPM_BUILD_ROOT
 %{__make} %{?_smp_mflags} install \
 	DESTDIR=$RPM_BUILD_ROOT
 
-install -m 644 -p system/netdata.conf $RPM_BUILD_ROOT%{_sysconfdir}/%{name}/*.conf
+install -m 644 -p system/netdata.conf $RPM_BUILD_ROOT%{_sysconfdir}/%{name}
 
-find $RPM_BUILD_ROOT -name .keep | xargs rm
+find $RPM_BUILD_ROOT -name .keep | xargs -r rm
 
 %if %{with systemd}
 install -d $RPM_BUILD_ROOT%{_unitdir}


### PR DESCRIPTION
fix config install error introduced from 1abb8faa. noted in https://github.com/firehol/netdata/issues/678#issuecomment-232154277

also fix rm if no .keep file is installed. pointed out here: https://github.com/firehol/netdata/issues/659#issuecomment-231372919