### PR TITLE
Changed documentation for nginx.

### DIFF
--- a/conf.d/python.d/nginx.conf
+++ b/conf.d/python.d/nginx.conf
@@ -1,5 +1,18 @@
 # netdata python.d.plugin configuration for nginx
 #
+# You must have ngx_http_stub_status_module configured on your nginx server for this
+# plugin to work. The following is an example config.
+# It must be located inside a server { } block.
+#  
+# location /stub_status {
+#   stub_status;
+#   # Security: Only allow access from the IP below.
+#   allow 192.168.1.200;
+#   # Deny anyone else
+#   deny all;
+#  }
+# Location must be /stub_status, nothing else will work.
+#
 # This file is in YaML format. Generally the format is:
 #
 # name: value
@@ -47,14 +60,15 @@
 # predefined parameters. These are:
 #
 # job_name:
-#     name: myname     # the JOB's name as it will appear at the
-#                      # dashboard (by default is the job_name)
+#     name: my_name    # the JOB's name as it will appear at the
+#                      # dashboard. If name: is not supplied the
+#                      # job_name: will be used (use _ for spaces)
 #                      # JOBs sharing a name are mutually exclusive
 #     update_every: 1  # the JOB's data collection frequency
 #     priority: 60000  # the JOB's order on the dashboard
 #     retries: 5       # the JOB's number of restoration attempts
 #
-# Additionally to the above, nginx also supports the following:
+# Additionally to the above, this plugin also supports the following:
 #
 #     url: 'URL'       # the URL to fetch nginx's status stats
 #
@@ -63,6 +77,14 @@
 #     user: 'username'
 #     pass: 'password'
 #
+# Example
+# 
+# RemoteNginx:
+#     name : 'Reverse_Proxy'
+#     url  : 'http://yourdomain.com/stub_status'
+#
+# "RemoteNginx" will show up in Netdata logs. "Reverse Proxy" will show up in the menu
+# in the nginx section.
 
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -444,10 +444,12 @@ If no configuration is given, module will attempt to connect to mysql server via
 
 # nginx
 
-This module will monitor one or more nginx servers depending on configuration. 
+This module will monitor one or more nginx servers depending on configuration. Servers can be either local or remote. 
 
 **Requirements:**
- * nginx with configured `stub_status`
+ * nginx with configured 'ngx_http_stub_status_module'
+ * 'location /stub_status'
+Example nginx configuration can be found in 'python.d/nginx.conf'
 
 It produces following charts:
 


### PR DESCRIPTION
I changed examples and descriptions in the python.d/README.md and the python.d/nginx.conf to make it easier for a linux novice to follow along. And to clear up the requirement for /stub_status as it is explicit and will only work from that location.