### PR TITLE
Added health.d to files section in netdata.spec.in

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -146,6 +146,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/*.conf
+%config(noreplace) %{_sysconfdir}/%{name}/health.d/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/python.d/*.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 


### PR DESCRIPTION
Was causing a build error due to the files in the health.d directory being unpackaged when attempting to build an rpm.