### PR TITLE
process alarms in the order they appear in the config files

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -277,7 +277,7 @@ struct rrdset {
     // ------------------------------------------------------------------------
     // the dimensions
 
-    avl_tree_lock dimensions_index;                     // the root of the dimensions index
+    avl_tree_lock dimensions_index;                 // the root of the dimensions index
     RRDDIM *dimensions;                             // the actual data for every dimension
 
 };


### PR DESCRIPTION
Alarms may be dependent to each other.
For example alarm A may depend on alarm B being evaluated (using `$B` in expressions).

netdata does not have dependency tree in it, meaning that it just evaluates the alarms, without taking into consideration their dependencies on other alarms. This could lead to a situation when A that depends on B, is using the value of B of its previous iteration, not the current one.

To work around this problem, this PR makes netdata evaluate alarms in the same order they appear within each configuration file. So, if you place alarm B above A, it will always be evaluated in that order.

Prior to this PR, templates where evaluates properly, but alarm definitions were processed in the reverse order. With this PR both alarms and templates respect their order.
