### PR TITLE
mountinfo bugfixes

### DIFF
--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -111,7 +111,8 @@ static char *strdup_decoding_octal(const char *string) {
 
 	while(*s) {
 		if(unlikely(*s == '\\')) {
-			if(likely(isdigit(s[1]) && isdigit(s[2]) && isdigit(s[3]))) {
+			s++;
+			if(likely(isdigit(*s) && isdigit(s[1]) && isdigit(s[2]))) {
 				char c = *s++ - '0';
 				c <<= 3;
 				c |= *s++ - '0';
@@ -119,10 +120,7 @@ static char *strdup_decoding_octal(const char *string) {
 				c |= *s++ - '0';
 				*d++ = c;
 			}
-			else {
-				*d++ = '_';
-				s++;
-			}
+			else *d++ = '_';
 		}
 		else *d++ = *s++;
 	}

--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -60,7 +60,7 @@ struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *ro
 			// super_options is a comma separated list
 			char *s = mi->super_options, *e;
 			while(*s) {
-				e = ++s;
+				e = s + 1;
 				while(*e && *e != ',') e++;
 
 				size_t len = e - s;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -48,8 +48,8 @@ void read_cgroup_plugin_configuration() {
 	char filename[FILENAME_MAX + 1], *s;
 	struct mountinfo *mi, *root = mountinfo_read();
 
-	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
-	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
+	mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
+	if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
 	if(!mi) {
 		error("Cannot find cgroup cpuacct mountinfo. Assuming default: /sys/fs/cgroup/cpuacct");
 		s = "/sys/fs/cgroup/cpuacct";
@@ -58,8 +58,8 @@ void read_cgroup_plugin_configuration() {
 	snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);
 	cgroup_cpuacct_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuacct", filename);
 
-	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "blkio");
-	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
+	mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
+	if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "blkio");
 	if(!mi) {
 		error("Cannot find cgroup blkio mountinfo. Assuming default: /sys/fs/cgroup/blkio");
 		s = "/sys/fs/cgroup/blkio";
@@ -68,8 +68,8 @@ void read_cgroup_plugin_configuration() {
 	snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);
 	cgroup_blkio_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/blkio", filename);
 
-	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "memory");
-	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
+	mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
+	if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "memory");
 	if(!mi) {
 		error("Cannot find cgroup memory mountinfo. Assuming default: /sys/fs/cgroup/memory");
 		s = "/sys/fs/cgroup/memory";
@@ -78,8 +78,8 @@ void read_cgroup_plugin_configuration() {
 	snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, s);
 	cgroup_memory_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/memory", filename);
 
-	mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "devices");
-	if(!mi) mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "devices");
+	mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "devices");
+	if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "devices");
 	if(!mi) {
 		error("Cannot find cgroup devices mountinfo. Assuming default: /sys/fs/cgroup/devices");
 		s = "/sys/fs/cgroup/devices";


### PR DESCRIPTION
1. spaces in mount points are escaped by the kernel in octal (`\XXX`). Now netdata parses these properly.
2. super options parsing (used by cgroups to find the proper mount points of cgroups) was wrong - fixed it.
3. re-arranged the code to prefer kernel cgroups over lxcfs when parsing mountinfo.
