### PR TITLE
cacheable registry response; minor alarm fine tunining

### DIFF
--- a/conf.d/health.d/softnet.conf
+++ b/conf.d/health.d/softnet.conf
@@ -5,7 +5,7 @@
   lookup: sum -1h unaligned absolute of dropped
    units: packets
    every: 1m
-    warn: $this > 0
+    warn: $this > ( ($status >= $WARNING) ? (0) : (5) )
    delay: down 30m multiplier 1.5 max 1h
     info: number of packets dropped because sysctl net.core.netdev_max_backlog was exceeded (this can be a cause for dropped packets)
       to: sysadmin
@@ -15,7 +15,7 @@
   lookup: sum -1h unaligned absolute of squeezed
    units: events
    every: 1m
-    warn: $this > 0
+    warn: $this > ( ($status >= $WARNING) ? (0) : (5) )
    delay: down 30m multiplier 1.5 max 1h
     info: number of times ksoftirq ran out of sysctl net.core.netdev_budget or time slice, with work remaining (this can be a cause for dropped packets)
       to: sysadmin

--- a/configs.signatures
+++ b/configs.signatures
@@ -131,6 +131,7 @@ declare -A configs_signatures=(
   ['1c12b678ab65f271a96da1bbd0a1ab1c']='health.d/softnet.conf'
   ['312b4b8e2805e19cf9be554b319567d6']='health.d/softnet.conf'
   ['565f11c38ae6bd5cc9d3c2adb542bc1b']='health.d/softnet.conf'
+  ['6398ef37a15cb6a0bc921f58948d2b39']='health.d/softnet.conf'
   ['a305b400378d6492efd15f9940c2779b']='health.d/softnet.conf'
   ['23ae815aefa221b1929f96752a1f7556']='health.d/squid.conf'
   ['3cc6255457d4cba881ae0554ae5d9190']='health.d/squid.conf'

--- a/web/index.html
+++ b/web/index.html
@@ -562,14 +562,23 @@
             var a1 = '';
             var found = 0;
 
+            if(machines_array === null) {
+                var ret = loadLocalStorage("registryCallback");
+                if(typeof ret !== 'undefined' && ret !== null) {
+                    machines_array = JSON.parse(ret);
+                    console.log("failed to contact the registry - loaded registry data from browser local storage");
+                }
+            }
+
             if(machines_array) {
-                function name_comparator_desc(a, b) {
+                saveLocalStorage("registryCallback", JSON.stringify(machines_array));
+
+                var machines = machines_array.sort(function (a, b) {
                     if (a.name > b.name) return -1;
                     if (a.name < b.name) return 1;
                     return 0;
-                }
+                });
 
-                var machines = machines_array.sort(name_comparator_desc);
                 var len = machines.length;
                 while(len--) {
                     var u = machines[len];


### PR DESCRIPTION
This PR includes:

1. registry responses for the my-netdata menu are now cacheable. This is to remove some stress from me, while updating netdata versions at the public global registry. Of course there is already another node that is synced every a few minutes, but it is not active-active yet.

2. an attempt to settle a few noisy alarms. Of course, I am not sure this is the right way to deal with these alarms, but anyway, until we find a better way, I think it is better to make the alarms more elastic.
