### PR TITLE
dovecot support + basic HTTP auth fixes

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -22,6 +22,7 @@ dist_pythonconfig_DATA = \
 	python.d/apache.conf \
 	python.d/apache_cache.conf \
 	python.d/cpufreq.conf \
+	python.d/dovecot.conf \
 	python.d/example.conf \
 	python.d/exim.conf \
 	python.d/hddtemp.conf \

--- a/conf.d/python.d/dovecot.conf
+++ b/conf.d/python.d/dovecot.conf
@@ -1,0 +1,89 @@
+# netdata python.d.plugin configuration for dovecot
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, dovecot also supports the following:
+#
+#     socket: 'path/to/dovecot/stats'
+#
+#  or
+#     host: 'IP or HOSTNAME' # the host to connect to
+#     port: PORT             # the port to connect to
+#
+#
+
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+
+localhost:
+  name     : 'local'
+  host     : 'localhost'
+  port     : 24242
+
+localipv4:
+  name     : 'local'
+  host     : '127.0.0.1'
+  port     : 24242
+
+localipv6:
+  name     : 'local'
+  host     : '::1'
+  port     : 24242
+
+localsocket:
+  name     : 'local'
+  socket   : '/var/run/dovecot/stats'
+

--- a/conf.d/python.d/hddtemp.conf
+++ b/conf.d/python.d/hddtemp.conf
@@ -60,6 +60,13 @@
 #     port: PORT             # the port to connect to
 #
 
+# By default this module will try to autodetect number of disks.
+# However this can be overridden by setting variable `disk_count` to
+# desired number of disks. Example for two disks:
+#
+# disk_count: 2
+#
+
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 # only one of them will run (they have the same name)

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -353,7 +353,7 @@ class PythonCharts(object):
                         pass
             except AttributeError as e:
                 self._stop(job)
-                msg.error(job.chart_name, "cannot find check() function.")
+                msg.error(job.chart_name, "cannot find check() function or it thrown unhandled exception.")
                 msg.debug(str(e))
             except (UnboundLocalError, Exception) as e:
                 msg.error(job.chart_name, str(e))
@@ -390,7 +390,7 @@ class PythonCharts(object):
                     # sys.stdout.flush()
                     i += 1
             except AttributeError:
-                msg.error(job.chart_name, "cannot find create() function.")
+                msg.error(job.chart_name, "cannot find create() function or it thrown unhandled exception.")
                 self._stop(job)
             except (UnboundLocalError, Exception) as e:
                 msg.error(job.chart_name, str(e))

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -11,6 +11,7 @@ dist_python_SCRIPTS = \
 	apache.chart.py \
 	apache_cache.chart.py \
 	cpufreq.chart.py \
+	dovecot.chart.py \
 	example.chart.py \
 	exim.chart.py \
 	hddtemp.chart.py \

--- a/python.d/dovecot.chart.py
+++ b/python.d/dovecot.chart.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# Description: dovecot netdata python.d module
+# Author: Pawel Krupa (paulfantom)
+
+from base import SocketService
+
+# default module values (can be overridden per job in `config`)
+# update_every = 2
+priority = 60000
+retries = 60
+
+# charts order (can be overridden if you want less charts, or different order)
+ORDER = ['sessions', 'commands',
+         'faults',
+         'context_switches',
+         'disk', 'bytes', 'syscalls',
+         'lookup', 'cache',
+         'auth', 'auth_cache']
+
+CHARTS = {
+    'sessions': {
+        'options': [None, "logins and sessions", 'number', 'IMAP', 'dovecot.imap', 'line'],
+        'lines': [
+            ['num_logins', 'logins', 'absolute'],
+            ['num_connected_sessions', 'active sessions', 'absolute']
+        ]},
+    'commands': {
+        'options': [None, "commands", "commands", 'IMAP', 'dovecot.imap', 'line'],
+        'lines': [
+            ['num_cmds', 'commands', 'absolute']
+        ]},
+    'faults': {
+        'options': [None, "faults", "faults", 'Faults', 'dovecot.faults', 'line'],
+        'lines': [
+            ['min_faults', 'minor', 'absolute'],
+            ['maj_faults', 'major', 'absolute']
+        ]},
+    'context_switches': {
+        'options': [None, "context switches", '', 'Context Switches', 'dovecot.context_switches', 'line'],
+        'lines': [
+            ['vol_cs', 'volountary', 'absolute'],
+            ['invol_cs', 'involountary', 'absolute']
+        ]},
+    'disk': {
+        'options': [None, "disk", 'bytes/s', 'Reads and Writes', 'dovecot.read_write', 'line'],
+        'lines': [
+            ['disk_input', 'read', 'incremental'],
+            ['disk_output', 'write', 'incremental']
+        ]},
+    'bytes': {
+        'options': [None, "bytes", 'bytes/s', 'Reads and Writes', 'dovecot.read_write', 'line'],
+        'lines': [
+            ['read_bytes', 'read', 'incremental'],
+            ['write_bytes', 'write', 'incremental']
+        ]},
+    'syscalls': {
+        'options': [None, "number of syscalls", 'syscalls/s', 'Reads and Writes', 'dovecot.read_write', 'line'],
+        'lines': [
+            ['read_count', 'read', 'incremental'],
+            ['write_count', 'write', 'incremental']
+        ]},
+    'lookup': {
+        'options': [None, "lookups", 'number/s', 'Mail', 'dovecot.mail', 'line'],
+        'lines': [
+            ['mail_lookup_path', 'path', 'incremental'],
+            ['mail_lookup_attr', 'attr', 'incremental']
+        ]},
+    'cache': {
+        'options': [None, "hits", 'hits/s', 'Mail', 'dovecot.mail', 'line'],
+        'lines': [
+            ['mail_cache_hits', 'hits', 'incremental']
+        ]},
+    'auth': {
+        'options': [None, "attempts", 'attempts', 'Authentication', 'dovecot.auth', 'stacked'],
+        'lines': [
+            ['auth_successes', 'success', 'absolute'],
+            ['auth_failures', 'failure', 'absolute']
+        ]},
+    'auth_cache': {
+        'options': [None, "cache", 'number', 'Authentication', 'dovecot.auth', 'stacked'],
+        'lines': [
+            ['auth_cache_hits', 'hit', 'absolute'],
+            ['auth_cache_misses', 'miss', 'absolute']
+        ]}
+}
+
+
+class Service(SocketService):
+    def __init__(self, configuration=None, name=None):
+        SocketService.__init__(self, configuration=configuration, name=name)
+        self.request = "EXPORT\tglobal\r\n"
+        self.host = None  # localhost
+        self.port = None  # 24242
+        # self._keep_alive = True
+        self.unix_socket = "/var/run/dovecot/stats"
+        self.order = ORDER
+        self.definitions = CHARTS
+
+    def _get_data(self):
+        """
+        Format data received from socket
+        :return: dict
+        """
+        try:
+            raw = self._get_raw_data()
+        except (ValueError, AttributeError):
+            return None
+
+        data = raw.split('\n')[:2]
+        desc = data[0].split('\t')
+        vals = data[1].split('\t')
+        # ret = dict(zip(desc, vals))
+        ret = {}
+        for i in range(len(desc)):
+            try:
+                #d = str(desc[i])
+                #if d in ('user_cpu', 'sys_cpu', 'clock_time'):
+                #    val = float(vals[i])
+                #else:
+                #    val = int(vals[i])
+                #ret[d] = val
+                ret[str(desc[i])] = int(vals[i])
+            except ValueError:
+                pass
+        if len(ret) == 0:
+            return None
+        return ret

--- a/python.d/hddtemp.chart.py
+++ b/python.d/hddtemp.chart.py
@@ -65,7 +65,6 @@ class Service(SocketService):
         Get data from TCP/IP socket
         :return: dict
         """
-        self.disk_count = self._get_disk_count()
         try:
             raw = self._get_raw_data().split("|")[:-1]
         except AttributeError:
@@ -96,6 +95,14 @@ class Service(SocketService):
         except (KeyError, TypeError) as e:
             self.info("No excluded disks")
             self.debug(str(e))
+
+        try:
+            self.disk_count = int(self.configuration['disk_count'])
+        except (KeyError, TypeError) as e:
+            self.info("Autodetecting number of disks")
+            self.disk_count = self._get_disk_count()
+            self.debug(str(e))
+
         data = self._get_data()
         if data is None:
             return False

--- a/python.d/memcached.chart.py
+++ b/python.d/memcached.chart.py
@@ -29,11 +29,11 @@ CHARTS = {
             ['bytes_written', 'written', 'incremental', 1, 1024]
         ]},
     'connections': {
-        'options': [None, 'Connections', 'connections', 'Cluster', 'memcached.cluster', 'line'],
+        'options': [None, 'Connections', 'connections/s', 'Cluster', 'memcached.cluster', 'line'],
         'lines': [
-            ['curr_connections', 'current', 'absolute'],
-            ['rejected_connections', 'rejected', 'absolute'],
-            ['total_connections', 'total', 'absolute']
+            ['curr_connections', 'current', 'incremental'],
+            ['rejected_connections', 'rejected', 'incremental'],
+            ['total_connections', 'total', 'incremental']
         ]},
     'items': {
         'options': [None, 'Items', 'items', 'Cluster', 'memcached.cluster', 'line'],

--- a/python.d/memcached.chart.py
+++ b/python.d/memcached.chart.py
@@ -42,7 +42,7 @@ CHARTS = {
             ['total_items', 'total', 'absolute']
         ]},
     'evicted_reclaimed': {
-        'options': [None, 'Items', 'items', 'Evicted & Reclaimed', 'memcached.evicted_reclaimed', 'line'],
+        'options': [None, 'Items', 'items', 'Evicted and Reclaimed', 'memcached.evicted_reclaimed', 'line'],
         'lines': [
             ['evictions', 'evicted', 'absolute'],
             ['reclaimed', 'reclaimed', 'absolute']

--- a/python.d/memcached.chart.py
+++ b/python.d/memcached.chart.py
@@ -23,10 +23,10 @@ ORDER = ['net', 'connections', 'items', 'evicted_reclaimed', 'get', 'get_rate', 
 
 CHARTS = {
     'net': {
-        'options': [None, 'Network', 'bytes', 'Network', 'memcached.net', 'line'],
+        'options': [None, 'Network', 'kilobytes/s', 'Network', 'memcached.net', 'line'],
         'lines': [
-            ['bytes_read', 'read', 'absolute'],
-            ['bytes_written', 'written', 'absolute']
+            ['bytes_read', 'read', 'incremental', 1, 1024],
+            ['bytes_written', 'written', 'incremental', 1, 1024]
         ]},
     'connections': {
         'options': [None, 'Connections', 'connections', 'Cluster', 'memcached.cluster', 'line'],
@@ -108,6 +108,7 @@ class Service(SocketService):
         self.request = "stats\r\n"
         self.host = "localhost"
         self.port = 11211
+        self._keep_alive = True
         self.unix_socket = None
         self.order = ORDER
         self.definitions = CHARTS
@@ -143,6 +144,12 @@ class Service(SocketService):
             return None
         else:
             return data
+
+    def _check_raw_data(self, data):
+        if data.endswith('END\r\n'):
+            return True
+        else:
+            return False
 
     def check(self):
         """

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -351,6 +351,10 @@ class Service(SimpleService):
                                               host=self.configuration['host'],
                                               port=self.configuration['port'],
                                               connect_timeout=self.update_every)
+        except MySQLdb.OperationalError as e:
+            self.error("Cannot establish connection to MySQL.")
+            self.debug(str(e))
+            raise RuntimeError
         except Exception as e:
             self.error("problem connecting to server:", e)
             raise RuntimeError

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -39,7 +39,7 @@ retries = 60
 #}
 
 # query executed on MySQL server
-QUERY = "SHOW GLOBAL STATUS"
+QUERY = "SHOW GLOBAL STATUS;"
 
 ORDER = ['net',
          'queries',
@@ -375,8 +375,6 @@ class Service(SimpleService):
             cursor = self.connection.cursor()
             cursor.execute(QUERY)
             raw_data = cursor.fetchall()
-
-
         except Exception as e:
             self.error("cannot execute query.", e)
             self.connection.close()

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -369,11 +369,20 @@ class Service(SimpleService):
             cursor = self.connection.cursor()
             cursor.execute(QUERY)
             raw_data = cursor.fetchall()
+        except MySQLdb.OperationalError as e:
+            self.debug("Reconnecting due to", str(e))
+            self._connect()
+            cursor = self.connection.cursor()
+            cursor.execute(QUERY)
+            raw_data = cursor.fetchall()
+
+
         except Exception as e:
             self.error("cannot execute query.", e)
             self.connection.close()
             self.connection = None
             return None
+
         data = dict(raw_data)
         try:
             data["Thread_cache_misses"] = int(data["Threads_created"] * 10000 / float(data["Connections"]))

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -543,8 +543,13 @@ class SocketService(SimpleService):
                         self._disconnect()
             else:
                 # connect to unix socket
-                self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-                self._sock.connect(self.unix_socket)
+                try:
+                    self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                    self._sock.connect(self.unix_socket)
+                except socket.error:
+                    self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    self._sock.connect(self.unix_socket)
+
         except Exception as e:
             self.error(str(e),
                        "Cannot create socket with following configuration: host:", str(self.host),

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -412,7 +412,7 @@ class UrlService(SimpleService):
 
     def __add_openers(self):
         # TODO add error handling
-        opener = urllib2.build_opener()
+        self.opener = urllib2.build_opener()
 
         # Proxy handling
         # TODO currently self.proxies isn't parsed from configuration file
@@ -439,9 +439,10 @@ class UrlService(SimpleService):
         if self.user is not None and self.password is not None:
             passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
             passman.add_password(None, self.url, self.user, self.password)
-            opener.add_handler(urllib2.HTTPBasicAuthHandler(passman))
+            self.opener.add_handler(urllib2.HTTPBasicAuthHandler(passman))
+            self.debug("Enabling HTTP basic auth")
 
-        urllib2.install_opener(opener)
+        #urllib2.install_opener(opener)
 
     def _get_raw_data(self):
         """
@@ -450,7 +451,8 @@ class UrlService(SimpleService):
         """
         raw = None
         try:
-            f = urllib2.urlopen(self.url, timeout=self.update_every * 2)
+            f = self.opener.open(self.url, timeout=self.update_every * 2)
+            # f = urllib2.urlopen(self.url, timeout=self.update_every * 2)
         except Exception as e:
             self.error(str(e))
             return None
@@ -488,7 +490,8 @@ class UrlService(SimpleService):
 
         self.__add_openers()
 
-        if self._get_data() is None or len(self._get_data()) == 0:
+        test = self._get_data()
+        if test is None or len(test) == 0:
             return False
         else:
             return True

--- a/python.d/tomcat.chart.py
+++ b/python.d/tomcat.chart.py
@@ -66,7 +66,8 @@ class Service(UrlService):
         if self.port == 0:
             self.port = 80
 
-        if self._get_data() is None or len(self._get_data()) == 0:
+        test = self._get_data()
+        if test is None or len(test) == 0:
             return False
         else:
             return True
@@ -81,13 +82,12 @@ class Service(UrlService):
             try:
                 data = ET.fromstring(raw)
             except ET.ParseError as e:
-                #if e.code == errors.codes[errors.XML_ERROR_JUNK_AFTER_DOC_ELEMENT]:
+                # if e.code == errors.codes[errors.XML_ERROR_JUNK_AFTER_DOC_ELEMENT]:
                 if e.code == 9:
-                    # cut rest of invalid string
-                    pos = 0
-                    for i in range(e.position[0] - 1):
-                        pos += raw.find('\n', pos)
-                    raw = raw[:47604 + pos + e.position[0] - 1]
+                    end = raw.find('</status>')
+                    end += 9
+                    raw = raw[:end]
+                    self.debug(raw)
                     data = ET.fromstring(raw)
                 else:
                     raise Exception(e)

--- a/python.d/tomcat.chart.py
+++ b/python.d/tomcat.chart.py
@@ -20,12 +20,12 @@ CHARTS = {
     'accesses': {
         'options': [None, "tomcat requests", "requests/s", "statistics", "tomcat.accesses", "area"],
         'lines': [
-            ["accesses"]
+            ["accesses", None, 'incremental']
         ]},
     'volume': {
         'options': [None, "tomcat volume", "KB/s", "volume", "tomcat.volume", "area"],
         'lines': [
-            ["volume", None, 'incremental']
+            ["volume", None, 'incremental', 1, 1024]
         ]},
     'threads': {
         'options': [None, "tomcat threads", "current threads", "statistics", "tomcat.threads", "line"],
@@ -36,7 +36,7 @@ CHARTS = {
     'jvm': {
         'options': [None, "JVM Free Memory", "MB", "statistics", "tomcat.jvm", "area"],
         'lines': [
-            ["jvm", None, "absolute"]
+            ["jvm", None, "absolute", 1, 1048576]
         ]}
 }
 


### PR DESCRIPTION
Adding dovecot support, which should fix #737 (future documentation should say about permission issues with dovecot unix socket - usually it is only writable by user root)

Adding fallback to SOCK_STREAM when SOCK_DGRAM cannot be used in SocketService, when unix_socket is defined.

Fixing issues with multiple tomcat instances, and with openers in UrlService (HTTP Basic auth not working on more than one children Service), should fix #719 

Fix #754 by optionally defining number of disks in configuration file and thus disabling autodetection of this number.

Changing `memcached.chart.py` connections dimensions from absolute to incremental as previously discussed in #751 


