### PR TITLE
another fix for plugins synchronization

### DIFF
--- a/node.d/node_modules/netdata.js
+++ b/node.d/node_modules/netdata.js
@@ -208,15 +208,14 @@ var netdata = {
 			service.update_every = netdata.options.update_every;
 
 		// align the runs
-		service.next_run = now - (now % (service.update_every * 1000));
+		service.next_run = now - (now % (service.update_every * 1000)) + (service.update_every * 1000);
 
 		service.commit = function() {
 			if(this.added !== true) {
 				this.added = true;
 				
 				var now = new Date().getTime();
-				while( this.next_run < now )
-					this.next_run += (this.update_every * 1000);
+                this.next_run = now - (now % (service.update_every * 1000)) + (service.update_every * 1000);
 
 				netdata.services.push(this);
 				if(netdata.options.DEBUG === true) netdata.debug(this.module.name + ': ' + this.name + ': service committed.');
@@ -553,8 +552,7 @@ var netdata = {
 			service.update();
 
 			now = new Date().getTime();
-			while(service.next_run < now)
-				service.next_run += (service.update_every * 1000);
+			service.next_run = now - (now % (service.update_every * 1000)) + (service.update_every * 1000);
 		}
 
 		// 1/10th of update_every in pause

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -148,7 +148,7 @@ class SimpleService(threading.Thread):
         self.debug("starting data collection - update frequency:", str(step), ", retries allowed:", str(self.retries))
         while True:  # run forever, unless something is wrong
             now = float(time.time())
-            next = self.timetable['next'] = now - (now % step) + step + (step / 3) # add 1/3 into the iteration to sync with netdata
+            next = self.timetable['next'] = now - (now % step) + step
 
             # it is important to do this in a loop
             # sleep() is interruptable

--- a/src/log.c
+++ b/src/log.c
@@ -125,7 +125,11 @@ int error_log_limit(int reset) {
 
     // prevent all logs if the errors per period is 0
     if(error_log_errors_per_period == 0)
+#ifdef NETDATA_INTERNAL_CHECKS
+        return 0;
+#else
         return 1;
+#endif
 
     time_t now = time(NULL);
     if(!start) start = now;
@@ -185,7 +189,11 @@ int error_log_limit(int reset) {
         prevented++;
 
         // prevent logging this error
+#ifdef NETDATA_INTERNAL_CHECKS
+        return 0;
+#else
         return 1;
+#endif
     }
 
     return 0;

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -461,8 +461,8 @@ static inline long align_entries_to_pagesize(long entries) {
 }
 
 static inline void timeval_align(struct timeval *tv, int update_every) {
-    tv->tv_sec  = tv->tv_sec - tv->tv_sec % update_every + update_every / 2;
-    tv->tv_usec = (unsigned long)(update_every % 2) * 500000;
+    tv->tv_sec -= tv->tv_sec % update_every;
+    tv->tv_usec = 500000;
 }
 
 RRDSET *rrdset_create(const char *type, const char *id, const char *name, const char *family, const char *context, const char *title, const char *units, long priority, int update_every, int chart_type)

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -527,9 +527,12 @@ RRDSET *rrdset_create(const char *type, const char *id, const char *name, const 
         }
 
         // make sure the database is aligned
-        if(st->last_updated.tv_sec % update_every) {
-            st->last_updated.tv_sec -= st->last_updated.tv_sec % update_every;
-            st->last_updated.tv_usec = 0;
+        if(st->last_updated.tv_sec) {
+            if(st->last_updated.tv_sec % update_every)
+                st->last_updated.tv_sec -= st->last_updated.tv_sec % update_every;
+
+            // aligned in the middle, for tolerance with plugins
+            st->last_updated.tv_usec = 500000ULL;
         }
     }
 
@@ -1103,7 +1106,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
         // align it to update_every
         st->last_collected_time.tv_sec -= st->last_collected_time.tv_sec % st->update_every;
-        st->last_collected_time.tv_usec = 0;
+        st->last_collected_time.tv_usec = 500000ULL;
 
         last_collect_ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - update_every_ut;
 
@@ -1149,7 +1152,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
         // align it to update_every
         st->last_collected_time.tv_sec -= st->last_collected_time.tv_sec % st->update_every;
-        st->last_collected_time.tv_usec = 0;
+        st->last_collected_time.tv_usec = 500000ULL;
 
         unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;
         st->last_updated.tv_sec = (time_t) (ut / 1000000ULL);


### PR DESCRIPTION
it seems that somehow when all plugins and the core are exactly synchronized to run at the same time, netdata receives data from them, too early: 0.001 and 0.999 i.e. twice in the same interpolation point.

This is true for almost all plugins except the internal ones, which probably means that there is some slight time difference of up to 100 microseconds on the way the various languages interpret time.

To fix this issue, the netdata core, aligns the database at 0.5 secs while all plugins at 0.0 secs. So, there is a tolerance of half a second.