### PR TITLE
QoS plugin now reports packets and dropped packets; installer now protects node.d config files

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -421,7 +421,7 @@ if [ -d "${NETDATA_PREFIX}/etc/netdata" ]
 	do
 		for y in "" ".old" ".orig"
 		do
-			if [ -f "${NETDATA_PREFIX}/etc/netdata/${x}.conf${y}" ]
+			if [ -f "${NETDATA_PREFIX}/etc/netdata/${x}.conf${y}" -a ! -f "${NETDATA_PREFIX}/etc/netdata/node.d/${x}.conf${y}" ]
 				then
 				run mv -f "${NETDATA_PREFIX}/etc/netdata/${x}.conf${y}" "${NETDATA_PREFIX}/etc/netdata/node.d/${x}.conf${y}"
 			fi


### PR DESCRIPTION
TC (QoS) plugin has been optimized a bit. It also now supports reporting packets and dropped packets.

There is more information already parsed by the plugin, per class, like lended traffic, borrowed traffic, etc. If anyone is missing this info, I can easily add it too.

Applied the last installer fix that protects charts.d config files, to node.d too.