### PR TITLE
additional cgroup memory statistics

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1126,3 +1126,20 @@ void get_system_HZ(void) {
 
     hz = (unsigned int) ticks;
 }
+
+int read_single_number_file(const char *filename, unsigned long long *result) {
+    char buffer[1024 + 1];
+
+    int fd = open(filename, O_RDONLY, 0666);
+    if(unlikely(fd == -1)) return 1;
+
+    ssize_t r = read(fd, buffer, 1024);
+    if(unlikely(r == -1)) {
+        close(fd);
+        return 2;
+    }
+
+    close(fd);
+    *result = strtoull(buffer, NULL, 0);
+    return 0;
+}

--- a/src/common.h
+++ b/src/common.h
@@ -184,4 +184,6 @@ extern void get_system_HZ(void);
 #endif
 #endif
 
+extern int read_single_number_file(const char *filename, unsigned long long *result);
+
 #endif /* NETDATA_COMMON_H */

--- a/system/netdata-lsb.in
+++ b/system/netdata-lsb.in
@@ -19,7 +19,7 @@ ${DEBIAN_SCRIPT_DEBUG:+ set -v -x}
 
 DAEMON="netdata"
 DAEMON_PATH=@sbindir_POST@
-PIDFILE=@localstatedir_POST@/$DAEMON.pid
+PIDFILE=@localstatedir_POST@/run/$DAEMON.pid
 DAEMONOPTS="-P $PIDFILE"
 
 test -x $DAEMON_PATH/$DAEMON || exit 0

--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -209,7 +209,7 @@ body {
 	outline: thin dotted;
 }
 .netdata-legend-series > .netdata-legend-series-content::-webkit-scrollbar {
-	display: block; /* was 'none', but chrome was hidding content with it */
+	display: block; /* was 'none', but chrome was hiding content with it */
 }
 .has-scrollbar > .netdata-legend-series-content::-webkit-scrollbar {
 	display: block;


### PR DESCRIPTION
cgroups now also read usage_in_bytes, memsw_usage_in_bytes, failcnt and create 2 new memory charts with this info.

fixes #1019