### PR TITLE
dashboards transfer theme, online help and Pan&Zoom via my-netdata

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -15,6 +15,7 @@
 // var netdataNoRegistry = true;		// Don't update the registry for this access
 // var netdataRegistryCallback = null;	// Callback function that will be invoked with one param,
 //                                         the URLs from the registry
+// var netdataShowHelp = true;			// enable/disable help
 //
 // You can also set the default netdata server, using the following.
 // When this variable is not set, we assume the page is hosted on your
@@ -153,6 +154,9 @@
 	else
 		NETDATA.themes.current = NETDATA.themes.white;
 
+	if(typeof netdataShowHelp === 'undefined')
+		netdataShowHelp = true;
+
 	NETDATA.colors = NETDATA.themes.current.colors;
 
 	// these are the colors Google Charts are using
@@ -268,7 +272,7 @@
 
 			destroy_on_hide: false,		// destroy charts when they are not visible
 
-			show_help: true,			// when enabled the charts will show some help
+			show_help: netdataShowHelp,	// when enabled the charts will show some help
 			show_help_delay_show_ms: 500,
 			show_help_delay_hide_ms: 0,
 
@@ -337,6 +341,7 @@
 			try {
 				// console.log('localStorage: loading "' + key.toString() + '"');
 				ret = localStorage.getItem(key.toString());
+				// console.log('netdata loaded: ' + key.toString() + ' = ' + ret.toString());
 				if(ret === null || ret === 'undefined') {
 					// console.log('localStorage: cannot load it, saving "' + key.toString() + '" with value "' + JSON.stringify(def) + '"');
 					localStorage.setItem(key.toString(), JSON.stringify(def));
@@ -624,6 +629,8 @@
 		force_before_ms: null,	// the timespan to sync all other charts
 		force_after_ms: null,
 
+		callback: null,
+
 		// set a new master
 		setMaster: function(state, after, before) {
 			if(NETDATA.options.current.sync_pan_and_zoom === false)
@@ -638,6 +645,9 @@
 			this.force_after_ms = after;
 			this.force_before_ms = before;
 			NETDATA.options.auto_refresher_stop_until = now + NETDATA.options.current.global_pan_sync_time;
+
+			if(typeof this.callback === 'function')
+				this.callback(true, after, before);
 		},
 
 		// clear the master
@@ -653,6 +663,9 @@
 			this.force_after_ms = null;
 			this.force_before_ms = null;
 			NETDATA.options.auto_refresher_stop_until = 0;
+
+			if(typeof this.callback === 'function')
+				this.callback(false, 0, 0);
 		},
 
 		// is the given state the master of the global
@@ -3395,7 +3408,7 @@
 		NETDATA.parseDom(NETDATA.chartRefresher);
 
 		// Registry initialization
-		setTimeout(NETDATA.registry.init, 3000);
+		setTimeout(NETDATA.registry.init, 1000);
 	};
 
 	// ----------------------------------------------------------------------------------------------------------------

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,20 @@
 		padding-top: 50px;
 	}
 
+	.loadOverlay {
+		position: absolute;
+		top: 0px;
+		left: 0px;
+		width: 100%;
+		height:100%;
+		z-index: 2000;
+		font-size: 10vh;
+		font-family: sans-serif;
+		padding: 40vh 0 40vh 0;
+		font-weight: bold;
+		text-align: center;
+	}
+
 	.modal-wide .modal-dialog {
 		width: 80%;
 	}
@@ -321,12 +335,79 @@
 	}
 	</style>
 
-	<!-- you can set your netdata server globally, by ucommenting this -->
-	<!-- you can also give a different server per chart, with the attribute: data-host="http://netdata.server:19999" -->
-	<!-- <script> netdataServer = "http://box:19999"; </script> -->
-
 	<!-- check which theme to use -->
-	<script>
+	<script type="text/javascript">
+		// --------------------------------------------------------------------
+		// urlOptions
+
+		var urlOptions = {
+			hash: '#',
+			theme: null,
+			help: null,
+			pan_and_zoom: false,
+			after: 0,
+			before: 0,
+			nowelcome: 0,
+			hasProperty: function(property) {
+				// console.log('checking property ' + property + ' of type ' + typeof(this[property]));
+				return typeof this[property] !== 'undefined';
+			}
+		};
+
+		function netdataPanAndZoomCallback(status, after, before) {
+			urlOptions.pan_and_zoom = status;
+			urlOptions.after = after;
+			urlOptions.before = before;
+			netdataHashUpdate();
+		}
+
+		function netdataHashUpdate() {
+			history.replaceState(null, document.title, netdataHash());
+		}
+
+		function netdataHash() {
+			var hash = urlOptions.hash;
+
+			if(urlOptions.pan_and_zoom === true) {
+				hash += ';after='  + urlOptions.after.toString() +
+				        ';before=' + urlOptions.before.toString();
+			}
+
+			if(urlOptions.theme !== null)
+				hash += ';theme=' + urlOptions.theme.toString();
+
+			if(urlOptions.help !== null)
+				hash += ';help=' + urlOptions.help.toString();
+
+			return hash;
+		}
+
+		function netdataHashParse() {
+			var variables = document.location.hash.split(';');
+			var len = variables.length;
+			while(len--) {
+				if(len !== 0) {
+					var p = variables[len].split('=');
+					if(urlOptions.hasProperty(p[0]) && typeof p[1] !== 'undefined')
+						urlOptions[p[0]] = p[1];
+				}
+				else {
+					if(variables[len].length > 0)
+						urlOptions.hash = variables[len];
+				}
+			}
+
+			if(urlOptions.before > 0 && urlOptions.after > 0)
+				urlOptions.pan_and_zoom = true;
+
+			// console.log(urlOptions);
+		}
+
+		netdataHashParse();
+
+		// --------------------------------------------------------------------
+		// check options that should be processed before loading netdata.js
+		
 		function loadLocalStorage(name) {
 			var ret = null;
 
@@ -341,10 +422,13 @@
 			if(typeof ret === 'undefined' || ret === null)
 				return null;
 
+			// console.log('loaded: ' + name.toString() + ' = ' + ret.toString());
+
 			return ret;
 		}
 
 		function saveLocalStorage(name, value) {
+			// console.log('saving: ' + name.toString() + ' = ' + value.toString());
 			try {
 				if(typeof Storage !== "undefined" && typeof localStorage === 'object') {
 					localStorage.setItem(name, value.toString());
@@ -366,13 +450,31 @@
 				return ret;
 		}
 
-		var netdataTheme = getTheme('slate');
-
 		function setTheme(theme) {
 			if(theme === netdataTheme) return false;
-
 			return saveLocalStorage('netdataTheme', theme);
 		}
+
+		var netdataTheme = getTheme('slate');
+		var netdataShowHelp = true;
+
+		if(urlOptions.theme !== null) {
+			setTheme(urlOptions.theme);
+			netdataTheme = urlOptions.theme;
+		}
+		else
+			urlOptions.theme = netdataTheme;
+
+		if(urlOptions.help !== null) {
+			saveLocalStorage('options.show_help', urlOptions.help);
+			netdataShowHelp = urlOptions.help;
+		}
+		else {
+			urlOptions.help = loadLocalStorage('options.show_help');
+		}
+
+		// --------------------------------------------------------------------
+		// registry call back to render my-netdata menu
 
 		var netdataRegistryCallback = function(machines_array) {
 			var el = '';
@@ -430,10 +532,16 @@
 	</script>
 
 	<!-- load the dashboard manager - it will do the rest -->
-	<script type="text/javascript" src="dashboard.js?v40"></script>
+	<script type="text/javascript" src="dashboard.js?v41"></script>
 </head>
-
 <body data-spy="scroll" data-target="#sidebar">
+	<div id="loadOverlay" class="loadOverlay" style="background-color: #888; color: #888;">
+		netdata<br/><div style="font-size: 3vh;">Real-time performance monitoring, done right!</div>
+	</div>
+	<script type="text/javascript">
+		// change the loadOverlay colors ASAP to match the theme
+		document.getElementById('loadOverlay').style = (urlOptions.theme === 'slate')?"background-color:#272b30; color: #373b40;":"background-color:#fff; color: #ddd;";
+	</script>
 	<nav class="navbar navbar-default navbar-fixed-top" role="banner">
 		<div class="container">
 			<nav id="mynetdata_nav" class="collapse navbar-collapse navbar-left hidden-sm hidden-xs" role="navigation" style="padding-right: 20px;">
@@ -995,7 +1103,7 @@
 		</div>
 	</div>
 
-<script>
+<script type="text/javascript">
 var this_is_demo = null;
 function isdemo() {
 	if(this_is_demo !== null) return this_is_demo;
@@ -1021,6 +1129,31 @@ function isdemo() {
 if(isdemo()) {
 	document.getElementById('masthead').style.display = 'block';
 }
+
+function netdataURL(url) {
+	if(typeof url === 'undefined')
+		url = document.location.toString();
+
+	if(url.indexOf('#') !== -1)
+		url = url.substring(0, url.indexOf('#'));
+
+	var hash = netdataHash();
+
+	// console.log('netdataURL: ' + url + hash);
+
+	return url + hash;
+}
+
+function netdataReload(url) {
+	var t = netdataURL(url);
+	// console.log('netdataReload: ' + t);
+	document.location = t;
+
+	// since we play with hash
+	// this is needed to reload the page
+	location.reload();
+}
+
 var gotoServerValidateRemaining = 0;
 var gotoServerMiddleClick = false;
 var gotoServerStop = false;
@@ -1031,25 +1164,26 @@ function gotoServerValidateUrl(id, guid, url) {
 			// to allow the user walk through all its servers.
 			penaldy = 500;
 
+	var finalURL = netdataURL(url);
+
 	setTimeout(function() {
-		document.getElementById('gotoServerList').innerHTML += '<tr><td style="padding-left: 20px;"><a href="' + url + '" target="_blank">' + url + '</a></td><td style="padding-left: 30px;"><code id="' + guid + '-' + id + '-status">checking...</code></td></tr>';
+		document.getElementById('gotoServerList').innerHTML += '<tr><td style="padding-left: 20px;"><a href="' + finalURL + '" target="_blank">' + url + '</a></td><td style="padding-left: 30px;"><code id="' + guid + '-' + id + '-status">checking...</code></td></tr>';
 
 		NETDATA.registry.hello(url, function(data) {
 			if (data) {
 				// console.log('OK ' + id + ' URL: ' + url);
 				document.getElementById(guid + '-' + id + '-status').innerHTML = "OK";
-				var hash = document.location.hash || '';
 
 				if(!gotoServerStop) {
 					gotoServerStop = true;
 
 					if(gotoServerMiddleClick) {
-						window.open(url + hash, '_blank');
+						window.open(finalURL, '_blank');
 						gotoServerMiddleClick = false;
-						document.getElementById('gotoServerResponse').innerHTML = '<b>Opening new window to ' + NETDATA.registry.machines[guid].name + '<br/><a href="' + url + hash + '">' + url + hash + '</a></b><br/>(check your pop-up blocker if it fails)';
+						document.getElementById('gotoServerResponse').innerHTML = '<b>Opening new window to ' + NETDATA.registry.machines[guid].name + '<br/><a href="' + finalURL + '">' + url + '</a></b><br/>(check your pop-up blocker if it fails)';
 					}
 					else
-						document.location = url + hash;
+						document.location = finalURL;
 				}
 			}
 			else {
@@ -2215,6 +2349,8 @@ function downloadAllCharts(netdata_url) {
 		netdata_url = NETDATA.serverDefault;
 
 	NETDATA.pause(function() {
+		$("#loadOverlay").css("display","none");
+		$("#loadOverlay").css("display","none");
 
 		// download all the charts the server knows
 		NETDATA.chartRegistry.downloadAll(netdata_url, function(data) {
@@ -2358,21 +2494,6 @@ function notifyForUpdate(force) {
 
 // ----------------------------------------------------------------------------
 
-function getUrlParameter(sParam) {
-    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-        sURLVariables = sPageURL.split('&'),
-        sParameterName,
-        i;
-
-    for (i = 0; i < sURLVariables.length; i++) {
-        sParameterName = sURLVariables[i].split('=');
-
-        if (sParameterName[0] === sParam) {
-            return sParameterName[1] === undefined ? true : sParameterName[1];
-        }
-    }
-}
-
 function finalizePage() {
 	// resize all charts - without starting the background thread
 	// this has to be done while NETDATA is paused
@@ -2380,14 +2501,9 @@ function finalizePage() {
 	// the Dom elements are initially zero-sized
 	NETDATA.parseDom();
 
-	var before = 0, after = 0, nowelcome = 0;
-	after = getUrlParameter('force_after_ms');
-	before = getUrlParameter('force_before_ms');
-	nowelcome = (getUrlParameter('nowelcome') === true)?true:false;
-
-	if(before > 0 && after > 0) {
-		nowelcome = true;
-		NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], after, before);
+	if(urlOptions.pan_and_zoom === true) {
+		urlOptions.nowelcome = true;
+		NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], urlOptions.after, urlOptions.before);
 	}
 
 	// ------------------------------------------------------------------------
@@ -2525,11 +2641,14 @@ function finalizePage() {
 	$(".chart-message").shorten();
 	// ------------------------------------------------------------------------
 
+	// callback for us to track PanAndZoom operations
+	NETDATA.globalPanAndZoom.callback = netdataPanAndZoomCallback;
+
 	// let it run (update the charts)
 	NETDATA.unpause();
 
 	// check if we have to jump to a specific section
-	scrollToId(location.hash.replace('#',''));
+	scrollToId(urlOptions.hash.replace('#',''));
 
 	/* activate bootstrap sidebar (affix) */
 	$('#sidebar').affix({
@@ -2555,8 +2674,14 @@ function finalizePage() {
 	// change the URL based on the current position of the screen
 	$('#sidebar').on('activate.bs.scrollspy', function (e) {
 		var el = $(e.target);
-		if(el.find('ul').size() == 0)
-			history.replaceState(null, document.title, el.find('a').attr('href'));
+		if(el.find('ul').size() == 0) {
+			var hash = el.find('a').attr('href');
+			if(typeof hash === 'string' && hash.substring(0, 1) == '#') {
+				urlOptions.hash = hash;
+				// console.log(urlOptions.hash);
+				netdataHashUpdate();
+			}
+		}
 	});
 
 	document.getElementById('footer').style.display = 'block';
@@ -2610,13 +2735,18 @@ function finalizePage() {
 	$('#stop_updates_when_focus_is_lost').change(function() { NETDATA.setOption('stop_updates_when_focus_is_lost', $(this).prop('checked')); });
 	$('#smooth_plot').change(function()                     { NETDATA.setOption('smooth_plot', $(this).prop('checked')); });
 	$('#pan_and_zoom_data_padding').change(function()       { NETDATA.setOption('pan_and_zoom_data_padding', $(this).prop('checked')); });
-	$('#show_help').change(function()                       { NETDATA.setOption('show_help', $(this).prop('checked')); location.reload(); });
+	$('#show_help').change(function()                       {
+		urlOptions.help = $(this).prop('checked');
+		NETDATA.setOption('show_help', urlOptions.help);
+		netdataReload();
+	});
 
 	// this has to be the last
 	// it reloads the page
 	$('#netdata_theme_control').change(function() {
-		if(setTheme($(this).prop('checked')?'slate':'white'))
-			location.reload();
+		urlOptions.theme = $(this).prop('checked')?'slate':'white';
+		if(setTheme(urlOptions.theme))
+			netdataReload();
 	});
 
 	$('#updateModal').on('shown.bs.modal', function() {
@@ -2628,7 +2758,7 @@ function finalizePage() {
 	});
 
 	if(isdemo()) {
-		if(!nowelcome) {
+		if(!urlOptions.nowelcome) {
 			setTimeout(function() {
 				$('#welcomeModal').modal();
 			}, 1000);
@@ -2654,10 +2784,10 @@ function resetDashboardOptions() {
 
 	NETDATA.resetOptions();
 	if(setTheme('slate'))
-		location.reload();
+		netdataReload();
 
 	if(help !== NETDATA.options.current.show_help)
-		location.reload();
+		netdataReload();
 }
 
 downloadAllCharts();


### PR DESCRIPTION
This PR allows a netdata dashboard to transfer:

1. its theme setting
2. its help setting
3. its Pan And Zoom settings
4. its focus section (the old URL hash)

to all other netdata servers, via the my-netdata menu item.

So, you change theme and help settings on one netdata, or you zoom a chart to a section of the tme-series and these settings are automatically transferred to the next netdata dashboard, via the my-netdata menu.

@paulfantom if you can spend some time testing this, please do so. I believe I have tested enough, but any feedback is always welcome.

Keep in mind that all netdata servers have to be updated to this version for it to work and you should at least once press control-F5 on your browser (after you update your netdata) to uncache the old version.

Additional improvements:

1. the ugly broken HTML displayed while the browser loads the html, javascript and css files is eliminated (and respects themes too).

2. the my-netdata menu now loads in 1 sec (had a 3 sec delay, which I think was annoying).


