### PR TITLE
Fix issues when using a manually configured list of drives in the hddtemp python module

### DIFF
--- a/python.d/hddtemp.chart.py
+++ b/python.d/hddtemp.chart.py
@@ -44,7 +44,7 @@ class Service(SocketService):
     def _get_disks(self):
         try:
             disks = self.configuration['devices']
-            print(disks)
+            self.info("Using configured disks" + str(disks))
         except (KeyError, TypeError) as e:
             self.info("Autodetecting disks")
             return ["/dev/" + f for f in os.listdir("/dev") if len(f) == 3 and f.startswith("sd")]
@@ -53,8 +53,7 @@ class Service(SocketService):
         for disk in disks:
             if not disk.startswith('/dev/'):
                 disk = "/dev/" + disk
-            if os.path.exists(disk):
-                ret.append(disk)
+            ret.append(disk)
         if len(ret) == 0:
             self.error("Provided disks cannot be found in /dev directory.")
         return ret


### PR DESCRIPTION
* Replaces print(disks) with an info.log(), otherwise netdata tries to
  interpret this as a command and breaks all python scripts.
* Remove checking for the existence of drives, this makes it useful
  for monitoring remote hosts or the localhost from within a docker.

Ideally this should probably just pull drive names directly from the hddtemp output, and never try search for disks in the file system at all. But this works for now.