### PR TITLE
Do not reclone the current project from github, as it's already here

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 
 FROM debian:jessie
 
-ADD docker-build.sh /docker-build.sh
+ADD . /netdata.git
 
-RUN chmod +x /docker-build.sh && sync && sleep 1 && /docker-build.sh
+RUN cd ./netdata.git && chmod +x ./docker-build.sh && sync && sleep 1 && ./docker-build.sh
 
 WORKDIR /
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -17,11 +17,6 @@ apt-get -qq update
 apt-get -y install zlib1g-dev uuid-dev libmnl-dev gcc make curl git autoconf autogen automake pkg-config netcat-openbsd jq
 apt-get -y install autoconf-archive lm-sensors nodejs python python-mysqldb python-yaml
 
-# fetch netdata
-
-git clone https://github.com/firehol/netdata.git /netdata.git --depth=1
-cd /netdata.git
-
 # use the provided installer
 
 ./netdata-installer.sh --dont-wait --dont-start-it


### PR DESCRIPTION
The fact that the Dockerfile would eventually reclone the entire project to build it was surprising to me. I was trying the slightly modify the build script so that the `netdata` user would have a fixed `uid`, but none of my changes were taken into account, because the build script that was executed was the one freshly cloned from github.

If you accept this PR, then the Dockerfile will build `netdata` using the code that was already pulled in the current directory. 