### PR TITLE
slack.com notifications support

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -11,10 +11,12 @@
 
 # The full path to the sendmail command.
 # If empty, the system $PATH will be searched for it.
+# If not found, email notifications will be disabled.
 sendmail=""
 
 # The full path of the curl command.
 # If empty, the system $PATH will be searched for it.
+# If not found, pushover and slack notifications will be disabled.
 curl=""
 
 
@@ -22,13 +24,13 @@ curl=""
 # sending emails
 
 # note: multiple recipients can be given like this:
-#              "admin1@example.com, admin2@example.com, ..."
+#              "admin1@example.com admin2@example.com ..."
 # note it needs a comma!
 
 # enable/disable sending emails
 SEND_EMAIL="YES"
 
-# if a role recipient is not configured, an email will be send to
+# if a role recipient is not configured, an email will be send to:
 DEFAULT_RECIPIENT_EMAIL="root"
 
 
@@ -36,19 +38,38 @@ DEFAULT_RECIPIENT_EMAIL="root"
 # sending pushover notifications (pushover.net)
 
 # note: multiple recipients can be given like this:
-#                  "USERTOKEN1 USERTOKEN2 USERTOKEN3 ..."
+#                  "USERTOKEN1 USERTOKEN2 ..."
 
 # enable/disable sending pushover notifications
 SEND_PUSHOVER="YES"
 
-# Login to pushover.com to get your pushover app token
+# Login to pushover.net to get your pushover app token
 # You need only one for all your netdata servers.
 # Without it, netdata cannot send pushover notifications.
 PUSHOVER_APP_TOKEN=""
 
 # if a role recipient is not configured, a notification will be send to
-# this pushover user token
+# this pushover user token:
 DEFAULT_RECIPIENT_PUSHOVER=""
+
+
+###############################################################################
+# sending slack notifications
+
+# note: multiple recipients can be given like this:
+#                  "CHANNEL1 CHANNEL2 ..."
+
+# enable/disable sending pushover notifications
+SEND_SLACK="YES"
+
+# Login to slack.com and create an incoming webhook.
+# You need only one for all your netdata servers.
+# Without it, netdata cannot send slack notifications.
+SLACK_WEBHOOK_URL=""
+
+# if a role recipient is not configured, a notification will be send to
+# this slack channel:
+DEFAULT_RECIPIENT_SLACK=""
 
 
 ###############################################################################
@@ -62,6 +83,8 @@ role_recipients_email[sysadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
 role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
+
 
 # -----------------------------------------------------------------------------
 # DNS related alarms
@@ -69,6 +92,8 @@ role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 role_recipients_email[domainadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
 role_recipients_pushover[domainadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 
 # -----------------------------------------------------------------------------
@@ -79,6 +104,8 @@ role_recipients_email[dba]="${DEFAULT_RECIPIENT_EMAIL}"
 
 role_recipients_pushover[dba]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
+
 
 # -----------------------------------------------------------------------------
 # web servers alarms
@@ -87,6 +114,8 @@ role_recipients_pushover[dba]="${DEFAULT_RECIPIENT_PUSHOVER}"
 role_recipients_email[webmaster]="${DEFAULT_RECIPIENT_EMAIL}"
 
 role_recipients_pushover[webmaster]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
 
 
 # -----------------------------------------------------------------------------
@@ -97,3 +126,4 @@ role_recipients_email[proxyadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
 role_recipients_pushover[proxyadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -53,8 +53,14 @@ curl=
 sendmail=
 
 # enable / disable features
-SEND_EMAIL="YES"
+SEND_SLACK="YES"
 SEND_PUSHOVER="YES"
+SEND_EMAIL="YES"
+
+# slack configs
+SLACK_WEBHOOK_URL=
+DEFAULT_RECIPIENT_SLACK=
+declare -A role_recipients_slack=()
 
 # pushover configs
 PUSHOVER_APP_TOKEN=
@@ -65,6 +71,8 @@ declare -A role_recipients_pushover=()
 DEFAULT_RECIPIENT_EMAIL="root"
 declare -A role_recipients_email=()
 
+# load the user configuration
+# this will overwrite the variables above
 if [ -f "${NETDATA_CONFIG_DIR}/health_alarm_notify.conf" ]
     then
     source "${NETDATA_CONFIG_DIR}/health_alarm_notify.conf"
@@ -73,23 +81,65 @@ fi
 # -----------------------------------------------------------------------------
 # find the exact recipient per method
 
-to_email="${role_recipients_email[${recipient}]}"
-[ -z "${to_email}" ] && to_email="${DEFAULT_RECIPIENT_EMAIL}"
+declare -A arr_slack=()
+declare -A arr_pushover=()
+declare -A arr_email=()
+
+# netdata may call us with multiple recipients
+# so, here we find the unique ones
+for x in ${recipient}
+do
+    # email
+    a="${role_recipients_email[${recipient}]}"
+    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_EMAIL}"
+    for r in ${a//,/ }; do arr_email[${r}]="1"; done
+
+    # pushover
+    a="${role_recipients_pushover[${recipient}]}"
+    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_PUSHOVER}"
+    for r in ${a//,/ }; do arr_pushover[${r}]="1"; done
+
+    # slack
+    a="${role_recipients_slack[${recipient}]}"
+    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_SLACK}"
+    for r in ${a//,/ }; do arr_slack[${r}]="1"; done
+done
+
+# build the list of slack recipients (channels)
+to_slack="${!arr_slack[*]}"
+[ -z "${to_slack}" ] && SEND_SLACK="NO"
+
+# build the list of pushover recipients (user tokens)
+to_pushover="${!arr_pushover[*]}"
+[ -z "${to_pushover}" ] && SEND_PUSHOVER="NO"
+
+# build the list of email recipients (email addresses)
+to_email=
+for x in "${!arr_email[*]}"
+do
+    [ ! -z "${to_email}" ] && to_email="${to_email}, "
+    to_email="${to_email}${x}"
+done
 [ -z "${to_email}" ] && to_email="root"
 
-to_pushover="${role_recipients_pushover[${recipient}]}"
-[ -z "${to_pushover}" ] && to_pushover="${DEFAULT_RECIPIENT_EMAIL}"
-[ -z "${to_pushover}" ] && SEND_PUSHOVER="NO"
 
 # -----------------------------------------------------------------------------
 # verify the delivery methods supported
 
+# check slack
+[ -z "${SLACK_WEBHOOK_URL}" ] && SEND_SLACK="NO"
+
+# check pushover
 [ -z "${PUSHOVER_APP_TOKEN}" ] && SEND_PUSHOVER="NO"
 
-if [ "${SEND_PUSHOVER}" = "YES" -a -z "${curl}" ]
+if [ \( "${SEND_PUSHOVER}" = "YES" -o "${SEND_SLACK}" = "YES" \) -a -z "${curl}" ]
     then
     curl="$(which curl 2>/dev/null || command -v curl 2>/dev/null)"
-    [ -z "${curl}" ] && SEND_PUSHOVER="NO"
+    if [ -z "${curl}" ]
+        then
+        SEND_PUSHOVER="NO"
+        SEND_SLACK="NO"
+    fi
 fi
 
 if [ "${SEND_EMAIL}" = "YES" -a -z "${sendmail}" ]
@@ -99,7 +149,7 @@ if [ "${SEND_EMAIL}" = "YES" -a -z "${sendmail}" ]
 fi
 
 # check that we have at least a method enabled
-if [ "${SEND_EMAIL}" != "YES" -a "${SEND_PUSHOVER}" != "YES" ]
+if [ "${SEND_EMAIL}" != "YES" -a "${SEND_PUSHOVER}" != "YES" -a "${SEND_SLACK}" != "YES" ]
     then
     echo >&2 "I don't have a means to send a notification. Sorry!"
     exit 1
@@ -117,6 +167,30 @@ fi
 
 date="$(date --date=@${when} 2>/dev/null)"
 [ -z "${date}" ] && date="$(date 2>/dev/null)"
+
+# -----------------------------------------------------------------------------
+# URL encode a string
+
+urlencode() {
+    local string="${1}" strlen encoded pos c o
+
+    strlen=${#string}
+    for (( pos=0 ; pos<strlen ; pos++ ))
+    do
+        c=${string:$pos:1}
+        case "$c" in
+            [-_.~a-zA-Z0-9])
+                o="${c}"
+                ;;
+
+            *)
+                printf -v o '%%%02x' "'$c"
+                ;;
+        esac
+        encoded+="${o}"
+    done
+    echo "${encoded}"
+}
 
 # -----------------------------------------------------------------------------
 # convert a duration in seconds, to a human readable duration
@@ -195,15 +269,15 @@ send_email() {
 # pushover sender
 
 send_pushover() {
-    local apptoken="${1}" usertoken="${2}" when="${3}" url="${4}" status="${5}" title="${6}" message="${7}" httpcode sent=0 user priority
+    local apptoken="${1}" usertokens="${2}" when="${3}" url="${4}" status="${5}" title="${6}" message="${7}" httpcode sent=0 user priority
 
-    if [ "${SEND_PUSHOVER}" = "YES" -a ! -z "${apptoken}" -a ! -z "${usertoken}" -a ! -z "${title}" -a ! -z "${message}" ]
+    if [ "${SEND_PUSHOVER}" = "YES" -a ! -z "${apptoken}" -a ! -z "${usertokens}" -a ! -z "${title}" -a ! -z "${message}" ]
         then
 
         priority=0
         [ "${status}" = "CRITICAL" ] && priority=1
 
-        for user in ${usertoken//,/ }
+        for user in ${usertokens}
         do
             httpcode=$(${curl} --write-out %{http_code} --silent --output /dev/null \
                 --form-string "token=${apptoken}" \
@@ -219,10 +293,47 @@ send_pushover() {
 
             if [ "${httpcode}" == "200" ]
             then
-                echo >&2 "${me}: Sent notification push for ${status} on '${chart}.${name}' to '${user}'"
+                echo >&2 "${me}: Sent pushover notification for: ${host} ${chart}.${name} is ${status} to '${user}'"
                 sent=$((sent + 1))
             else
-                echo >&2 "${me}: FAILED to send notification push for ${status} on '${chart}.${name}' to '${user}' with HTTP error code ${httpcode}."
+                echo >&2 "${me}: Failed to send pushover notification for: ${host} ${chart}.${name} is ${status} to '${user}' with HTTP error code ${httpcode}."
+            fi
+        done
+
+        [ ${sent} -gt 0 ] && return 0
+    fi
+
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# slack sender
+
+send_slack() {
+    local webhook="${1}" channels="${2}" when="${3}" username="${4}" image="${5}" author="${6}" httpcode sent=0 channel color
+
+    if [ "${SEND_SLACK}" = "YES" -a ! -z "${webhook}" -a ! -z "${channels}" -a ! -z "${username}" -a ! -z "${image}" -a ! -z "${author}" ]
+        then
+
+        case "${status}" in
+            WARNING) color="warning" ;;
+            CRITICAL) color="danger" ;;
+            CLEAR) color="good" ;;
+            *) color="#777777" ;;
+        esac
+
+        for channel in ${channels}
+        do
+            httpcode=$(${curl} --write-out %{http_code} --silent --output /dev/null -X POST --data-urlencode \
+                "payload={\"channel\": \"#${channel}\", \"username\": \"${username}\", \"text\": \"${hostname} ${status_message} about ${author} ${raised_for} - click <${goto_url}|here> to view the netdata dashboard.\", \"icon_url\": \"${image}\", \"attachments\": [{\"fallback\": \"${alarm} - ${info}\", \"color\": \"${color}\", \"title\": \"${alarm}\", \"title_link\": \"${goto_url}\", \"text\": \"${info}\", \"footer\": \"netdata\", \"footer_icon\": \"${NETDATA_REGISTRY_URL}/images/seo-performance-128.png\", \"ts\": ${when}}]}" \
+                "${webhook}")
+
+            if [ "${httpcode}" == "200" ]
+            then
+                echo >&2 "${me}: Sent slack notification for: ${host} ${chart}.${name} is ${status} to '${channel}'"
+                sent=$((sent + 1))
+            else
+                echo >&2 "${me}: Failed to send slack notification for: ${host} ${chart}.${name} is ${status} to '${channel}', with HTTP error code ${httpcode}."
             fi
         done
 
@@ -236,17 +347,14 @@ send_pushover() {
 # -----------------------------------------------------------------------------
 # prepare the content of the notification
 
-# description of the alarm
-[ ! -z "${info}" ] && info=" <small><br/>${info}</small>"
-
 # the url to send the user on click
-goto_url="${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html?machine_guid=${NETDATA_REGISTRY_UNIQUE_ID}&chart=${chart}&family=${family}"
+goto_url="${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html?host=$(urlencode "${NETDATA_REGISTRY_HOSTNAME}")&chart=${chart}&family=${family}"
 
 # the severity of the alarm
 severity="${status}"
 
 # the time the alarm was raised
-raised_for="<br/><small>(was ${old_status,,} for $(duration4human ${duration}))</small>"
+raised_for="(was ${old_status,,} for $(duration4human ${duration}))"
 
 # the key status message
 status_message="status unknown"
@@ -257,19 +365,25 @@ color="grey"
 # the alarm value
 alarm="${name//_/ } = ${value} ${units}"
 
+# the image of the alarm
+image="${NETDATA_REGISTRY_URL}/images/seo-performance-128.png"
+
 # prepare the title based on status
 case "${status}" in
 	CRITICAL)
+        image="${NETDATA_REGISTRY_URL}/images/alert-128-red.png"
         status_message="is critical"
         color="#ca414b"
         ;;
 
     WARNING)
+        image="${NETDATA_REGISTRY_URL}/images/alert-128-orange.png"
         status_message="needs attention"
         color="#caca4b"
 		;;
 
 	CLEAR)
+        image="${NETDATA_REGISTRY_URL}/images/check-mark-2-128-green.png"
     	status_message="recovered"
 		color="#77ca6d"
 
@@ -284,7 +398,7 @@ then
     severity="Recovered from ${old_status}"
     if [ $non_clear_duration -gt $duration ]
     then
-        raised_for="<br/><small>(had issues for $(duration4human ${non_clear_duration}))</small>"
+        raised_for="(had issues for $(duration4human ${non_clear_duration}))"
     fi
 
 elif [ "${old_status}" = "WARNING" -a "${status}" = "CRITICAL" ]
@@ -292,7 +406,7 @@ then
     severity="Escalated to ${status}"
     if [ $non_clear_duration -gt $duration ]
     then
-        raised_for="<br/><small>(has issues for $(duration4human ${non_clear_duration}))</small>"
+        raised_for="(has issues for $(duration4human ${non_clear_duration}))"
     fi
 
 elif [ "${old_status}" = "CRITICAL" -a "${status}" = "WARNING" ]
@@ -300,23 +414,38 @@ then
     severity="Demoted to ${status}"
     if [ $non_clear_duration -gt $duration ]
     then
-        raised_for="<br/><small>(has issues for $(duration4human ${non_clear_duration}))</small>"
+        raised_for="(has issues for $(duration4human ${non_clear_duration}))"
     fi
 
 else
     raised_for=
 fi
 
+# prepare HTML versions of elements
+info_html=
+[ ! -z "${info}" ] && info_html=" <small><br/>${info}</small>"
+
+raised_for_html=
+[ ! -z "${raised_for}" ] && raised_for_html="<br/><small>${raised_for}</small>"
 
 # -----------------------------------------------------------------------------
-# send the pushover
+# send the slack notification
+
+# slack aggregates posts from the same username
+# so we use "${hostname} ${status}" as the bot username, to make them diff
+
+send_slack "${SLACK_WEBHOOK_URL}" "${to_slack}" "${when}" "${hostname} ${status}" "${image}" "${chart} (${family})"
+SENT_SLACK=$?
+
+# -----------------------------------------------------------------------------
+# send the pushover notification
 
 send_pushover "${PUSHOVER_APP_TOKEN}" "${to_pushover}" "${when}" "${goto_url}" "${status}" "${hostname} ${status_message} - ${name//_/ } - ${chart}" "
-<font color=\"${color}\"><b>${alarm}</b></font>${info}<br/>&nbsp;
+<font color=\"${color}\"><b>${alarm}</b></font>${info_html}<br/>&nbsp;
 <small><b>${chart}</b><br/>Chart<br/>&nbsp;</small>
 <small><b>${family}</b><br/>Family<br/>&nbsp;</small>
 <small><b>${severity}</b><br/>Severity<br/>&nbsp;</small>
-<small><b>${date}${raised_for}</b><br/>Time<br/>&nbsp;</small>
+<small><b>${date}${raised_for_html}</b><br/>Time<br/>&nbsp;</small>
 <a href=\"${goto_url}\">View Netdata</a><br/>&nbsp;
 <small><small>The source of this alarm is line ${src}</small></small>
 "
@@ -326,79 +455,77 @@ SENT_PUSHOVER=$?
 # -----------------------------------------------------------------------------
 # send the email
 
-cat <<EOF | send_email
+send_email <<EOF
 To: ${to_email}
 Subject: ${hostname} ${status_message} - ${name//_/ } - ${chart}
 Content-Type: text/html
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; padding: 0;">
-<body style="font-family:'Helvetica Neue','Helvetica',Helvetica,Arial,sans-serif;font-size:14px;width:100%!important;min-height:100%;line-height:1.6;background:#f6f6f6;margin:0;padding:0">
+<body style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; width: 100% !important; min-height: 100%; line-height: 1.6; background: #f6f6f6; margin:0; padding: 0;">
 <table>
     <tbody>
     <tr>
-        <td style="vertical-align:top;" valign="top"></td>
-        <td width="700" style="vertical-align:top;display:block!important;max-width:700px!important;clear:both!important;margin:0 auto;padding:0" valign="top">
-            <div style="max-width:700px;display:block;margin:0 auto;padding:20px">
-                <table width="100%" cellpadding="0" cellspacing="0" style="background:#fff;border:1px solid #e9e9e9">
+        <td style="vertical-align: top;" valign="top"></td>
+        <td width="700" style="vertical-align: top; display: block !important; max-width: 700px !important; clear: both !important; margin: 0 auto; padding: 0;" valign="top">
+            <div style="max-width: 700px; display: block; margin: 0 auto; padding: 20px;">
+                <table width="100%" cellpadding="0" cellspacing="0" style="background: #fff; border: 1px solid #e9e9e9;">
                     <tbody>
                     <tr>
-                        <td bgcolor="#eee" style="padding: 5px 20px 5px 20px;background-color:#eee;">
-                            <div style="font-size:20px;color:#777;font-weight: bold;">netdata notification</div>
+                        <td bgcolor="#eee" style="padding: 5px 20px 5px 20px; background-color: #eee;">
+                            <div style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 20px; color: #777; font-weight: bold;">netdata notification</div>
                         </td>
                     </tr>
                     <tr>
-                        <td bgcolor="${color}" style="font-size:16px;vertical-align:top;font-weight:400;text-align:center;margin:0;padding:10px;color:#ffffff;background:${color}!important;border:1px solid ${color};border-top-color:${color}" align="center" valign="top">
-                            <h1 style="font-weight:400;margin:0">${hostname} ${status_message}</h1>
+                        <td bgcolor="${color}" style="font-size: 16px; vertical-align: top; font-weight: 400; text-align: center; margin: 0; padding: 10px; color: #ffffff; background: ${color} !important; border: 1px solid ${color}; border-top-color: ${color};" align="center" valign="top">
+                            <h1 style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: 400; margin: 0;">${hostname} ${status_message}</h1>
                         </td>
                     </tr>
                     <tr>
-                        <td style="vertical-align:top" valign="top">
-                            <div style="margin:0;padding:20px;max-width:700px">
+                        <td style="vertical-align: top;" valign="top">
+                            <div style="margin: 0; padding: 20px; max-width: 700px;">
                                 <table width="100%" cellpadding="0" cellspacing="0" style="max-width:700px">
                                     <tbody>
                                     <tr>
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px" align="left" valign="top">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding:0 0 20px;" align="left" valign="top">
                                             <span>${chart}</span>
-                                            <span style="display:block;color:#666666;font-size:12px;font-weight:300;line-height:1;text-transform:uppercase">Chart</span>
+                                            <span style="display: block; color: #666666; font-size: 12px; font-weight: 300; line-height: 1; text-transform: uppercase;">Chart</span>
                                         </td>
                                     </tr>
-                                    <tr style="margin:0;padding:0">
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px" align="left" valign="top">
-                                            <span><b>${alarm}</b>${info}</span>
-                                            <span style="display:block;color:#666666;font-size:12px;font-weight:300;line-height:1;text-transform:uppercase">Alarm</span>
+                                    <tr style="margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" align="left" valign="top">
+                                            <span><b>${alarm}</b>${info_html}</span>
+                                            <span style="display: block; color: #666666; font-size: 12px; font-weight: 300; line-height: 1; text-transform: uppercase;">Alarm</span>
                                         </td>
                                     </tr>
                                     <tr>
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px" align="left" valign="top">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" align="left" valign="top">
                                             <span>${family}</span>
-                                            <span style="display:block;color:#666666;font-size:12px;font-weight:300;line-height:1;text-transform:uppercase">Family</span>
+                                            <span style="display: block; color: #666666; font-size: 12px; font-weight: 300; line-height: 1; text-transform: uppercase;">Family</span>
                                         </td>
                                     </tr>
-                                    <tr style="margin:0;padding:0">
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px" align="left" valign="top">
+                                    <tr style="margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" align="left" valign="top">
                                             <span>${severity}</span>
-                                            <span style="display:block;color:#666666;font-size:12px;font-weight:300;line-height:1;text-transform:uppercase">Severity</span>
+                                            <span style="display: block; color: #666666; font-size: 12px; font-weight: 300; line-height: 1; text-transform: uppercase;">Severity</span>
                                         </td>
                                     </tr>
-                                    <tr style="margin:0;padding:0">
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px" align="left" valign="top"><span>${date}</span>
-                                            <span>${raised_for}</span> <span style="display:block;color:#666666;font-size:12px;font-weight:300;line-height:1;text-transform:uppercase">Time</span>
+                                    <tr style="margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" align="left" valign="top"><span>${date}</span>
+                                            <span>${raised_for_html}</span> <span style="display: block; color: #666666; font-size: 12px; font-weight: 300; line-height: 1; text-transform: uppercase;">Time</span>
                                         </td>
                                     </tr>
-                                    <!--
-                                    <tr style="margin:0;padding:0">
-                                        <td style="font-size:18px;vertical-align:top;margin:0;padding:0 0 20px">
-                                            <a href="${goto_url}" style="font-size:14px;color:#ffffff;text-decoration:none;line-height:1.5;font-weight:bold;text-align:center;display:inline-block;text-transform:capitalize;background:#35568d;border-width:1px;border-style:solid;border-color:#2b4c86;margin:0;padding:10px 15px" target="_blank">View Netdata</a>
+                                    <tr style="margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;">
+                                            <a href="${goto_url}" style="font-size: 14px; color: #ffffff; text-decoration: none; line-height: 1.5; font-weight: bold; text-align: center; display: inline-block; text-transform: capitalize; background: #35568d; border-width: 1px; border-style: solid; border-color: #2b4c86; margin: 0; padding: 10px 15px;" target="_blank">View Netdata</a>
                                         </td>
                                     </tr>
-                                    -->
-                                    <tr style="text-align:center;margin:0;padding:0">
-                                        <td style="font-size:11px;vertical-align:top;margin:0;padding:10px 0 0 0;color:#666666" align="center" valign="bottom">The source of this alarm is line <code>${src}</code>
+                                    <tr style="text-align: center; margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 11px; vertical-align: top; margin: 0; padding: 10px 0 0 0; color: #666666;" align="center" valign="bottom">The source of this alarm is line <code>${src}</code>
                                         </td>
                                     </tr>
-                                    <tr style="text-align:center;margin:0;padding:0">
-                                        <td style="font-size:12px;vertical-align:top;margin:0;padding:20px 0 0 0;color:#666666;border-top:1px solid #f0f0f0" align="center" valign="bottom">Sent by
+                                    <tr style="text-align: center; margin: 0; padding: 0;">
+                                        <td style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 12px; vertical-align: top; margin:0; padding: 20px 0 0 0; color: #666666; border-top: 1px solid #f0f0f0;" align="center" valign="bottom">Sent by
                                             <a href="https://mynetdata.io/" target="_blank">netdata</a>, the real-time performance monitoring.
                                         </td>
                                     </tr>
@@ -424,7 +551,7 @@ SENT_EMAIL=$?
 # let netdata know
 
 # we did send somehting
-[ ${SENT_EMAIL} -eq 0 -o ${SENT_PUSHOVER} -eq 0 ] && exit 0
+[ ${SENT_EMAIL} -eq 0 -o ${SENT_PUSHOVER} -eq 0 -o ${SENT_SLACK} -eq 0 ] && exit 0
 
 # we did not send anything
 exit 1


### PR DESCRIPTION
With this PR, `alarm-notify.sh` supports:

1. email notifications
2. pushover.net notifications
3. slack.com notifications (slack calls them: **incoming webhooks**)

Also, each alarm gives one or **more roles** (yes, with this PR, multiple roles can be given, space separated at the `to` line).

For each role, there may be multiple recipients (email addresses, pushover user tokens, slack channels).

Documentation for configuring it, at `/etc/netdata/health_alarm_notify.conf` (here online: https://github.com/firehol/netdata/blob/master/conf.d/health_alarm_notify.conf)

cc: #285 #663 #846 #826 #88 #879 #318 #775 #809 #813 #848 

This is how it looks:

![image](https://cloud.githubusercontent.com/assets/2662304/18405218/d5ae63a2-76f8-11e6-8b8f-3a0be1b73f65.png)
