### PR TITLE
netdata can bind to multiple IPs and ports

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -561,7 +561,16 @@ NETDATA_DEBUG="$( config_option "debug flags" ${defdebug} )"
 
 # port
 defport=19999
-NETDATA_PORT="$( config_option "port" ${defport} )"
+NETDATA_PORT="$( config_option "default port" ${defport} )"
+NETDATA_PORT2="$( config_option "port" ${defport} )"
+
+if [ "${NETDATA_PORT}" != "${NETDATA_PORT2}" ]
+then
+    if [ "${NETDATA_PORT2}" != "${defport}" ]
+    then
+        NETDATA_PORT="${NETDATA_PORT2}"
+    fi
+fi
 
 # directories
 NETDATA_LIB_DIR="$( config_option "lib directory" "${NETDATA_PREFIX}/var/lib/netdata" )"
@@ -569,7 +578,6 @@ NETDATA_CACHE_DIR="$( config_option "cache directory" "${NETDATA_PREFIX}/var/cac
 NETDATA_WEB_DIR="$( config_option "web files directory" "${NETDATA_PREFIX}/usr/share/netdata/web" )"
 NETDATA_LOG_DIR="$( config_option "log directory" "${NETDATA_PREFIX}/var/log/netdata" )"
 NETDATA_CONF_DIR="$( config_option "config directory" "${NETDATA_PREFIX}/etc/netdata" )"
-NETDATA_BIND="$( config_option "bind socket to IP" "*" )"
 NETDATA_RUN_DIR="${NETDATA_PREFIX}/var/run"
 
 
@@ -1007,27 +1015,19 @@ chmod 750 netdata-uninstaller.sh
 
 # -----------------------------------------------------------------------------
 
-if [ "${NETDATA_BIND}" = "*" ]
-	then
-	access="localhost"
-else
-	access="${NETDATA_BIND}"
-fi
-
 cat <<-END
 
 
 	-------------------------------------------------------------------------------
 
-	OK. NetData is installed and it is running (listening to ${NETDATA_BIND}:${NETDATA_PORT}).
+	OK. NetData is installed and it is running.
 
 	-------------------------------------------------------------------------------
 
-	INFO: Command line options changed. -pidfile, -nd and -ch are deprecated.
-	If you use custom startup scripts, please run netdata -h to see the 
-	corresponding options and update your scripts.
+	By default netdata listens on all IPs on port ${NETDATA_PORT},
+	so you can access it with:
 
-	Hit http://${access}:${NETDATA_PORT}/ from your browser.
+	http://this.machine.ip:${NETDATA_PORT}/
 
 	To stop netdata, just kill it, with:
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -26,6 +26,9 @@ extern const char *config_set_default(const char *section, const char *name, con
 extern long long config_set_number(const char *section, const char *name, long long value);
 extern int config_set_boolean(const char *section, const char *name, int value);
 
+extern int config_exists(const char *section, const char *name);
+extern int config_rename(const char *section, const char *old, const char *new);
+
 extern void generate_config(BUFFER *wb, int only_changed);
 
 #endif /* NETDATA_CONFIG_H */

--- a/src/main.c
+++ b/src/main.c
@@ -375,14 +375,14 @@ int main(int argc, char **argv)
 					help(0);
 					break;
 				case 'i':
-					config_set("global", "bind socket to IP", optarg);
+					config_set("global", "bind to", optarg);
 					break;
 				case 'P':
 					strncpy(pidfile, optarg, FILENAME_MAX);
 					pidfile[FILENAME_MAX] = '\0';
 					break;
 				case 'p':
-					config_set("global", "port", optarg);
+					config_set("global", "default port", optarg);
 					break;
 				case 's':
 					config_set("global", "host access prefix", optarg);
@@ -395,7 +395,7 @@ int main(int argc, char **argv)
 					break;
 				case 'v':
 					// TODO: Outsource version to makefile which can compute version from git.
-					printf("netdata 1.1.0\n");
+					printf("netdata 1.2.1_master\n");
 					return 0;
 					break;
 				case 'W':

--- a/src/main.c
+++ b/src/main.c
@@ -652,9 +652,7 @@ int main(int argc, char **argv)
 
 		// --------------------------------------------------------------------
 
-		listen_fd = create_listen_socket();
-		if(listen_fd == -1)
-			fatal("Cannot listen socket.");
+		create_listen_sockets();
 	}
 
 	// never become a problem

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -672,6 +672,9 @@ void *tc_main(void *ptr) {
 #endif
 	uint32_t first_hash;
 
+	snprintfz(buffer, TC_LINE_MAX, "%s/tc-qos-helper.sh", config_get("plugins", "plugins directory", PLUGINS_DIR));
+	char *tc_script = config_get("plugin:tc", "script to run to get tc values", buffer);
+	
 	for(;1;) {
 		if(unlikely(netdata_exit)) break;
 
@@ -679,7 +682,7 @@ void *tc_main(void *ptr) {
 		struct tc_device *device = NULL;
 		struct tc_class *class = NULL;
 
-		snprintfz(buffer, TC_LINE_MAX, "exec %s %d", config_get("plugin:tc", "script to run to get tc values", PLUGINS_DIR "/tc-qos-helper.sh"), rrd_update_every);
+		snprintfz(buffer, TC_LINE_MAX, "exec %s %d", tc_script, rrd_update_every);
 		debug(D_TC_LOOP, "executing '%s'", buffer);
 
 		fp = mypopen(buffer, &tc_child_pid);

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -9,19 +9,18 @@
 #define LISTEN_PORT 19999
 #define LISTEN_BACKLOG 100
 
-extern int listen_backlog;
-extern int listen_fd;
-extern int listen_port;
+#ifndef MAX_LISTEN_FDS
+#define MAX_LISTEN_FDS 100
+#endif
 
 #define WEB_SERVER_MODE_MULTI_THREADED 0
 #define WEB_SERVER_MODE_SINGLE_THREADED 1
 extern int web_server_mode;
 
-extern int create_listen_socket4(const char *ip, int port, int listen_backlog);
-extern int create_listen_socket6(const char *ip, int port, int listen_backlog);
 extern void *socket_listen_main_multi_threaded(void *ptr);
 extern void *socket_listen_main_single_threaded(void *ptr);
-extern int create_listen_socket(void);
+extern int create_listen_sockets(void);
+extern int is_listen_socket(int fd);
 
 #ifndef HAVE_ACCEPT4
 extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);


### PR DESCRIPTION
This PR provides the following:

1. netdata can now bind to multiple IPs and ports. Up to 100 different ports (I thought 100 is a good enough default - you can increase it at compile time with `-DMAX_LISTEN_FDS=200`).

2. There is a new setting `[global].bind to`. This supports a space or coma delimited list like this:

  ```
[global]
    bind to = 127.0.0.1:19999 10.1.1.1:19998 hostname:19997 [::]:19996 localhost:19995 *:http
```

  Using the above, netdata will bind to:

  - IPv4 127.0.0.1 at port 19999
  - IPv4 10.1.1.1 at port 19998
  - All the IPs `hostname` resolves to (both IPv4 and IPv6 depending on the resolved IPs) at port 19997
  - All IPv6 IPs at port 19996
  - All the IPs `localhost` resolves to (both IPv4 and IPv6 depending the resolved IPs) at port 19996
  - All IPv4 and IPv6 IPs at port `http` as set in `/etc/services`

3. The option `[global].port` has been renamed to `[global].default port`. The old setting works too if found. This setting affects the default port in case an entry at `bind to` does not specify a port.

4. The option `[global].bind to IP` is used as `[global].bind to` if found.

### Side effects
The command line option `-p` sets the `default port`. This port is used only for entries in `bind to` that do not specify a port.
