### PR TITLE
Add xmpp group on apps_groups.conf

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -114,7 +114,7 @@ ha: corosync hs_logd ha_logd stonithd
 pbx: asterisk safe_asterisk *vicidial*
 sip: opensips* stund
 murmur: murmurd
-vines: *vines*
+xmpp: *vines* *prosody*
 
 # -----------------------------------------------------------------------------
 # monitoring


### PR DESCRIPTION
Hi,

I would like to add  "prosody", the Jabber/xmpp server to apps_groups.conf.
I took this opportunity to create a new "xmpp" group.

Thanks.
