### PR TITLE
disk space monitoring improvements

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -806,6 +806,49 @@ issystemd() {
     return 1
 }
 
+installed_init_d=0
+install_non_systemd_init() {
+    [ "${UID}" != 0 ] && return 1
+
+    local key="unknown"
+    if [ -f /etc/os-release ]
+        then
+        source /etc/os-release || return 1
+        key="${ID}-${VERSION_ID}"
+
+    elif [ -f /etc/centos-release ]
+        then
+        key=$(</etc/centos-release)
+    fi
+
+    if [ -d /etc/init.d -a ! -f /etc/init.d/netdata ]
+        then
+        if [ "${key}" = "gentoo" ]
+            then
+            run cp system/netdata-openrc /etc/init.d/netdata && \
+            run chmod 755 /etc/init.d/netdata && \
+            run rc-update add netdata default && \
+            installed_init_d=1
+        
+        elif [ "${key}" = "ubuntu-12.04" -o "${key}" = "ubuntu-14.04" ]
+            then
+            run cp system/netdata-lsb /etc/init.d/netdata && \
+            run chmod 755 /etc/init.d/netdata && \
+            run update-rc.d netdata enable && \
+            installed_init_d=1
+
+        elif [ "${key}" = "CentOS release 6.8 (Final)" ]
+            then
+            run cp system/netdata-init-d /etc/init.d/netdata && \
+            run chmod 755 /etc/init.d/netdata && \
+            run chkconfig netdata on && \
+            installed_init_d=1
+        fi
+    fi
+
+    return 0
+}
+
 started=0
 if [ "${UID}" -eq 0 ]
     then
@@ -826,6 +869,8 @@ if [ "${UID}" -eq 0 ]
 
         stop_all_netdata
         service netdata restart && started=1
+    else
+        install_non_systemd_init
     fi
 
     if [ ${started} -eq 0 ]
@@ -1068,6 +1113,12 @@ if [ -f /etc/systemd/system/netdata.service ]
     then
     echo "Deleting /etc/systemd/system/netdata.service ..."
     rm -i /etc/systemd/system/netdata.service
+fi
+
+if [ -f /etc/init.d/netdata ]
+    then
+    echo "Deleting /etc/init.d/netdata ..."
+    rm -i /etc/init.d/netdata
 fi
 
 getent passwd netdata > /dev/null

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -83,19 +83,16 @@ static inline void do_disk_space_stats(struct disk *d, const char *mount_point, 
         char var_name[4096 + 1];
         snprintfz(var_name, 4096, "plugin:proc:/proc/diskstats:%s", mount_point);
 
-        int def_space = CONFIG_ONDEMAND_ONDEMAND;
+        int def_space = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
+        int def_inodes = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "inodes usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
 
-        if(unlikely(strncmp(mount_point, "/run/user/", 10) == 0))
+        if(unlikely(strncmp(mount_point, "/run/user/", 10) == 0)) {
             def_space = CONFIG_ONDEMAND_NO;
+            def_inodes = CONFIG_ONDEMAND_NO;
+        }
 
-        // check the user configuration (this will also show our 'on demand' decision)
-        def_space = config_get_boolean_ondemand(var_name, "enable space metrics", def_space);
-
-        int ddo_space = def_space,
-                ddo_inodes = def_space;
-
-        do_space = config_get_boolean_ondemand(var_name, "space usage", ddo_space);
-        do_inodes = config_get_boolean_ondemand(var_name, "inodes usage", ddo_inodes);
+        do_space = config_get_boolean_ondemand(var_name, "space usage", def_space);
+        do_inodes = config_get_boolean_ondemand(var_name, "inodes usage", def_inodes);
     }
 
     if(do_space == CONFIG_ONDEMAND_NO && do_inodes == CONFIG_ONDEMAND_NO)
@@ -346,7 +343,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
                 global_enable_performance_for_partitions = CONFIG_ONDEMAND_NO,
                 global_enable_performance_for_mountpoints = CONFIG_ONDEMAND_NO,
                 global_enable_performance_for_virtual_mountpoints = CONFIG_ONDEMAND_ONDEMAND,
-                global_enable_space_for_mountpoints = CONFIG_ONDEMAND_ONDEMAND,
                 global_do_io = CONFIG_ONDEMAND_ONDEMAND,
                 global_do_ops = CONFIG_ONDEMAND_ONDEMAND,
                 global_do_mops = CONFIG_ONDEMAND_ONDEMAND,
@@ -354,8 +350,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
                 global_do_qops = CONFIG_ONDEMAND_ONDEMAND,
                 global_do_util = CONFIG_ONDEMAND_ONDEMAND,
                 global_do_backlog = CONFIG_ONDEMAND_ONDEMAND,
-                global_do_space = CONFIG_ONDEMAND_ONDEMAND,
-                global_do_inodes = CONFIG_ONDEMAND_ONDEMAND,
                 globals_initialized = 0;
 
     if(unlikely(!globals_initialized)) {
@@ -366,7 +360,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
         global_enable_performance_for_partitions = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for partitions", global_enable_performance_for_partitions);
         global_enable_performance_for_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted filesystems", global_enable_performance_for_mountpoints);
         global_enable_performance_for_virtual_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "performance metrics for mounted virtual disks", global_enable_performance_for_virtual_mountpoints);
-        global_enable_space_for_mountpoints = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space metrics for mounted filesystems", global_enable_space_for_mountpoints);
 
         global_do_io      = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "bandwidth for all disks", global_do_io);
         global_do_ops     = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "operations for all disks", global_do_ops);
@@ -375,8 +368,6 @@ int do_proc_diskstats(int update_every, unsigned long long dt) {
         global_do_qops    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "queued operations for all disks", global_do_qops);
         global_do_util    = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "utilization percentage for all disks", global_do_util);
         global_do_backlog = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "backlog for all disks", global_do_backlog);
-        global_do_space   = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "space usage for all disks", global_do_space);
-        global_do_inodes  = config_get_boolean_ondemand("plugin:proc:/proc/diskstats", "inodes usage for all disks", global_do_inodes);
 
         globals_initialized = 1;
     }


### PR DESCRIPTION
1. fixes the options that were not working, fixes #1206 
2. added option `exclude space metrics on paths` to exclude certain paths from disk space statistics (handy for automounted filesystems), fixes #1206 
3. the installer now installs `/etc/init.d/netdata` on certain distros (gentoo, centos 6.8, ubuntu 12.04 and 14.04).