### PR TITLE
installer now generates netdata-updater.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ netdata.spec
 
 *.tar.*
 
+cov-int/
+netdata-coverity-analysis.tgz
+
 .cproject
 .idea/
 .project
@@ -66,6 +69,7 @@ python.d/python-modules-installer.sh
 
 netdata-installer.log
 netdata-uninstaller.sh
+netdata-updater.sh
 
 gmon.out
 gmon.txt

--- a/web/index.html
+++ b/web/index.html
@@ -1799,7 +1799,7 @@ var chartData = {
 
     'system.entropy': {
         colors: '#CC22AA',
-        info: '<a href="https://en.wikipedia.org/wiki/Entropy_(computing)" target="_blank">Entropy</a>, read from <code>/proc/sys/kernel/random/entropy_avail</code>, is like a pool of random numbers that are mainly used in cryptography. It is advised that the pool remains always <a href="https://blog.cloudflare.com/ensuring-randomness-with-linuxs-random-number-generator/" target="_blank">above 200</a>. If the pool of entropy gets empty, you risk your security to be predictable and you should install a user-space random numbers generating daemon, like <a href="http://www.issihosts.com/haveged/" target="_blank">haveged</a>, to keep the pool in healthy levels.'
+        info: '<a href="https://en.wikipedia.org/wiki/Entropy_(computing)" target="_blank">Entropy</a>, read from <code>/proc/sys/kernel/random/entropy_avail</code>, is like a pool of random numbers (<a href="https://en.wikipedia.org/wiki//dev/random" target="_blank">/dev/random</a>) that are mainly used in cryptography. It is advised that the pool remains always <a href="https://blog.cloudflare.com/ensuring-randomness-with-linuxs-random-number-generator/" target="_blank">above 200</a>. If the pool of entropy gets empty, you risk your security to be predictable and you should install a user-space random numbers generating daemon, like <a href="http://www.issihosts.com/haveged/" target="_blank">haveged</a> or <code>rng-tools</code> (i.e. <b>rngd</b>), to keep the pool in healthy levels.'
     },
 
     'system.forks': {


### PR DESCRIPTION
`netdata-installer.sh` now generates `netdata-updater.sh` which you can run either interactively or from cron-job.

When running headless (i.e. crontab) the updater will not output anything, unless something failed, so that you will receive an email from crond if it fails.

The updater is re-generated after each successful netdata installation. It maintains all flags and options given to the installer, including the working directory.

I needed something like that to quickly update a lot of servers. So, here it it.