### PR TITLE
Fix extraction of nginx status values.

### DIFF
--- a/python.d/nginx.chart.py
+++ b/python.d/nginx.chart.py
@@ -63,11 +63,11 @@ class Service(UrlService):
         try:
             raw = self._get_raw_data().split(" ")
             return {'active': int(raw[2]),
-                    'requests': int(raw[7]),
+                    'requests': int(raw[9]),
                     'reading': int(raw[11]),
                     'writing': int(raw[13]),
                     'waiting': int(raw[15]),
-                    'accepts': int(raw[8]),
-                    'handled': int(raw[9])}
+                    'accepts': int(raw[7]),
+                    'handled': int(raw[8])}
         except (ValueError, AttributeError):
             return None


### PR DESCRIPTION
I believe the the variables are extracted with wrong indexes from https://nginx.org/en/docs/http/ngx_http_stub_status_module.html . Result of this are much smaller "requests" values on chart than expected and big difference between "accepted" and "handled" connections. On chart they would be usually very close to each other.