### PR TITLE
Use systemd to reload netdata

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -7,6 +7,7 @@ Type=simple
 User=netdata
 Group=netdata
 ExecStart=@sbindir_POST@/netdata -D
+ExecReload=/bin/kill -USR2 $MAINPID
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=60


### PR DESCRIPTION
The wiki often describes how to reload netdata without restarting it: `killall -USR2 netdata`. Adding one line to the `netdata.service` file will allow the use of `systemctl reload netdata`.