### PR TITLE
Add el6 support

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1,4 +1,10 @@
 %define contentdir %{_datadir}/netdata
+
+# This is temporary and should eventually be resolved. This bypasses
+# the default rhel __os_install_post which throws a python compile
+# error.
+%define __os_install_post %{nil}
+
 #
 # Conditional build:
 %bcond_without  systemd  # systemd

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -113,6 +113,8 @@ exit 0
 %post
 # Register the netdata service
 /sbin/chkconfig --add netdata
+# Start the netdata service
+/sbin/service netdata start
 
 %preun
 if [ $1 = 0 ]; then

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1,7 +1,8 @@
+%define contentdir %{_datadir}/netdata
 #
 # Conditional build:
-%bcond_without	systemd		# systemd
-%bcond_without	nfacct		# build with nfacct plugin
+%bcond_without  systemd  # systemd
+%bcond_with     nfacct   # build with nfacct plugin
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
 %else
@@ -19,16 +20,24 @@ URL:		http://netdata.firehol.org/
 BuildRequires:	pkgconfig
 BuildRequires:	xz
 BuildRequires:	zlib-devel
+
+# Packages can be found in the EPEL repo
 %if %{with nfacct}
 BuildRequires:	libmnl-devel
 BuildRequires:	libnetfilter_acct-devel
 %endif
+
+Requires(pre): /usr/sbin/groupadd
+Requires(pre): /usr/sbin/useradd
+
 %if %{with systemd}
-BuildRequires:		systemd
-Requires(post):		systemd
-Requires(preun):	systemd
-Requires(postun):	systemd
+Requires(preun):  systemd-units
+Requires(postun): systemd-units
+Requires(post):   systemd-units
+%else
+Requires(post):   chkconfig
 %endif
+
 BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
 
 %description
@@ -46,7 +55,6 @@ happened, on your systems and applications.
 
 %build
 %configure \
-	--docdir=%{_docdir}/%{name}-%{version} \
 	--with-zlib \
 	--with-math \
 	%{?with_nfacct:--enable-plugin-nfacct} \
@@ -65,13 +73,20 @@ find $RPM_BUILD_ROOT -name .keep | xargs -r rm
 %if %{with systemd}
 install -d $RPM_BUILD_ROOT%{_unitdir}
 install -m 644 -p system/netdata.service $RPM_BUILD_ROOT%{_unitdir}/netdata.service
+%else
+# install SYSV init stuff
+mkdir -p $RPM_BUILD_ROOT/etc/rc.d/init.d
+install -m755 system/netdata-init-d \
+        $RPM_BUILD_ROOT/etc/rc.d/init.d/netdata
 %endif
 
-%pre
-getent group netdata > /dev/null || groupadd -r netdata
-getent passwd netdata > /dev/null || useradd -r -g netdata -c netdata -s /sbin/nologin -d / netdata
-
 %if %{with systemd}
+%pre
+# Add the "netdata" user
+/usr/sbin/groupadd -r netdata 2> /dev/null || :
+/usr/sbin/useradd -c "netdata" -g netdata \
+        -s /sbin/nologin -r -d %{contentdir} netdata 2> /dev/null || :
+
 %post
 %systemd_post netdata.service
 
@@ -80,6 +95,24 @@ getent passwd netdata > /dev/null || useradd -r -g netdata -c netdata -s /sbin/n
 
 %postun
 %systemd_postun_with_restart netdata.service
+%else
+%pre
+# Add the "netdata" user
+getent group netdata >/dev/null || groupadd -r netdata
+getent passwd netdata >/dev/null || \
+  useradd -r -g netdata -s /sbin/nologin \
+    -d %{contentdir} -c "netdata" netdata
+exit 0
+
+%post
+# Register the netdata service
+/sbin/chkconfig --add netdata
+
+%preun
+if [ $1 = 0 ]; then
+        /sbin/service netdata stop > /dev/null 2>&1
+        /sbin/chkconfig --del netdata
+fi
 %endif
 
 %clean
@@ -88,18 +121,29 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %attr(-,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
 %attr(-,netdata,netdata) %dir %{_localstatedir}/log/%{name}
-%config(noreplace) %verify(not md5 mtime size) %{_sysconfdir}/%{name}/*.conf
+%config(noreplace) %{_sysconfdir}/%{name}/*.conf
+%config(noreplace) %{_sysconfdir}/%{name}/python.d/*.conf
 %dir %{_sysconfdir}/%{name}
 %{?with_systemd:%{_unitdir}/netdata.service}
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
 %dir %{_datadir}/%{name}
 
+%if %{with systemd}
+%else
+%{_sysconfdir}/rc.d/init.d/netdata
+%endif
+
 # override defattr for web files
 %defattr(644,root,netdata,755)
 %{_datadir}/%{name}/web
 
 %changelog
+* Tue Jul 26 2016 Jason Barnett <J@sonBarnett.com> - 1.2.0-2
+- Added support for EL6
+- Corrected several Requires statements
+- Changed default to build without nfacct
+- Removed --docdir from configure
 * Mon May 16 2016 Costa Tsaousis <costa@tsaousis.gr> - 1.2.0-1
 - netdata is now 30% faster.
 - netdata now has a registry (my-netdata menu on the dashboard).


### PR DESCRIPTION
This is an attempt to fix #678.

I've tested this on both CentOS 6 and CentOS 7.

- [x] EL6 support
- [x] EL7 support
- [ ] logrotate scripts installed via RPM