### PR TITLE
hardcode the release number in the spec

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -18,7 +18,7 @@
 Summary:	Real-time performance monitoring, done right
 Name:		@PACKAGE_NAME@
 Version:	@PACKAGE_RPM_VERSION@
-Release:	@PACKAGE_RPM_RELEASE@%{?release_suffix}%{?dist}
+Release:	1%{?dist}
 License:	GPL v3+
 Group:		Applications/System
 Source0:	http://firehol.org/download/netdata/releases/v@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.xz


### PR DESCRIPTION
Because I don't understand the whole `configure.ac` process and how things get searched and replaced, I have low confidence that is the right thing to do for this specific project.

In general, I have __not__ seen `%{?release_suffix}` in the `Release:` line and don't believe it's best practice to have that (low confidence). So at the very least I would like to remove that.