### PR TITLE
alarm notifications minor improvements

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -72,6 +72,7 @@ SEND_SLACK="YES"
 # Login to slack.com and create an incoming webhook.
 # You need only one for all your netdata servers.
 # Without it, netdata cannot send slack notifications.
+# Get yours from: https://api.slack.com/incoming-webhooks
 SLACK_WEBHOOK_URL=""
 
 # if a role's recipients are not configured, a notification will be send to

--- a/web/goto-host-from-alarm.html
+++ b/web/goto-host-from-alarm.html
@@ -46,12 +46,22 @@
     var gotoServerValidateRemaining = 0;
     var gotoServerMiddleClick = false;
     var gotoServerStop = false;
+    var thisIsHttps = false;
+    var urlsInHttp = 0;
     function gotoServerValidateUrl(id, guid, url) {
         var penaldy = 0;
-        if(document.location.toString().startsWith('http://') && url.toString().startsWith('https://'))
-                // we penalize https only if the current url is http
-                // to allow the user walk through all its servers.
-                penaldy = 500;
+        var error = 'failed';
+
+        if(thisIsHttps === false && url.toString().startsWith('https://')) {
+            // we penalize https only if the current url is http
+            // to allow the user walk through all its servers.
+            penaldy = 500;
+        }
+
+        else if(thisIsHttps === true && url.toString().startsWith('http://')) {
+            error = 'can\'t check';
+            urlsInHttp++;
+        }
 
         var finalURL = netdataURL(url);
 
@@ -66,7 +76,7 @@
                         gotoServerStop = true;
 
                         if(gotoServerMiddleClick) {
-                            window.open(finalURL, '_blank');
+                            window.open(finalURL);
                             gotoServerMiddleClick = false;
                             document.getElementById('gotoServerResponse').innerHTML = '<b>Opening new window to ' + NETDATA.registry.machines[guid].name + '<br/><a href="' + finalURL + '">' + url + '</a></b><br/>(check your pop-up blocker if it fails)';
                         }
@@ -75,11 +85,16 @@
                     }
                 }
                 else {
-                    document.getElementById(guid + '-' + id + '-status').innerHTML = "failed!";
+                    document.getElementById(guid + '-' + id + '-status').innerHTML = error;
                     gotoServerValidateRemaining--;
                     if(gotoServerValidateRemaining <= 0) {
                         gotoServerMiddleClick = false;
                         document.getElementById('gotoServerResponse').innerHTML = '<b>Sorry! I cannot find any operational URL for this server</b>';
+
+                        if(thisIsHttps === true && urlsInHttp > 0) {
+                            document.getElementById('gotoServerResponse').innerHTML += '<br/>redirecting myself to HTTP to allow checking';
+                            document.location = document.location.toString().replace('https://', 'http://');
+                        }
                     }
                 }
             });
@@ -87,6 +102,11 @@
     }
 
     var netdataRegistryCallback = function(machines_array) {
+        document.getElementById('message').innerHTML = 'These are the URLs this machine is known:';
+
+        if(document.location.toString().startsWith('https://'))
+            thisIsHttps = true;
+
         if(machines_array) {
             var len = machines_array.length;
             while(len--) {
@@ -119,7 +139,7 @@
 <body>
 <div class="container" id="">
     <div id="bodylog" style="padding-top: 8vmax; font-size: 2.0vmax;">
-        Please wait...
+        <span id="message">Please wait...</span>
 
         <div style="padding-top: 20px;">
             <table id="gotoServerList" class="table">

--- a/web/goto-host-from-alarm.html
+++ b/web/goto-host-from-alarm.html
@@ -23,6 +23,10 @@
         host: null,
         chart: null,
         family: null,
+        alarm: null,
+        alarm_unique_id: 0,
+        alarm_id: 0,
+        alarm_event_id: 0,
         hasProperty: function(property) {
             return typeof this[property] !== 'undefined';
         }
@@ -40,7 +44,16 @@
     }
 
     function netdataURL(url) {
-        return url + '#top;show_alarms=true;chart=' + urlOptions.chart + ';family=' + urlOptions.family;
+        return url + '#top'
+            + ';nowelcome=1'
+            + ';show_alarms=1'
+            + ';chart=' + urlOptions.chart.toString()
+            + ';family=' + urlOptions.family.toString()
+            + ';alarm=' + urlOptions.alarm.toString()
+            + ';alarm_unique_id=' + urlOptions.alarm_unique_id.toString()
+            + ';alarm_id=' + urlOptions.alarm_id.toString()
+            + ';alarm_event_id=' + urlOptions.alarm_event_id.toString()
+            ;
     }
 
     var gotoServerValidateRemaining = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -1263,11 +1263,16 @@ var gotoServerMiddleClick = false;
 var gotoServerStop = false;
 function gotoServerValidateUrl(id, guid, url) {
     var penaldy = 0;
+    var error = 'failed';
+
     if(document.location.toString().startsWith('http://') && url.toString().startsWith('https://'))
             // we penalize https only if the current url is http
             // to allow the user walk through all its servers.
             penaldy = 500;
 
+    else if(document.location.toString().startsWith('https://') && url.toString().startsWith('http://'))
+        error = 'can\'t check';
+    
     var finalURL = netdataURL(url);
 
     setTimeout(function() {

--- a/web/index.html
+++ b/web/index.html
@@ -408,10 +408,14 @@
             pan_and_zoom: false,
             after: 0,
             before: 0,
-            nowelcome: 0,
-            show_alarms: 0,
+            nowelcome: false,
+            show_alarms: false,
             chart: null,
             family: null,
+            alarm: null,
+            alarm_unique_id: 0,
+            alarm_id: 0,
+            alarm_event_id: 0,
             hasProperty: function(property) {
                 // console.log('checking property ' + property + ' of type ' + typeof(this[property]));
                 return typeof this[property] !== 'undefined';
@@ -461,8 +465,21 @@
                 }
             }
 
-            if(urlOptions.before > 0 && urlOptions.after > 0)
+            var booleans = [ 'nowelcome', 'show_alarms', 'pan_and_zoom' ];
+            len = booleans.length;
+            while(len--) {
+                if(urlOptions[booleans[len]] === 'true' || urlOptions[booleans[len]] === true || urlOptions[booleans[len]] === '1' || urlOptions[booleans[len]] === 1)
+                    urlOptions[booleans[len]] = true;
+                else
+                    urlOptions[booleans[len]] = false;
+            }
+
+            if(urlOptions.before > 0 && urlOptions.after > 0) {
                 urlOptions.pan_and_zoom = true;
+                urlOptions.nowelcome = true;
+            }
+            else
+                urlOptions.pan_and_zoom = false;
 
             // console.log(urlOptions);
         }
@@ -3030,10 +3047,8 @@ function finalizePage() {
     // the Dom elements are initially zero-sized
     NETDATA.parseDom();
 
-    if(urlOptions.pan_and_zoom === true) {
-        urlOptions.nowelcome = true;
+    if(urlOptions.pan_and_zoom === true)
         NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], urlOptions.after, urlOptions.before);
-    }
 
     // ------------------------------------------------------------------------
     // https://github.com/viralpatel/jquery.shorten/blob/master/src/jquery.shorten.js
@@ -3299,7 +3314,7 @@ function finalizePage() {
     });
 
     if(isdemo()) {
-        if(!urlOptions.nowelcome) {
+        if(urlOptions.nowelcome !== true) {
             setTimeout(function() {
                 $('#welcomeModal').modal();
             }, 1000);
@@ -3319,7 +3334,7 @@ function finalizePage() {
     }
     else notifyForUpdate();
 
-    if(urlOptions.show_alarms === 'true')
+    if(urlOptions.show_alarms === true)
         setTimeout(function() { $('#alarmsModal').modal('show'); }, 1000);
 }
 


### PR DESCRIPTION
1. re-worked parsing of alarm related URL options.
2. alarm redirections to an HTTP netdata from an HTTPS registry failed (can't be checked) - now the registry will attempt to redirect the client to an HTTP registry URL and then perform the check again.
3. speed improvements in `alarm-notify.sh`.