### PR TITLE
RPM improvements/fixes: lock down and fix %files section

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -142,9 +142,10 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0700,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
 %attr(0700,netdata,netdata) %dir %{_localstatedir}/log/%{name}
 %attr(0700,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
+%attr(0700,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
 
 %dir %{_datadir}/%{name}
-%attr(-,root,netdata) %{_datadir}/%{name}/web
+%attr(0644,root,netdata,0755) %{_datadir}/%{name}/web
 
 %if %{with systemd}
 %{_unitdir}/netdata.service

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -129,26 +129,28 @@ fi
 rm -rf $RPM_BUILD_ROOT
 
 %files
-%attr(-,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
-%attr(-,netdata,netdata) %dir %{_localstatedir}/log/%{name}
+%defattr(-,root,root)
+
+%dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/python.d/*.conf
-%dir %{_sysconfdir}/%{name}
-%{_sysconfdir}/logrotate.d/%{name}
+%config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
+
+%attr(0700,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
+%attr(0700,netdata,netdata) %dir %{_localstatedir}/log/%{name}
+%attr(0700,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
+
 %dir %{_datadir}/%{name}
-%dir %{_sharedstatedir}/%{name}
+%attr(-,root,netdata) %{_datadir}/%{name}/web
 
 %if %{with systemd}
 %{_unitdir}/netdata.service
 %else
 %{_sysconfdir}/rc.d/init.d/netdata
 %endif
-
-# override defattr for web files
-%defattr(644,root,netdata,755)
-%{_datadir}/%{name}/web
 
 %changelog
 * Tue Jul 26 2016 Jason Barnett <J@sonBarnett.com> - 1.2.0-2


### PR DESCRIPTION
- Fix what @glensc pointed out here: https://github.com/firehol/netdata/pull/734#discussion_r72586417
- Fix the logrotate configuration with what @glensc pointed out here: https://github.com/firehol/netdata/pull/734#discussion_r72586278
- Reorder `%files` section to make things more readable.
- Lock down everything under `/var` to be owned by `netdata` and to be locked down with `0700` permissions. This follows Redhat's best practices; can be seen in their httpd RPM.