### PR TITLE
minor improvements

### DIFF
--- a/conf.d/health.d/entropy.conf
+++ b/conf.d/health.d/entropy.conf
@@ -11,4 +11,4 @@
     warn: $this < (($status >= $WARNING) ? (200) : (100))
    delay: down 1h multiplier 1.5 max 1h
     info: minimum entries in the random numbers pool in the last 30 minutes
-      to: sysadmin
+      to: silent

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -26,7 +26,7 @@ printf "%q " "$0" "${@}" >>netdata-installer.log
 printf "\n" >>netdata-installer.log
 
 REINSTALL_PWD="${PWD}"
-REINSTALL_COMMAND="$(printf "CFLAGS=\"%s\" " "${CFLAGS}"; printf "%q " "$0" "${@}"; printf "\n")"
+REINSTALL_COMMAND="$(printf "%q " "$0" "${@}"; printf "\n")"
 
 service="$(which service 2>/dev/null || command -v service 2>/dev/null)"
 systemctl="$(which systemctl 2>/dev/null || command -v systemctl 2>/dev/null)"
@@ -1076,6 +1076,9 @@ echo >&2 "Uninstall script generated: ./netdata-uninstaller.sh"
 
 cat >netdata-updater.sh.new <<REINSTALL
 #!/usr/bin/env bash
+
+export PATH="\${PATH}:${PATH}"
+export CFLAGS="${CFLAGS}"
 
 LAST_UID="${UID}"
 if [ "\${LAST_UID}" != "\${UID}" ]

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -27,9 +27,10 @@ current_time_ms_from_date() {
 
 current_time_ms_from_date
 current_time_ms_from_uptime_started="${now_ms}"
+current_time_ms_from_uptime_last="${now_ms}"
 current_time_ms_from_uptime_first=0
 current_time_ms_from_uptime() {
-    local up rest arr n
+    local up rest arr=() n
 
     read up rest </proc/uptime
     if [ $? -ne 0 ]
@@ -58,16 +59,19 @@ current_time_ms_from_uptime() {
 
     now_ms=$((current_time_ms_from_uptime_started - current_time_ms_from_uptime_first + n))
 
-    if [ "${now_ms}" -lt "${current_time_ms_from_uptime_started}" ]
+    if [ "${now_ms}" -lt "${current_time_ms_from_uptime_last}" ]
         then
-        echo >&2 "$0: Cannot use current_time_ms_from_uptime() - falling back to current_time_ms_from_date()."
+        echo >&2 "$0: Cannot use current_time_ms_from_uptime() - new time ${now_ms} is older than the last ${current_time_ms_from_uptime_last} - falling back to current_time_ms_from_date()."
         current_time_ms="current_time_ms_from_date"
         current_time_ms_from_date
         current_time_ms_accuracy=1
     fi
+
+    current_time_ms_from_uptime_last="${now_ms}"
 }
 current_time_ms_from_uptime
 current_time_ms_from_uptime_first="$((now_ms - current_time_ms_from_uptime_started))"
+current_time_ms_from_uptime_last="${current_time_ms_from_uptime_first}"
 current_time_ms="current_time_ms_from_uptime"
 current_time_ms_accuracy=10
 if [ "${current_time_ms_from_uptime_first}" -eq 0 ]
@@ -129,25 +133,19 @@ loopsleepms() {
         return
     fi
 
-    # get the current time, in ms
+    # get the current time, in ms in ${now_ms}
     ${current_time_ms}
 
-    # this is our first run
-    # just wait the requested time
-    if [ ${LOOPSLEEPMS_LASTRUN} -eq 0 ]
-        then
-        LOOPSLEEPMS_LASTWORK=0
-    else
-        # calculate ms since last run
+    # calculate ms since last run
+    [ ${LOOPSLEEPMS_LASTRUN} -gt 0 ] && \
         LOOPSLEEPMS_LASTWORK=$((now_ms - LOOPSLEEPMS_LASTRUN - LOOPSLEEPMS_LASTSLEEP))
-    fi
     # echo "# last loop's work took $LOOPSLEEPMS_LASTWORK ms"
-
+    
     # remember this run
     LOOPSLEEPMS_LASTRUN=${now_ms}
 
-    # calculate the next run    
-    LOOPSLEEPMS_NEXTRUN=$(( ( now_ms - now_ms % ( t * 1000 ) ) + ( t * 1000 ) ))
+    # calculate the next run
+    LOOPSLEEPMS_NEXTRUN=$(( ( now_ms - ( now_ms % ( t * 1000 ) ) ) + ( t * 1000 ) ))
 
     # calculate ms to sleep
     mstosleep=$(( LOOPSLEEPMS_NEXTRUN - now_ms + current_time_ms_accuracy ))
@@ -156,8 +154,10 @@ loopsleepms() {
     # if we are too slow, sleep some time
     test ${mstosleep} -lt 200 && mstosleep=200
 
-    s=$((mstosleep / 1000))
-    m=$((mstosleep - (s * 1000)))
+    s=$(( mstosleep / 1000 ))
+    m=$(( mstosleep - (s * 1000) ))
+    [ "${m}" -lt 100 ] && m="0${m}"
+    [ "${m}" -lt 10  ] && m="0${m}"
 
     test $tellwork -eq 1 && echo >&2 " >>> PERFORMANCE >>> WORK TOOK ${LOOPSLEEPMS_LASTWORK} ms ( $((LOOPSLEEPMS_LASTWORK * 100 / 1000)).$((LOOPSLEEPMS_LASTWORK % 10))% cpu ) >>> SLEEPING ${mstosleep} ms"
 
@@ -170,3 +170,19 @@ loopsleepms() {
     LOOPSLEEPMS_LASTSLEEP=$mstosleep
 }
 
+# test it
+#while [ 1 ]
+#do
+#    r=$(( (RANDOM * 2000 / 32767) ))
+#    s=$((r / 1000))
+#    m=$((r - (s * 1000)))
+#    [ "${m}" -lt 100 ] && m="0${m}"
+#    [ "${m}" -lt 10  ] && m="0${m}"
+#    echo "${r} = ${s}.${m}"
+#
+#    # the work
+#    ${mysleep} ${s}.${m}
+#
+#    # the alignment loop
+#    loopsleepms tellwork 1
+#done

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -267,10 +267,10 @@ static inline void tc_device_commit(struct tc_device *d) {
         snprintfz(var_name, CONFIG_MAX_NAME, "dropped packets chart for %s", d->id);
         d->enabled_dropped = config_get_boolean_ondemand("plugin:tc", var_name, enable_dropped);
 
-        snprintfz(var_name, CONFIG_MAX_NAME, "dropped tokens chart for %s", d->id);
+        snprintfz(var_name, CONFIG_MAX_NAME, "tokens chart for %s", d->id);
         d->enabled_tokens = config_get_boolean_ondemand("plugin:tc", var_name, enable_tokens);
 
-        snprintfz(var_name, CONFIG_MAX_NAME, "dropped ctokens chart for %s", d->id);
+        snprintfz(var_name, CONFIG_MAX_NAME, "ctokens chart for %s", d->id);
         d->enabled_ctokens = config_get_boolean_ondemand("plugin:tc", var_name, enable_ctokens);
     }
 

--- a/src/proc_net_snmp.c
+++ b/src/proc_net_snmp.c
@@ -43,7 +43,7 @@ static struct netstat_columns icmp_data[] = {
     { "OutErrors", 0, 0, -1, NULL },
     { "InCsumErrors", 0, 0, 1, NULL },
 
-    // all there are available in icmpmsg
+    // all these are available in icmpmsg
 //    { "InDestUnreachs", 0, 0, 1, NULL },
 //    { "OutDestUnreachs", 0, 0, -1, NULL },
 //    { "InTimeExcds", 0, 0, 1, NULL },

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -379,7 +379,7 @@ struct feed_values test4_feed[] = {
 };
 
 calculated_number test4_results[] = {
-        5, 10, 10, 10, 10, 10, 10, 10, 10
+        10, 10, 10, 10, 10, 10, 10, 10, 10
 };
 
 struct test test4 = {
@@ -414,7 +414,7 @@ struct feed_values test5_feed[] = {
 };
 
 calculated_number test5_results[] = {
-        500, 500, 0, 500, 500, 0, 0, 0, 0
+        1000, 500, 0, 500, 500, 0, 0, 0, 0
 };
 
 struct test test5 = {
@@ -455,7 +455,7 @@ struct feed_values test6_feed[] = {
 };
 
 calculated_number test6_results[] = {
-        3000, 4000, 4000, 4000
+        4000, 4000, 4000, 4000
 };
 
 struct test test6 = {
@@ -490,7 +490,7 @@ struct feed_values test7_feed[] = {
 };
 
 calculated_number test7_results[] = {
-        250, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500
+        500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500
 };
 
 struct test test7 = {
@@ -597,7 +597,7 @@ struct feed_values test10_feed[] = {
 };
 
 calculated_number test10_results[] = {
-        500, 1000, 1000, 1000, 1000, 1000, 1000
+        1000, 1000, 1000, 1000, 1000, 1000, 1000
 };
 
 struct test test10 = {
@@ -770,6 +770,7 @@ struct test test14 = {
         NULL,               // feed2
         NULL                // results2
 };
+
 struct feed_values test14b_feed[] = {
         {        0, 0 },
         { 13573000, 13573000 },
@@ -798,6 +799,38 @@ struct test test14b = {
         8,                  // result entries
         test14b_feed,        // feed
         test14b_results,     // results
+        NULL,               // feed2
+        NULL                // results2
+};
+
+struct feed_values test14c_feed[] = {
+        { 29000000, 29000000 },
+        {  1000000, 29000000 + 1000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 },
+        { 30000000, 29000000 + 1000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 + 30000000 },
+};
+
+calculated_number test14c_results[] = {
+        1000000, 1000000, 1000000, 1000000, 1000000, 1000000, 1000000, 1000000, 1000000
+};
+
+struct test test14c = {
+        "test14c",            // name
+        "issue #981 with dummy data, checking for late start",
+        30,                 // update_every
+        1,                  // multiplier
+        1,                  // divisor
+        RRDDIM_INCREMENTAL, // algorithm
+        10,                 // feed entries
+        9,                  // result entries
+        test14c_feed,        // feed
+        test14c_results,     // results
         NULL,               // feed2
         NULL                // results2
 };
@@ -944,6 +977,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(run_test(&test14b))
+        return 1;
+
+    if(run_test(&test14c))
         return 1;
 
     return 0;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -3871,7 +3871,7 @@
             showLabelsOnHighlight: self.data('dygraph-showlabelsonhighlight') || true,
             hideOverlayOnMouseOut: self.data('dygraph-hideoverlayonmouseout') || true,
 
-            includeZero: self.data('dygraph-includezero') || false,
+            includeZero: self.data('dygraph-includezero') || ((chart_type === 'stacked')? true : false),
             xRangePad: self.data('dygraph-xrangepad') || 0,
             yRangePad: self.data('dygraph-yrangepad') || 1,
 

--- a/web/index.html
+++ b/web/index.html
@@ -1754,6 +1754,10 @@ var submenuData = {
         info: 'Kernel Same-page Merging (KSM) performance monitoring, read from several files in <code>/sys/kernel/mm/ksm/</code>. KSM is a memory-saving de-duplication feature in the Linux kernel (since version 2.6.32). The KSM daemon ksmd periodically scans those areas of user memory which have been registered with it, looking for pages of identical content which can be replaced by a single write-protected page (which is automatically copied if a process later wants to update its content). KSM was originally developed for use with KVM (where it was known as Kernel Shared Memory), to fit more virtual machines into physical memory, by sharing the data common between them.  But it can be useful to any application which generates many instances of the same data.'
     },
 
+    'ipv4.ecn': {
+        info: '<a href="https://en.wikipedia.org/wiki/Explicit_Congestion_Notification" target="_blank">Explicit Congestion Notification (ECN)</a> is a TCP extension that allows end-to-end notification of network congestion without dropping packets. ECN is an optional feature that may be used between two ECN-enabled endpoints when the underlying network infrastructure also supports it.'
+    },
+
     'netfilter.conntrack': {
         title: 'Connection Tracker',
         info: 'Netfilter Connection Tracker performance monitoring, read from <code>/proc/net/stat/nf_conntrack</code>. The connection tracker keeps track of all connections of the machine, inbound and outbound. It works by keeping a database with all open connections, tracking network and address translation and connection expectations.'

--- a/web/index.html
+++ b/web/index.html
@@ -1911,6 +1911,17 @@ var chartData = {
     },
 
     // ------------------------------------------------------------------------
+    // IPv4
+
+    'ipv4.tcpmemorypressures': {
+        info: 'Number of times a socket was put in <b>memory pressure</b> due to a non fatal memory allocation failure (the kernel attempts to work around this situation by reducing the send buffers, etc).'
+    },
+
+    'ipv4.tcpconnaborts': {
+        info: 'TCP connection aborts. <b>baddata</b> (<code>TCPAbortOnData</code>) happens while the connection is on <code>FIN_WAIT1</code> and the kernel receives a packet with a sequence number beyond the last one for this connection - the kernel responds with <code>RST</code> (closes the connection). <b>userclosed</b> (<code>TCPAbortOnClose</code>) happens when the kernel receives data on an already closed connection and responds with <code>RST</code>. <b>nomemory</b> (<code>TCPAbortOnMemory</code> happens when there are too many orphaned sockets (not attached to an fd) and the kernel has to drop a connection - sometimes it will send an <code>RST</code>, sometimes it won\'t. <b>timeout</b> (<code>TCPAbortOnTimeout</code>) happens when a connection times out. <b>linger</b> (<code>TCPAbortOnLinger</code>) happens when the kernel killed a socket that was already closed by the application and lingered around for long enough. <b>failed</b> (<code>TCPAbortFailed</code>) happens when the kernel attempted to send an <code>RST</code> but failed because there was no memory available.'
+    },
+
+    // ------------------------------------------------------------------------
     // APPS
 
     'apps.cpu': {

--- a/web/index.html
+++ b/web/index.html
@@ -622,7 +622,7 @@
     </script>
 
     <!-- load the dashboard manager - it will do the rest -->
-    <script type="text/javascript" src="dashboard.js?v49"></script>
+    <script type="text/javascript" src="dashboard.js?v50"></script>
 </head>
 <body data-spy="scroll" data-target="#sidebar">
     <div id="loadOverlay" class="loadOverlay" style="background-color: #888; color: #888;">


### PR DESCRIPTION
1. entropy alarm is now silent
2. more information on the dashboard
3. fixes #1000 (command `pidof` not found by `netdata-updater.sh`)
4. fixes #981 (extrapolation of the first point added to a chart)
5. fixes a bug in tc-qos-helper.sh (loopsleepms.inc) where the reported work time was wrong
6. fixes #1010 (zero in not shown on stacked charts on OSX browsers)