### PR TITLE
Fixed typo in docs

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -119,7 +119,7 @@ DEFAULT_RECIPIENT_PUSHOVER=""
 # Users also need to open a query with the bot (see below).
 
 # note: multiple recipients can be given like this:
-#                  "CHAT_ID_1 CHAT_ID_1 ..."
+#                  "CHAT_ID_1 CHAT_ID_2 ..."
 
 # enable/disable sending telegram messages
 SEND_TELEGRAM="YES"


### PR DESCRIPTION
Fixed Small typo in health_alarm_notify.conf comments, and I get award of the most useless PR in github :smiley: 