### PR TITLE
guest values in CPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,6 @@ set(APPS_PLUGIN_SOURCE_FILES
         src/log.h
         src/procfile.c
         src/procfile.h
-        src/storage_number.c
-        src/storage_number.h
         src/web_buffer.c
         src/web_buffer.h
         config.h)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,6 +86,7 @@ apps_plugin_SOURCES = \
 	common.c common.h \
 	log.c log.h \
 	procfile.c procfile.h \
+	web_buffer.c web_buffer.h \
 	$(NULL)
 
 install-data-hook:

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2751,6 +2751,35 @@ void parse_args(int argc, char **argv)
             continue;
         }
 
+		if(strcmp("-h", argv[i]) == 0 || strcmp("--help", argv[i]) == 0) {
+            fprintf(stderr,
+                    "apps.plugin\n"
+                    "(C) 2016 Costa Tsaousis"
+                    "GPL v3+\n"
+                    "This program is a data collector plugin for netdata.\n"
+                    "\n"
+                    "Valid command line options:\n"
+                    "\n"
+                    "SECONDS           set the data collection frequency\n"
+                    "\n"
+                    "debug             enable debugging (lot of output)\n"
+                    "\n"
+                    "with-childs\n"
+                    "without-childs    enable / disable aggregating exited\n"
+                    "                  children resources into parents\n"
+                    "                  (default is enabled)\n"
+                    "\n"
+                    "with-guest\n"
+                    "without-guest     enable / disable reporting guest charts\n"
+                    "                  (default is disabled)\n"
+                    "\n"
+                    "NAME              read apps_NAME.conf instead of\n"
+                    "                  apps_groups.conf\n"
+                    "                  (default NAME=groups)\n"
+            );
+            exit(1);
+        }
+
         if(!name) {
 			name = argv[i];
 			continue;

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -708,85 +708,89 @@ int read_proc_pid_stat(struct pid_stat *p) {
 	p->stat_collected_usec = timems();
 	file_counter++;
 
-	// parse the process name
-	unsigned int i = 0;
+	// p->pid			= atol(procfile_lineword(ff, 0, 0+i));
+
 	strncpyz(p->comm, procfile_lineword(ff, 0, 1), MAX_COMPARE_NAME);
 
-	// p->pid			= atol(procfile_lineword(ff, 0, 0+i));
-	// comm is at 1
-	// p->state			= *(procfile_lineword(ff, 0, 2+i));
-	p->ppid				= (int32_t) atol(procfile_lineword(ff, 0, 3 + i));
-	// p->pgrp			= atol(procfile_lineword(ff, 0, 4+i));
-	// p->session		= atol(procfile_lineword(ff, 0, 5+i));
-	// p->tty_nr		= atol(procfile_lineword(ff, 0, 6+i));
-	// p->tpgid			= atol(procfile_lineword(ff, 0, 7+i));
-	// p->flags			= strtoull(procfile_lineword(ff, 0, 8+i), NULL, 10);
+	// p->state			= *(procfile_lineword(ff, 0, 2));
+	p->ppid				= (int32_t) atol(procfile_lineword(ff, 0, 3));
+	// p->pgrp			= atol(procfile_lineword(ff, 0, 4));
+	// p->session		= atol(procfile_lineword(ff, 0, 5));
+	// p->tty_nr		= atol(procfile_lineword(ff, 0, 6));
+	// p->tpgid			= atol(procfile_lineword(ff, 0, 7));
+	// p->flags			= strtoull(procfile_lineword(ff, 0, 8), NULL, 10);
 
 	unsigned long long last;
 
 	last = p->minflt_raw;
-	p->minflt_raw		= strtoull(procfile_lineword(ff, 0, 9+i), NULL, 10);
+	p->minflt_raw		= strtoull(procfile_lineword(ff, 0, 9), NULL, 10);
 	p->minflt = (p->minflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->cminflt_raw;
-	p->cminflt_raw		= strtoull(procfile_lineword(ff, 0, 10+i), NULL, 10);
+	p->cminflt_raw		= strtoull(procfile_lineword(ff, 0, 10), NULL, 10);
 	p->cminflt = (p->cminflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->majflt_raw;
-	p->majflt_raw		= strtoull(procfile_lineword(ff, 0, 11+i), NULL, 10);
+	p->majflt_raw		= strtoull(procfile_lineword(ff, 0, 11), NULL, 10);
 	p->majflt = (p->majflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->cmajflt_raw;
-	p->cmajflt_raw		= strtoull(procfile_lineword(ff, 0, 12+i), NULL, 10);
+	p->cmajflt_raw		= strtoull(procfile_lineword(ff, 0, 12), NULL, 10);
 	p->cmajflt = (p->cmajflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->utime_raw;
-	p->utime_raw		= strtoull(procfile_lineword(ff, 0, 13+i), NULL, 10);
+	p->utime_raw		= strtoull(procfile_lineword(ff, 0, 13), NULL, 10);
 	p->utime = (p->utime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->stime_raw;
-	p->stime_raw		= strtoull(procfile_lineword(ff, 0, 14+i), NULL, 10);
+	p->stime_raw		= strtoull(procfile_lineword(ff, 0, 14), NULL, 10);
 	p->stime = (p->stime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->cutime_raw;
-	p->cutime_raw		= strtoull(procfile_lineword(ff, 0, 15+i), NULL, 10);
+	p->cutime_raw		= strtoull(procfile_lineword(ff, 0, 15), NULL, 10);
 	p->cutime = (p->cutime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
 	last = p->cstime_raw;
-	p->cstime_raw		= strtoull(procfile_lineword(ff, 0, 16+i), NULL, 10);
+	p->cstime_raw		= strtoull(procfile_lineword(ff, 0, 16), NULL, 10);
 	p->cstime = (p->cstime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
-	// p->priority		= strtoull(procfile_lineword(ff, 0, 17+i), NULL, 10);
-	// p->nice			= strtoull(procfile_lineword(ff, 0, 18+i), NULL, 10);
-	p->num_threads		= (int32_t) atol(procfile_lineword(ff, 0, 19 + i));
-	// p->itrealvalue	= strtoull(procfile_lineword(ff, 0, 20+i), NULL, 10);
-	// p->starttime		= strtoull(procfile_lineword(ff, 0, 21+i), NULL, 10);
-	// p->vsize			= strtoull(procfile_lineword(ff, 0, 22+i), NULL, 10);
-	p->rss				= strtoull(procfile_lineword(ff, 0, 23+i), NULL, 10);
-	// p->rsslim		= strtoull(procfile_lineword(ff, 0, 24+i), NULL, 10);
-	// p->starcode		= strtoull(procfile_lineword(ff, 0, 25+i), NULL, 10);
-	// p->endcode		= strtoull(procfile_lineword(ff, 0, 26+i), NULL, 10);
-	// p->startstack	= strtoull(procfile_lineword(ff, 0, 27+i), NULL, 10);
-	// p->kstkesp		= strtoull(procfile_lineword(ff, 0, 28+i), NULL, 10);
-	// p->kstkeip		= strtoull(procfile_lineword(ff, 0, 29+i), NULL, 10);
-	// p->signal		= strtoull(procfile_lineword(ff, 0, 30+i), NULL, 10);
-	// p->blocked		= strtoull(procfile_lineword(ff, 0, 31+i), NULL, 10);
-	// p->sigignore		= strtoull(procfile_lineword(ff, 0, 32+i), NULL, 10);
-	// p->sigcatch		= strtoull(procfile_lineword(ff, 0, 33+i), NULL, 10);
-	// p->wchan			= strtoull(procfile_lineword(ff, 0, 34+i), NULL, 10);
-	// p->nswap			= strtoull(procfile_lineword(ff, 0, 35+i), NULL, 10);
-	// p->cnswap		= strtoull(procfile_lineword(ff, 0, 36+i), NULL, 10);
-	// p->exit_signal	= atol(procfile_lineword(ff, 0, 37+i));
-	// p->processor		= atol(procfile_lineword(ff, 0, 38+i));
-	// p->rt_priority	= strtoul(procfile_lineword(ff, 0, 39+i), NULL, 10);
-	// p->policy		= strtoul(procfile_lineword(ff, 0, 40+i), NULL, 10);
-	// p->delayacct_blkio_ticks		= strtoull(procfile_lineword(ff, 0, 41+i), NULL, 10);
-	p->gtime_raw		= strtoull(procfile_lineword(ff, 0, 42+i), NULL, 10);
-	p->cgtime_raw		= strtoull(procfile_lineword(ff, 0, 43+i), NULL, 10);
+	// p->priority		= strtoull(procfile_lineword(ff, 0, 17), NULL, 10);
+	// p->nice			= strtoull(procfile_lineword(ff, 0, 18), NULL, 10);
+	p->num_threads		= (int32_t) atol(procfile_lineword(ff, 0, 19));
+	// p->itrealvalue	= strtoull(procfile_lineword(ff, 0, 20), NULL, 10);
+	// p->starttime		= strtoull(procfile_lineword(ff, 0, 21), NULL, 10);
+	// p->vsize			= strtoull(procfile_lineword(ff, 0, 22), NULL, 10);
+	p->rss				= strtoull(procfile_lineword(ff, 0, 23), NULL, 10);
+	// p->rsslim		= strtoull(procfile_lineword(ff, 0, 24), NULL, 10);
+	// p->starcode		= strtoull(procfile_lineword(ff, 0, 25), NULL, 10);
+	// p->endcode		= strtoull(procfile_lineword(ff, 0, 26), NULL, 10);
+	// p->startstack	= strtoull(procfile_lineword(ff, 0, 27), NULL, 10);
+	// p->kstkesp		= strtoull(procfile_lineword(ff, 0, 28), NULL, 10);
+	// p->kstkeip		= strtoull(procfile_lineword(ff, 0, 29), NULL, 10);
+	// p->signal		= strtoull(procfile_lineword(ff, 0, 30), NULL, 10);
+	// p->blocked		= strtoull(procfile_lineword(ff, 0, 31), NULL, 10);
+	// p->sigignore		= strtoull(procfile_lineword(ff, 0, 32), NULL, 10);
+	// p->sigcatch		= strtoull(procfile_lineword(ff, 0, 33), NULL, 10);
+	// p->wchan			= strtoull(procfile_lineword(ff, 0, 34), NULL, 10);
+	// p->nswap			= strtoull(procfile_lineword(ff, 0, 35), NULL, 10);
+	// p->cnswap		= strtoull(procfile_lineword(ff, 0, 36), NULL, 10);
+	// p->exit_signal	= atol(procfile_lineword(ff, 0, 37));
+	// p->processor		= atol(procfile_lineword(ff, 0, 38));
+	// p->rt_priority	= strtoul(procfile_lineword(ff, 0, 39), NULL, 10);
+	// p->policy		= strtoul(procfile_lineword(ff, 0, 40), NULL, 10);
+	// p->delayacct_blkio_ticks = strtoull(procfile_lineword(ff, 0, 41), NULL, 10);
 
-	if(show_guest_time || p->gtime_raw || p->cgtime_raw) {
-		p->utime_raw -= p->gtime_raw;
-		p->cutime_raw -= p->cgtime_raw;
+	last = p->gtime_raw;
+	p->gtime_raw		= strtoull(procfile_lineword(ff, 0, 42), NULL, 10);
+	p->gtime = (p->gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+
+	last = p->cgtime_raw;
+	p->cgtime_raw		= strtoull(procfile_lineword(ff, 0, 43), NULL, 10);
+	p->cgtime = (p->cgtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+
+	if(show_guest_time || p->gtime || p->cgtime) {
+		p->utime  -= (p->utime  >= p->gtime )?p->gtime :p->utime;
+		p->cutime -= (p->cutime >= p->cgtime)?p->cgtime:p->cutime;
 		show_guest_time = 1;
 	}
 

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -782,15 +782,15 @@ int read_proc_pid_stat(struct pid_stat *p) {
 	// p->policy		= strtoul(procfile_lineword(ff, 0, 40), NULL, 10);
 	// p->delayacct_blkio_ticks = strtoull(procfile_lineword(ff, 0, 41), NULL, 10);
 
-	last = p->gtime_raw;
-	p->gtime_raw		= strtoull(procfile_lineword(ff, 0, 42), NULL, 10);
-	p->gtime = (p->gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
-
-	last = p->cgtime_raw;
-	p->cgtime_raw		= strtoull(procfile_lineword(ff, 0, 43), NULL, 10);
-	p->cgtime = (p->cgtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
-
     if(enable_guest_charts) {
+        last = p->gtime_raw;
+        p->gtime_raw		= strtoull(procfile_lineword(ff, 0, 42), NULL, 10);
+        p->gtime = (p->gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+
+        last = p->cgtime_raw;
+        p->cgtime_raw		= strtoull(procfile_lineword(ff, 0, 43), NULL, 10);
+        p->cgtime = (p->cgtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+
         if (show_guest_time || p->gtime || p->cgtime) {
             p->utime -= (p->utime >= p->gtime) ? p->gtime : p->utime;
             p->cutime -= (p->cutime >= p->cgtime) ? p->cgtime : p->cutime;
@@ -988,12 +988,12 @@ int read_proc_stat() {
     gtime_raw = strtoull(procfile_lineword(ff, 0, 10), NULL, 10);
     global_gtime = (gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
-    // guest nice time, on guest time
-    last = gntime_raw;
-    gntime_raw = strtoull(procfile_lineword(ff, 0, 11), NULL, 10);
-    global_gtime += (gntime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
-
     if(enable_guest_charts) {
+        // guest nice time, on guest time
+        last = gntime_raw;
+        gntime_raw = strtoull(procfile_lineword(ff, 0, 11), NULL, 10);
+        global_gtime += (gntime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+
         // remove guest time from user time
         global_utime -= (global_utime > global_gtime) ? global_gtime : global_utime;
     }

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -75,14 +75,11 @@ int do_proc_stat(int update_every, unsigned long long dt) {
 			softirq		= strtoull(procfile_lineword(ff, l, 7), NULL, 10);
 			steal		= strtoull(procfile_lineword(ff, l, 8), NULL, 10);
 
-			if(words >= 10) {
-				guest		= strtoull(procfile_lineword(ff, l, 9), NULL, 10);
-				user -= guest;
-			}
-			if(words >= 11) {
-				guest_nice	= strtoull(procfile_lineword(ff, l, 10), NULL, 10);
-				nice -= guest_nice;
-			}
+			guest		= strtoull(procfile_lineword(ff, l, 9), NULL, 10);
+			user -= guest;
+
+			guest_nice	= strtoull(procfile_lineword(ff, l, 10), NULL, 10);
+			nice -= guest_nice;
 
 			char *title, *type, *context, *family;
 			long priority;

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -74,8 +74,15 @@ int do_proc_stat(int update_every, unsigned long long dt) {
 			irq			= strtoull(procfile_lineword(ff, l, 6), NULL, 10);
 			softirq		= strtoull(procfile_lineword(ff, l, 7), NULL, 10);
 			steal		= strtoull(procfile_lineword(ff, l, 8), NULL, 10);
-			if(words >= 10) guest		= strtoull(procfile_lineword(ff, l, 9), NULL, 10);
-			if(words >= 11) guest_nice	= strtoull(procfile_lineword(ff, l, 10), NULL, 10);
+
+			if(words >= 10) {
+				guest		= strtoull(procfile_lineword(ff, l, 9), NULL, 10);
+				user -= guest;
+			}
+			if(words >= 11) {
+				guest_nice	= strtoull(procfile_lineword(ff, l, 10), NULL, 10);
+				nice -= guest_nice;
+			}
 
 			char *title, *type, *context, *family;
 			long priority;

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -1049,6 +1049,17 @@ unsigned long long rrdset_done(RRDSET *st)
 					continue;
 				}
 
+				// if the new is smaller than the old (an overflow, or reset), set the old equal to the new
+				// to reset the calculation (it will give zero as the calculation for this second)
+				if(unlikely(rd->last_collected_value > rd->collected_value)) {
+					debug(D_RRD_STATS, "%s.%s: RESET or OVERFLOW. Last collected value = " COLLECTED_NUMBER_FORMAT ", current = " COLLECTED_NUMBER_FORMAT
+					, st->name, rd->name
+					, rd->last_collected_value
+					, rd->collected_value);
+					if(!(rd->flags & RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS)) storage_flags = SN_EXISTS_RESET;
+					rd->last_collected_value = rd->collected_value;
+				}
+
 				// the percentage of the current increment
 				// over the increment of all dimensions together
 				if(unlikely(st->collected_total == st->last_collected_total))

--- a/src/storage_number.c
+++ b/src/storage_number.c
@@ -17,6 +17,9 @@
 #endif
 #endif
 
+extern char *print_number_lu_r(char *str, unsigned long uvalue);
+extern char *print_number_llu_r(char *str, unsigned long long uvalue);
+
 storage_number pack_storage_number(calculated_number value, uint32_t flags)
 {
 	// bit 32 = sign 0:positive, 1:negative
@@ -119,30 +122,6 @@ calculated_number unpack_storage_number(storage_number value)
 	return n;
 }
 
-#ifdef ENVIRONMENT32
-// This trick seems to give an 80% speed increase in 32bit systems
-// print_calculated_number_llu_r() will just print the digits up to the
-// point the remaining value fits in 32 bits, and then calls
-// print_calculated_number_lu_r() to print the rest with 32 bit arithmetic.
-
-static char *print_calculated_number_lu_r(char *str, unsigned long uvalue) {
-	char *wstr = str;
-
-	// print each digit
-	do *wstr++ = (char)('0' + (uvalue % 10)); while(uvalue /= 10);
-	return wstr;
-}
-
-static char *print_calculated_number_llu_r(char *str, unsigned long long uvalue) {
-	char *wstr = str;
-
-	// print each digit
-	do *wstr++ = (char)('0' + (uvalue % 10)); while((uvalue /= 10) && uvalue > (unsigned long long)0xffffffff);
-	if(uvalue) return print_calculated_number_lu_r(wstr, uvalue);
-	return wstr;
-}
-#endif
-
 int print_calculated_number(char *str, calculated_number value)
 {
 	char *wstr = str;
@@ -160,9 +139,9 @@ int print_calculated_number(char *str, calculated_number value)
 
 #ifdef ENVIRONMENT32
 	if(uvalue > (unsigned long long)0xffffffff)
-		wstr = print_calculated_number_llu_r(str, uvalue);
+		wstr = print_number_llu_r(str, uvalue);
 	else
-		wstr = print_calculated_number_lu_r(str, uvalue);
+		wstr = print_number_lu_r(str, uvalue);
 #else
 	do *wstr++ = (char)('0' + (uvalue % 10)); while(uvalue /= 10);
 #endif

--- a/src/web_buffer.h
+++ b/src/web_buffer.h
@@ -67,4 +67,9 @@ extern void buffer_sprintf(BUFFER *wb, const char *fmt, ...) __attribute__ (( fo
 
 extern void buffer_char_replace(BUFFER *wb, char from, char to);
 
+extern char *print_number_lu_r(char *str, unsigned long uvalue);
+extern char *print_number_llu_r(char *str, unsigned long long uvalue);
+
+extern void buffer_print_llu(BUFFER *wb, unsigned long long uvalue);
+
 #endif /* NETDATA_WEB_BUFFER_H */


### PR DESCRIPTION
Properly use guest values in all CPU charts

- host CPU charts substract guest from user and guest_nice from nice
- application, users and user groups cpu charts now take into account guest and children guest (substracted from user time)
- when guest time is reported by the kernel for any process, another CPU chart is presented in Applications, Users and User Groups, reporting the guest time.
- apps.plugin optimizations to eliminate all `printf()` calls and send all the data to netdata in just one `write()` call.
- added apps.plugin command line help
- added command line options `with-guest` and `without-guest` to enable / disable reporting guest CPU time separately.

fixes #729 