### PR TITLE
Better logging from python.d and its modules

### DIFF
--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -39,8 +39,8 @@ OVERRIDE_UPDATE_EVERY = False
 # # -----------------------------------------------------------------------------
 # # start logging
 logging.basicConfig(format=logs.LOG_FORMAT, datefmt=logs.LOG_DATE_FMT)
-msg = logging.getLogger(__name__)
-#msg.setLevel("CRITICAL")
+msg = logging.getLogger("python")
+msg.setLevel("DEBUG")
 
 try:
     assert sys.version_info >= (3, 1)
@@ -474,7 +474,7 @@ def parse_cmdline(directory, *commands):
         OVERRIDE_UPDATE_EVERY = True
         msg.debug("overriding update interval to " + str(BASE_CONFIG['update_every']))
 
-    msg.debug("started from " + commands[0] + " with options: " + " ".join(commands[1:]))
+    msg.info("started from " + commands[0] + " with options: " + " ".join(commands[1:]))
 
     return mods
 
@@ -532,6 +532,7 @@ def run():
     logs.LOGS_INTERVAL = log_interval
     if not DEBUG_FLAG:
         msg.addFilter(logs.TruncateFilter())
+        msg.setLevel("ERROR")
 
 #    msg.DEBUG_FLAG = DEBUG_FLAG
 #    msg.LOG_COUNTER = log_counter

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -9,6 +9,8 @@ import os
 import sys
 import time
 import threading
+import logging
+import logs
 
 # -----------------------------------------------------------------------------
 # globals & environment setup
@@ -32,7 +34,13 @@ OVERRIDE_UPDATE_EVERY = False
 
 # -----------------------------------------------------------------------------
 # custom, third party and version specific python modules management
-import msg
+#import msg
+
+# # -----------------------------------------------------------------------------
+# # start logging
+logging.basicConfig(format=logs.LOG_FORMAT, datefmt=logs.LOG_DATE_FMT)
+msg = logging.getLogger(__name__)
+#msg.setLevel("CRITICAL")
 
 try:
     assert sys.version_info >= (3, 1)
@@ -52,18 +60,21 @@ except (AssertionError, ImportError):
         PY_VERSION = 2
         msg.info('Using python v2')
     except ImportError:
-        msg.fatal('Cannot start. No importlib.machinery on python3 or lack of imp on python2')
+        msg.critical('Cannot start. No importlib.machinery on python3 or lack of imp on python2')
+        sys.exit(1)
 # try:
 #     import yaml
 # except ImportError:
-#     msg.fatal('Cannot find yaml library')
+#     msg.critical('Cannot find yaml library')
+#     sys.exit(1)
 try:
     if PY_VERSION == 3:
         import pyyaml3 as yaml
     else:
         import pyyaml2 as yaml
 except ImportError:
-    msg.fatal('Cannot find yaml library')
+    msg.critical('Cannot find yaml library')
+    sys.exit(1)
 
 
 class PythonCharts(object):
@@ -125,8 +136,8 @@ class PythonCharts(object):
                 return importlib.machinery.SourceFileLoader(name, path).load_module()
             else:
                 return imp.load_source(name, path)
-        except Exception as e:
-            msg.error("Problem loading", name, str(e))
+        except Exception:
+            msg.error("Problem loading " + str(name), exc_info=1)
             return None
 
     def _load_modules(self, path, modules, disabled):
@@ -140,7 +151,8 @@ class PythonCharts(object):
 
         # check if plugin directory exists
         if not os.path.isdir(path):
-            msg.fatal("cannot find charts directory ", path)
+            msg.critical("cannot find charts directory " + str(path))
+            sys.exit(1)
 
         # load modules
         loaded = []
@@ -152,13 +164,14 @@ class PythonCharts(object):
                 if mod is not None:
                     loaded.append(mod)
                 else:  # exit if plugin is not found
-                    msg.fatal('no modules found.')
+                    msg.critical('no modules found.')
+                    sys.exit(1)
         else:
             # scan directory specified in path and load all modules from there
             names = os.listdir(path)
             for mod in names:
                 if mod.replace(MODULE_EXTENSION, "") in disabled:
-                    msg.error(mod + ": disabled module ", mod.replace(MODULE_EXTENSION, ""))
+                    msg.error(mod + ": disabled module " + mod.replace(MODULE_EXTENSION, ""))
                     continue
                 m = self._import_module(path + mod)
                 if m is not None:
@@ -184,10 +197,10 @@ class PythonCharts(object):
                     setattr(mod,
                             'config',
                             self._parse_config(mod, read_config(configfile)))
-                except Exception as e:
-                    msg.error(mod.__name__ + ": cannot parse configuration file '" + configfile + "':", str(e))
+                except Exception:
+                    msg.error(mod.__name__ + ": cannot parse configuration file '" + configfile + "':", exc_info=1)
             else:
-                msg.error(mod.__name__ + ": configuration file '" + configfile + "' not found. Using defaults.")
+                msg.info(mod.__name__ + ": configuration file '" + configfile + "' not found. Using defaults.")
                 # set config if not found
                 if not hasattr(mod, 'config'):
                     msg.debug(mod.__name__ + ": setting configuration for only one job")
@@ -265,11 +278,11 @@ class PythonCharts(object):
                 conf = module.config[name]
                 try:
                     job = module.Service(configuration=conf, name=name)
-                except Exception as e:
+                except Exception:
                     msg.error(module.__name__ +
                               ("/" + str(name) if name is not None else "") +
-                              ": cannot start job: '" +
-                              str(e))
+                              ": cannot start job: '",
+                              exc_info=1)
                     return None
                 else:
                     # set chart_name (needed to plot run time graphs)
@@ -293,9 +306,9 @@ class PythonCharts(object):
             prefix += "/" + job.name
         try:
             self.jobs.remove(job)
-            msg.info("Disabled", prefix)
-        except Exception as e:
-            msg.debug("This shouldn't happen. NO " + prefix + " IN LIST:" + str(self.jobs) + " ERROR: " + str(e))
+            msg.info("Disabled " + prefix)
+        except Exception:
+            msg.debug("This shouldn't happen. NO " + prefix + " IN LIST:" + str(self.jobs), exc_info=1)
 
         # TODO remove section below and remove `reason`.
         prefix += ": "
@@ -327,15 +340,15 @@ class PythonCharts(object):
         """
         i = 0
         overridden = []
-        msg.debug("all job objects", str(self.jobs))
+        msg.debug("all job objects " + str(self.jobs))
         while i < len(self.jobs):
             job = self.jobs[i]
             try:
                 if not job.check():
-                    msg.error(job.chart_name, "check function failed.")
+                    msg.error(job.chart_name + ": check function failed.")
                     self._stop(job)
                 else:
-                    msg.debug(job.chart_name, "check succeeded")
+                    msg.debug(job.chart_name + " check succeeded")
                     i += 1
                     try:
                         if job.override_name is not None:
@@ -355,11 +368,11 @@ class PythonCharts(object):
                 self._stop(job)
                 msg.error(job.chart_name, "cannot find check() function or it thrown unhandled exception.")
                 msg.debug(str(e))
-            except (UnboundLocalError, Exception) as e:
-                msg.error(job.chart_name, str(e))
+            except (UnboundLocalError, Exception):
+                msg.error(job.chart_name, exc_info=1)
                 self._stop(job)
-        msg.debug("overridden job names:", str(overridden))
-        msg.debug("all remaining job objects:", str(self.jobs))
+        msg.debug("overridden job names: " + str(overridden))
+        msg.debug("all remaining job objects: " + str(self.jobs))
 
     def create(self):
         """
@@ -373,7 +386,7 @@ class PythonCharts(object):
             job = self.jobs[i]
             try:
                 if not job.create():
-                    msg.error(job.chart_name, "create function failed.")
+                    msg.error(job.chart_name + "create function failed.")
                     self._stop(job)
                 else:
                     chart = job.chart_name
@@ -386,14 +399,14 @@ class PythonCharts(object):
                         str(job.timetable['freq']) +
                         '\n')
                     sys.stdout.write("DIMENSION run_time 'run time' absolute 1 1\n\n")
-                    msg.debug("created charts for", job.chart_name)
+                    msg.debug("created charts for " + job.chart_name)
                     # sys.stdout.flush()
                     i += 1
             except AttributeError:
-                msg.error(job.chart_name, "cannot find create() function or it thrown unhandled exception.")
+                msg.error(job.chart_name + " cannot find create() function or it thrown unhandled exception.")
                 self._stop(job)
-            except (UnboundLocalError, Exception) as e:
-                msg.error(job.chart_name, str(e))
+            except (UnboundLocalError, Exception):
+                msg.error(job.chart_name, exc_info=1)
                 self._stop(job)
 
     def update(self):
@@ -406,7 +419,8 @@ class PythonCharts(object):
 
         while True:
             if threading.active_count() <= 1:
-                msg.fatal("no more jobs")
+                msg.critical("no more jobs")
+                sys.exit(1)
             time.sleep(1)
 
 
@@ -420,10 +434,10 @@ def read_config(path):
         with open(path, 'r') as stream:
             config = yaml.load(stream)
     except (OSError, IOError):
-        msg.error(str(path), "is not a valid configuration file")
+        msg.error(str(path) + " is not a valid configuration file")
         return None
     except yaml.YAMLError as e:
-        msg.error(str(path), "is malformed:", e)
+        msg.error(str(path) + " is malformed", exc_info=1)
         return None
     return config
 
@@ -458,9 +472,9 @@ def parse_cmdline(directory, *commands):
                 pass
     if changed_update and DEBUG_FLAG:
         OVERRIDE_UPDATE_EVERY = True
-        msg.debug(PROGRAM, "overriding update interval to", str(BASE_CONFIG['update_every']))
+        msg.debug("overriding update interval to " + str(BASE_CONFIG['update_every']))
 
-    msg.debug("started from", commands[0], "with options:", *commands[1:])
+    msg.debug("started from " + commands[0] + " with options: " + " ".join(commands[1:]))
 
     return mods
 
@@ -476,7 +490,7 @@ def run():
     disabled = []
     configfile = CONFIG_DIR + "python.d.conf"
     msg.PROGRAM = PROGRAM
-    msg.info("reading configuration file:", configfile)
+    msg.info("reading configuration file: " + configfile)
     log_counter = 200
     log_interval = 3600
 
@@ -485,7 +499,8 @@ def run():
         try:
             # exit the whole plugin when 'enabled: no' is set in 'python.d.conf'
             if conf['enabled'] is False:
-                msg.fatal('disabled in configuration file.\n')
+                msg.critical('disabled in configuration file.')
+                sys.exit(1)
         except (KeyError, TypeError):
             pass
         try:
@@ -513,9 +528,14 @@ def run():
 
     # parse passed command line arguments
     modules = parse_cmdline(MODULES_DIR, *sys.argv)
-    msg.DEBUG_FLAG = DEBUG_FLAG
-    msg.LOG_COUNTER = log_counter
-    msg.LOG_INTERVAL = log_interval
+    logs.LOGS_PER_INTERVAL = log_counter
+    logs.LOGS_INTERVAL = log_interval
+    if not DEBUG_FLAG:
+        msg.addFilter(logs.TruncateFilter())
+
+#    msg.DEBUG_FLAG = DEBUG_FLAG
+#    msg.LOG_COUNTER = log_counter
+#    msg.LOG_INTERVAL = log_interval
     msg.info("MODULES_DIR='" + MODULES_DIR +
              "', CONFIG_DIR='" + CONFIG_DIR +
              "', UPDATE_EVERY=" + str(BASE_CONFIG['update_every']) +
@@ -526,7 +546,8 @@ def run():
     charts.check()
     charts.create()
     charts.update()
-    msg.fatal("finished")
+    msg.critical("finished")
+    sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -39,7 +39,7 @@ pythonmodulesdir=$(pythondir)/python_modules
 dist_pythonmodules_DATA = \
     python_modules/__init__.py \
     python_modules/base.py \
-    python_modules/msg.py \
+    python_modules/logs.py \
     python_modules/lm_sensors.py \
     $(NULL)
 

--- a/python.d/cpufreq.chart.py
+++ b/python.d/cpufreq.chart.py
@@ -47,7 +47,7 @@ class Service(SimpleService):
         try:
             self.sys_dir = str(self.configuration['sys_dir'])
         except (KeyError, TypeError):
-            self.error("No path specified. Using: '" + self.sys_dir + "'")
+            self.info("No path specified. Using: '" + self.sys_dir + "'")
 
         self._orig_name = self.chart_name
 
@@ -56,7 +56,7 @@ class Service(SimpleService):
                 self.paths.append(dirpath + "/" + self.filename)
 
         if len(self.paths) == 0:
-            self.error("cannot find", self.filename)
+            self.error("cannot find " + self.filename)
             return False
 
         self.paths.sort()

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -3,22 +3,22 @@
 # Author: Pawel Krupa (paulfantom)
 
 from base import SimpleService
-import msg
+import logs
 
 # import 3rd party library to handle MySQL communication
 try:
     import MySQLdb
 
     # https://github.com/PyMySQL/mysqlclient-python
-    msg.info("using MySQLdb")
+    logs.message("INFO", "using MySQLdb")
 except ImportError:
     try:
         import pymysql as MySQLdb
 
         # https://github.com/PyMySQL/PyMySQL
-        msg.info("using pymysql")
+        logs.message("INFO", "using pymysql")
     except ImportError:
-        msg.error("MySQLdb or PyMySQL module is needed to use mysql.chart.py plugin")
+        logs.message("INFO", "MySQLdb or PyMySQL module is needed to use mysql.chart.py plugin")
         raise ImportError
 
 # default module values (can be overridden per job in `config`)
@@ -344,8 +344,8 @@ class Service(SimpleService):
             self.error("Cannot establish connection to MySQL.")
             self.debug(str(e))
             raise RuntimeError
-        except Exception as e:
-            self.error("problem connecting to server:", e)
+        except Exception:
+            self.error("problem connecting to server:", exc_info=1)
             raise RuntimeError
 
     def _get_data(self):
@@ -362,14 +362,14 @@ class Service(SimpleService):
             cursor = self.connection.cursor()
             cursor.execute(QUERY)
             raw_data = cursor.fetchall()
-        except MySQLdb.OperationalError as e:
-            self.debug("Reconnecting due to", str(e))
+        except MySQLdb.OperationalError:
+            self.debug("Reconnecting due to", exc_info=1)
             self._connect()
             cursor = self.connection.cursor()
             cursor.execute(QUERY)
             raw_data = cursor.fetchall()
-        except Exception as e:
-            self.error("cannot execute query.", e)
+        except Exception:
+            self.error("cannot execute query.", exc_info=1)
             self.connection.close()
             self.connection = None
             return None

--- a/python.d/python_modules/logs.py
+++ b/python.d/python_modules/logs.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Description: logging for netdata python.d modules
+
+import time
+import logging
+
+LOG_FORMAT = '%(asctime)s %(module)s %(levelname)s: %(message)s'
+LOG_DATE_FMT = '%Y-%m-%d %X'
+LOGS_PER_INTERVAL = 2
+LOGS_INTERVAL = 2
+DEFAULT_LOG_LEVEL = "DEBUG"
+
+
+class TruncateFilter(logging.Filter):
+    message_counter = 1
+    next_check = 0
+
+    def filter(self, record):
+        now = time.time()
+        if self.next_check <= now:
+            self.next_check = now - (now % LOGS_INTERVAL) + LOGS_INTERVAL
+            if self.message_counter > LOGS_PER_INTERVAL:
+                record.msg = "truncated %s log messages" % self.message_counter
+                self.message_counter = 1
+                return 1
+
+        if self.message_counter > LOGS_PER_INTERVAL:
+            self.message_counter += 1
+            return 0
+
+        self.message_counter += 1
+        return 1
+
+logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
+msg = logging.getLogger(__name__)
+msg.setLevel(DEFAULT_LOG_LEVEL)

--- a/python.d/python_modules/logs.py
+++ b/python.d/python_modules/logs.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 # Description: logging for netdata python.d modules
 
+import sys
 import time
 import logging
 
-LOG_FORMAT = '%(asctime)s %(module)s %(levelname)s: %(message)s'
+LOG_FORMAT = '%(asctime)s python %(levelname)s: %(message)s'
+#LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s: %(message)s'
+#LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
 LOG_DATE_FMT = '%Y-%m-%d %X'
 LOGS_PER_INTERVAL = 2
 LOGS_INTERVAL = 2
-DEFAULT_LOG_LEVEL = "DEBUG"
+DEFAULT_LOG_LEVEL = "ERROR"
 
 
 class TruncateFilter(logging.Filter):
@@ -31,6 +34,17 @@ class TruncateFilter(logging.Filter):
         self.message_counter += 1
         return 1
 
-logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
-msg = logging.getLogger(__name__)
-msg.setLevel(DEFAULT_LOG_LEVEL)
+# logging.basicConfig(format=LOG_FORMAT, datefmt=LOG_DATE_FMT)
+# log = logging.getLogger(__name__)
+# log.setLevel(DEFAULT_LOG_LEVEL)
+# msg = log
+
+
+def message(type, *args):
+    """
+    Print message on stderr.
+    """
+    timestamp = time.strftime('%Y-%m-%d %X')
+    msg = "%s: %s %s: %s" % (timestamp, "python", str(type), " ".join(args))
+    sys.stderr.write(msg)
+

--- a/python.d/sensors.chart.py
+++ b/python.d/sensors.chart.py
@@ -131,13 +131,13 @@ class Service(SimpleService):
     def check(self):
         try:
             sensors.init()
-        except Exception as e:
-            self.error(e)
+        except Exception:
+            self.debug("", exc_info=1)
             return False
 
         try:
             self._create_definitions()
-        except Exception as e:
-            self.error(e)
+        except Exception:
+            self.debug("", exc_info=1)
             return False
         return True

--- a/python.d/tomcat.chart.py
+++ b/python.d/tomcat.chart.py
@@ -87,7 +87,7 @@ class Service(UrlService):
                     end = raw.find('</status>')
                     end += 9
                     raw = raw[:end]
-                    self.debug(raw)
+                    log.debug(raw)
                     data = ET.fromstring(raw)
                 else:
                     raise Exception(e)
@@ -101,11 +101,11 @@ class Service(UrlService):
                     'current': threads.attrib['currentThreadCount'],
                     'busy': threads.attrib['currentThreadsBusy'],
                     'jvm': memory.attrib['free']}
-        except (ValueError, AttributeError) as e:
-            self.debug(str(e))
+        except (ValueError, AttributeError):
+            self.debug("", exc_info=1)
             return None
-        except SyntaxError as e:
+        except SyntaxError:
             self.error("Tomcat module needs python 2.7 at least. Stopping")
-            self.debug(str(e))
-        except Exception as e:
-            self.debug(str(e))
+            self.debug("", exc_info=1)
+        except Exception:
+            self.debug("", exc_info=1)


### PR DESCRIPTION
Due to the fact that logs sent by python modules are usually insufficient to debug anything by other users of netdata, I refactored every piece of code responsible for sending messages to stderr. It is also a beginning of work to resolve issue #1155.
This pull request implements hierarchical python logger ("python" -> "base" -> "module") based on `logging` module. It also implements log rate limitation (spam prevention) in form of `TruncateFilter` class as well as logging full stack trace messages. I will also add configurable option to desired log level from configuration file (it may be possible to configure different log levels for different modules).

Currently testing is in progress.