### PR TITLE
health enhancements

### DIFF
--- a/plugins.d/cgroup-name.sh
+++ b/plugins.d/cgroup-name.sh
@@ -29,6 +29,7 @@ function get_name_classic {
     local DOCKERID="$1"
     echo >&2 "Running command: docker ps --filter=id=\"${DOCKERID}\" --format=\"{{.Names}}\""
     NAME="$( docker ps --filter=id="${DOCKERID}" --format="{{.Names}}" )"
+    return 0
 }
 
 function get_name_api {
@@ -36,18 +37,20 @@ function get_name_api {
     if [ ! -S "/var/run/docker.sock" ]
         then
         echo >&2 "Can't find /var/run/docker.sock"
-        return
+        return 1
     fi
     echo >&2 "Running API command: /containers/${DOCKERID}/json"
     JSON=$(echo -e "GET /containers/${DOCKERID}/json HTTP/1.0\r\n" | nc -U /var/run/docker.sock | egrep '^{.*')
     NAME=$(echo $JSON | jq -r .Name,.Config.Hostname | grep -v null | head -n1 | sed 's|^/||')
+    return 0
 }
 
 if [ -z "${NAME}" ]
     then
-    if [[ "${CGROUP}" =~ ^.*docker[_-/\.][a-fA-F0-9]+[_-\.]?.*$ ]]
+    if [[ "${CGROUP}" =~ ^.*docker[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]
         then
-        DOCKERID="$( echo "${CGROUP}" | sed "s|^.*docker[_-/]\([a-fA-F0-9]\+\)[_-\.]\?.*$|\1|" )"
+        DOCKERID="$( echo "${CGROUP}" | sed "s|^.*docker[-_/]\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|" )"
+        # echo "DOCKERID=${DOCKERID}"
 
         if [ ! -z "${DOCKERID}" -a \( ${#DOCKERID} -eq 64 -o ${#DOCKERID} -eq 12 \) ]
             then
@@ -55,7 +58,7 @@ if [ -z "${NAME}" ]
                 then
                 get_name_classic $DOCKERID
             else
-                get_name_api $DOCKERID
+                get_name_api $DOCKERID || get_name_classic $DOCKERID
             fi
             if [ -z "${NAME}" ]
                 then

--- a/plugins.d/cgroup-name.sh
+++ b/plugins.d/cgroup-name.sh
@@ -16,7 +16,7 @@ fi
 
 if [ -f "${CONFIG}" ]
     then
-    NAME="$(cat "${CONFIG}" | grep "^${CGROUP} " | sed "s/[[:space:]]\+/ /g" | cut -d ' ' -f 2)"
+    NAME="$(grep "^${CGROUP} " "${CONFIG}" | sed "s/[[:space:]]\+/ /g" | cut -d ' ' -f 2)"
     if [ -z "${NAME}" ]
         then
         echo >&2 "${0}: cannot find cgroup '${CGROUP}' in '${CONFIG}'."
@@ -26,13 +26,13 @@ if [ -f "${CONFIG}" ]
 fi
 
 function get_name_classic {
-    DOCKERID=$1
+    local DOCKERID="$1"
     echo >&2 "Running command: docker ps --filter=id=\"${DOCKERID}\" --format=\"{{.Names}}\""
     NAME="$( docker ps --filter=id="${DOCKERID}" --format="{{.Names}}" )"
 }
 
 function get_name_api {
-    DOCKERID=$1
+    local DOCKERID="$1"
     if [ ! -S "/var/run/docker.sock" ]
         then
         echo >&2 "Can't find /var/run/docker.sock"
@@ -45,9 +45,9 @@ function get_name_api {
 
 if [ -z "${NAME}" ]
     then
-    if [[ "${CGROUP}" =~ ^.*docker[-/\.][a-fA-F0-9]+[-\.]?.*$ ]]
+    if [[ "${CGROUP}" =~ ^.*docker[_-/\.][a-fA-F0-9]+[_-\.]?.*$ ]]
         then
-        DOCKERID="$( echo "${CGROUP}" | sed "s|^.*docker[-/]\([a-fA-F0-9]\+\)[-\.]\?.*$|\1|" )"
+        DOCKERID="$( echo "${CGROUP}" | sed "s|^.*docker[_-/]\([a-fA-F0-9]\+\)[_-\.]\?.*$|\1|" )"
 
         if [ ! -z "${DOCKERID}" -a \( ${#DOCKERID} -eq 64 -o ${#DOCKERID} -eq 12 \) ]
             then

--- a/src/health.h
+++ b/src/health.h
@@ -256,6 +256,7 @@ extern void rrddimvar_free(RRDDIMVAR *rs);
 extern void rrdsetcalc_link_matching(RRDSET *st);
 extern void rrdsetcalc_unlink(RRDCALC *rc);
 extern void rrdcalctemplate_link_matching(RRDSET *st);
+extern RRDCALC *rrdcalc_find(RRDSET *st, const char *name);
 
 extern void health_init(void);
 extern void *health_main(void *ptr);

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -157,6 +157,13 @@ paths:
           format: 'as returned by /charts'
           allowEmptyValue: false
           default: system.cpu
+        - name: alarm
+          in: query
+          description: 'the name of an alarm linked to the chart'
+          required: false
+          type: string
+          format: 'any text'
+          allowEmptyValue: true
         - name: dimension
           in: query
           description: 'zero, one or more dimension ids, as returned by the /chart call.'


### PR DESCRIPTION
- [x] extended the badges API to support rendering alarms With just `chart` and `alarm` query parameters netdata returns colorful badges indicating the current status of the alarm. The value returned is the value of the alarm. Updated the badges documentation to reflect this extension.

- [x] solved a bug where alarms where not properly linked to charts.

- [x] fix for not parsing properly docker container ids