### PR TITLE
Fix occasional crashes in python plugins

### DIFF
--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -163,7 +163,7 @@ class SimpleService(threading.Thread):
                 self.error("Something wrong: ", str(e))
                 return
             if status:  # handle retries if update failed
-                time.sleep(self.timetable['next'] - time.time())
+                time.sleep(max (0, self.timetable['next'] - time.time()))
                 self.retries_left = self.retries
             else:
                 self.retries_left -= 1


### PR DESCRIPTION
Occasionally python plugins such as the nginx plugin crash with

```
Exception in thread local:
Traceback (most recent call last):
  File "/usr/lib64/python3.4/threading.py", line 911, in _bootstrap_inner
    self.run()
  File "/usr/libexec/netdata/python.d/python_modules/base.py", line 166, in run
    time.sleep(self.timetable['next'] - time.time())
ValueError: sleep length must be non-negative
```

Afterwards no further data is collected for the plugin until netdata
is restarted
