### PR TITLE
Fixed path to netdata pid file

### DIFF
--- a/system/netdata-init-d.in
+++ b/system/netdata-init-d.in
@@ -13,7 +13,7 @@
 
 DAEMON="netdata"
 DAEMON_PATH=@sbindir_POST@
-PIDFILE=@localstatedir_POST@/$DAEMON.pid
+PIDFILE=@localstatedir_POST@/run/$DAEMON.pid
 DAEMONOPTS="-P $PIDFILE"
 STOP_TIMEOUT="10"
 


### PR DESCRIPTION
Fixed path to netdata pid file: /var/run

File modified: system/netdata-init-d.in

The installation displays the following paths (CentOS 6.X)

  - the daemon    at /usr/sbin/netdata
  - config files  at /etc/netdata
  - web files     at /usr/share/netdata
  - plugins       at /usr/libexec/netdata
  - cache files   at /var/cache/netdata
  - db files      at /var/lib/netdata
  - log files     at /var/log/netdata
  - pid file      at /var/run

grep "pid" system/netdata-init-d
PIDFILE=/var/$DAEMON.pid