### PR TITLE
plugin: ignore encoding errors (hddtemp related)

### DIFF
--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -608,7 +608,7 @@ class SocketService(SimpleService):
                 buf = self._sock.recv(4096)
                 if len(buf) == 0 or buf is None:  # handle server disconnect
                     break
-                data += buf.decode()
+                data += buf.decode(errors='ignore')
                 if self._check_raw_data(data):
                     break
             else:


### PR DESCRIPTION
In my case, the `hddtemp` module was not working (at all).

Here is an example data from `nc localhost 7634 | base64`:

```
fC9kZXYvc2RhfElOVEVMIFNTRFNDMkJXMTIwQTQgICAgICAgICAgICAgICAgICAgICAQgHwyN3xD
fHwvZGV2L3NkYTF8SU5URUwgU1NEU0MyQlcxMjBBNCAgICAgICAgICAgICAgICAgICAgIBCAfDI3
fEN8fC9kZXYvc2RifFNUMjAwMERMMDAzLTlWVDE2NiAgICAgICAgICAgICAgICAgICAgICAQgHwz
NXxDfHwvZGV2L3NkY3xIR1NUIEhEUzcyNDA0MEFMRTY0MCAgICAgICAgICAgICAgICAgICAgEIB8
Mzl8Q3x8L2Rldi9zZGMxfEhHU1QgSERTNzI0MDQwQUxFNjQwICAgICAgICAgICAgICAgICAgICAQ
gHwzOXxDfHwvZGV2L3NkZHxHZW5lcmljIFNUT1JBR0UgREVWSUNFfE5BfCp8fC9kZXYvc2RkMXxH
ZW5lcmljIFNUT1JBR0UgREVWSUNFfE5BfCp8
```

Once that input data is fed to `hddtemp.chart.py`, `base.py` will complain that:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "../python.d/python_modules/base.py", line 637, in _get_raw_data
    data = self._receive()
  File "../python.d/python_modules/base.py", line 612, in _receive
    data += buf.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0x80 in position 51: ordinal not in range(128)
```

## Version

**hddtemp**: 0.3-beta15
**python**: 2.7.12 (default, Sep  6 2016, 18:21:48) [GCC 5.4.0]
**netdata**: ccf5173