### PR TITLE
backends: graphite and opentsdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(NETDATA_SOURCE_FILES
         src/appconfig.h
         src/avl.c
         src/avl.h
+        src/backends.c
+        src/backends.h
         src/common.c
         src/common.h
         src/daemon.c

--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -52,6 +52,7 @@ dist_pythonconfig_DATA = \
 healthconfigdir=$(configdir)/health.d
 dist_healthconfig_DATA = \
     health.d/apache.conf \
+    health.d/backend.conf \
     health.d/cpu.conf \
     health.d/disks.conf \
     health.d/entropy.conf \

--- a/conf.d/health.d/backend.conf
+++ b/conf.d/health.d/backend.conf
@@ -1,0 +1,44 @@
+
+# make sure we are sending data to backend
+
+   alarm: backend_last_buffering
+      on: netdata.backend_metrics
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful buffering of backend data
+      to: dba
+
+   alarm: backend_metrics_sent
+      on: netdata.backend_metrics
+   units: %
+    calc: $sent * 100 / $buffered
+   every: 10s
+    warn: $this != 100
+   delay: down 5m multiplier 1.5 max 1h
+    info: percentage of metrics sent to the backend server
+      to: dba
+
+   alarm: backend_metrics_lost
+      on: netdata.backend_metrics
+   units: metrics
+    calc: $lost
+   every: 10s
+    crit: $this != 0
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of metrics lost due to repeating failures to contact the backend server
+      to: dba
+
+   alarm: backend_slow
+      on: netdata.backend_latency
+   units: %
+    calc: $latency * 100 / ($update_every * 1000)
+   every: 10s
+    warn: $this > 50
+    crit: $this > 100
+   delay: down 5m multiplier 1.5 max 1h
+    info: the percentage of time between iterations needed by the backend time to process the data sent by netdata
+      to: dba

--- a/configs.signatures
+++ b/configs.signatures
@@ -159,6 +159,7 @@ declare -A configs_signatures=(
   ['88f77865f75c9fb61c97d700bd4561ee']='python.d/mysql.conf'
   ['8989b5e2f4ef9cd278ef58be0fae4074']='health.d/disks.conf'
   ['899bcb0b3f4375b0a1280296be930201']='health.d/named.conf'
+  ['89fb3cbb223be4fa0cb676cfa3b07055']='health.d/backend.conf'
   ['8a1b95d375992d7b11330a0ac46f369c']='health.d/disks.conf'
   ['8c1d41e2c88aeca78bc319ed74c8748c']='python.d/phpfpm.conf'
   ['8d0552371a7c9725a04196fa560813d1']='health.d/cpu.conf'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,7 @@ plugins_PROGRAMS = apps.plugin
 netdata_SOURCES = \
 	appconfig.c appconfig.h \
 	avl.c avl.h \
+	backends.c backends.h \
 	common.c common.h \
 	daemon.c daemon.h \
 	dictionary.c dictionary.h \

--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -493,7 +493,7 @@ void generate_config(BUFFER *wb, int only_changed)
                     !strcmp(co->name, "plugins")  ||
                     !strcmp(co->name, "registry") ||
                     !strcmp(co->name, "health")   ||
-                    !strcmp(co->name, "backends"))
+                    !strcmp(co->name, "backend"))
                 pri = 0;
             else if(!strncmp(co->name, "plugin:", 7)) pri = 1;
             else pri = 2;

--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -490,9 +490,10 @@ void generate_config(BUFFER *wb, int only_changed)
         config_global_write_lock();
         for(co = config_root; co ; co = co->next) {
             if(!strcmp(co->name, "global") ||
-                    !strcmp(co->name, "plugins") ||
+                    !strcmp(co->name, "plugins")  ||
                     !strcmp(co->name, "registry") ||
-                    !strcmp(co->name, "health"))
+                    !strcmp(co->name, "health")   ||
+                    !strcmp(co->name, "backends"))
                 pri = 0;
             else if(!strncmp(co->name, "plugin:", 7)) pri = 1;
             else pri = 2;

--- a/src/backends.c
+++ b/src/backends.c
@@ -348,7 +348,7 @@ void *backends_main(void *ptr) {
 
         if(unlikely(netdata_exit)) break;
 
-        fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b)); // FIXME
+        // fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b)); // FIXME
         //fprintf(stderr, "after = %lu, before = %lu\n", after, before);
 
         if(unlikely(sock == -1)) {

--- a/src/backends.c
+++ b/src/backends.c
@@ -237,7 +237,7 @@ void *backends_main(void *ptr) {
     BUFFER *b = buffer_create(1);
     void (*formatter)(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before);
 
-    info("BACKENDs thread created with task id %d", gettid());
+    info("BACKEND thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
         error("Cannot set pthread cancel type to DEFERRED.");
@@ -247,13 +247,13 @@ void *backends_main(void *ptr) {
 
     int default_port = 0;
     int sock = -1;
-    int enabled = config_get_boolean("backends", "enable", 0);
-    const char *source = config_get("backends", "data source", "as stored");
-    const char *type = config_get("backends", "type", "graphite");
-    const char *destination = config_get("backends", "destination", "localhost");
-    const char *prefix = config_get("backends", "prefix", "netdata");
-    int frequency = (int)config_get_number("backends", "update every", 30);
-    int buffer_on_failures = (int)config_get_number("backends", "buffer on failures", 10);
+    int enabled = config_get_boolean("backend", "enable", 0);
+    const char *source = config_get("backend", "data source", "as stored");
+    const char *type = config_get("backend", "type", "graphite");
+    const char *destination = config_get("backend", "destination", "localhost");
+    const char *prefix = config_get("backend", "prefix", "netdata");
+    int frequency = (int)config_get_number("backend", "update every", 30);
+    int buffer_on_failures = (int)config_get_number("backend", "buffer on failures", 10);
 
     if(!enabled)
         goto cleanup;
@@ -380,7 +380,7 @@ cleanup:
     if(sock != -1)
         close(sock);
 
-    info("BACKENDs thread exiting");
+    info("BACKEND thread exiting");
 
     pthread_exit(NULL);
     return NULL;

--- a/src/backends.c
+++ b/src/backends.c
@@ -164,7 +164,7 @@ static inline int connect_to_one(const char *definition, int default_port, struc
     return fd;
 }
 
-static inline calculated_number backend_duration_average(RRDSET *st, RRDDIM *rd, time_t after, time_t before, uint32_t options) {
+static inline calculated_number backend_calculate_value_from_stored_data(RRDSET *st, RRDDIM *rd, time_t after, time_t before, uint32_t options) {
     time_t first_t = rrdset_first_entry_t(st);
     time_t last_t = rrdset_last_entry_t(st);
 
@@ -227,7 +227,7 @@ static inline int format_dimension_collected_graphite_plaintext(BUFFER *b, const
 
 static inline int format_dimension_stored_graphite_plaintext(BUFFER *b, const char *prefix, RRDHOST *host, const char *hostname, RRDSET *st, RRDDIM *rd, time_t after, time_t before, uint32_t options) {
     (void)host;
-    calculated_number value = backend_duration_average(st, rd, after, before, options);
+    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options);
     if(!isnan(value)) {
         buffer_sprintf(b, "%s.%s.%s.%s " CALCULATED_NUMBER_FORMAT " %u\n", prefix, hostname, st->id, rd->id, value, (uint32_t) before);
         return 1;
@@ -246,7 +246,7 @@ static inline int format_dimension_collected_opentsdb_telnet(BUFFER *b, const ch
 
 static inline int format_dimension_stored_opentsdb_telnet(BUFFER *b, const char *prefix, RRDHOST *host, const char *hostname, RRDSET *st, RRDDIM *rd, time_t after, time_t before, uint32_t options) {
     (void)host;
-    calculated_number value = backend_duration_average(st, rd, after, before, options);
+    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options);
     if(!isnan(value)) {
         buffer_sprintf(b, "put %s.%s.%s %u " CALCULATED_NUMBER_FORMAT " host=%s\n", prefix, st->id, rd->id, (uint32_t) before, value, hostname);
         return 1;

--- a/src/backends.c
+++ b/src/backends.c
@@ -2,7 +2,7 @@
 
 #define BACKEND_SOURCE_DATA_AS_COLLECTED 0x00000001
 #define BACKEND_SOURCE_DATA_AVERAGE      0x00000002
-#define BACKEND_SOURCE_DATA_SUM          0x00000003
+#define BACKEND_SOURCE_DATA_SUM          0x00000004
 
 int connect_to_socket4(const char *ip, int port) {
     int sock;
@@ -263,7 +263,7 @@ void *backends_main(void *ptr) {
     const char *destination = config_get("backend", "destination", "localhost");
     const char *prefix = config_get("backend", "prefix", "netdata");
     const char *hostname = config_get("backend", "hostname", localhost.hostname);
-    int frequency = (int)config_get_number("backend", "update every", 30);
+    int frequency = (int)config_get_number("backend", "update every", 10);
     int buffer_on_failures = (int)config_get_number("backend", "buffer on failures", 10);
 
     if(!enabled || frequency < 1)
@@ -348,7 +348,7 @@ void *backends_main(void *ptr) {
 
         if(unlikely(netdata_exit)) break;
 
-        //fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b));
+        fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b)); // FIXME
         //fprintf(stderr, "after = %lu, before = %lu\n", after, before);
 
         if(unlikely(sock == -1)) {

--- a/src/backends.c
+++ b/src/backends.c
@@ -266,7 +266,7 @@ void *backends_main(void *ptr) {
             formatter = format_dimension_stored_graphite_plaintext;
     }
     else if(!strcmp(type, "opentsdb") || !strcmp(type, "opentsdb:telnet")) {
-        default_port = 2003;
+        default_port = 4242;
         if(!strcmp(source, "as collected"))
             formatter = format_dimension_collected_opentsdb_telnet;
         else

--- a/src/backends.c
+++ b/src/backends.c
@@ -1,0 +1,269 @@
+#include "common.h"
+
+int connect_to_socket4(const char *ip, int port) {
+    int sock;
+
+    debug(D_LISTENER, "IPv4 connecting to ip '%s' port %d", ip, port);
+
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock < 0) {
+        error("IPv4 socket() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    struct sockaddr_in name;
+    memset(&name, 0, sizeof(struct sockaddr_in));
+    name.sin_family = AF_INET;
+    name.sin_port = htons(port);
+
+    int ret = inet_pton(AF_INET, ip, (void *)&name.sin_addr.s_addr);
+    if(ret != 1) {
+        error("Failed to convert '%s' to a valid IPv4 address.", ip);
+        close(sock);
+        return -1;
+    }
+
+    if(connect(sock, (struct sockaddr *) &name, sizeof(name)) < 0) {
+        close(sock);
+        error("IPv4 failed to connect to '%s', port %d", ip, port);
+        return -1;
+    }
+
+    debug(D_LISTENER, "Connected to IPv4 ip '%s' port %d", ip, port);
+    return sock;
+}
+
+int connect_to_socket6(const char *ip, int port) {
+    int sock = -1;
+    int ipv6only = 1;
+
+    debug(D_LISTENER, "IPv6 connecting to ip '%s' port %d", ip, port);
+
+    sock = socket(AF_INET6, SOCK_STREAM, 0);
+    if (sock < 0) {
+        error("IPv6 socket() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    /* IPv6 only */
+    if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&ipv6only, sizeof(ipv6only)) != 0)
+        error("Cannot set IPV6_V6ONLY on ip '%s' port's %d.", ip, port);
+
+    struct sockaddr_in6 name;
+    memset(&name, 0, sizeof(struct sockaddr_in6));
+    name.sin6_family = AF_INET6;
+    name.sin6_port = htons ((uint16_t) port);
+
+    int ret = inet_pton(AF_INET6, ip, (void *)&name.sin6_addr.s6_addr);
+    if(ret != 1) {
+        error("Failed to convert IP '%s' to a valid IPv6 address.", ip);
+        close(sock);
+        return -1;
+    }
+
+    name.sin6_scope_id = 0;
+
+    if(connect(sock, (struct sockaddr *)&name, sizeof(name)) < 0) {
+        close(sock);
+        error("IPv6 failed to connect to '%s', port %d", ip, port);
+        return -1;
+    }
+
+    debug(D_LISTENER, "Connected to IPv6 ip '%s' port %d", ip, port);
+    return sock;
+}
+
+
+static inline int connect_to_one(const char *definition, int default_port) {
+    struct addrinfo hints;
+    struct addrinfo *result = NULL, *rp = NULL;
+
+    char buffer[strlen(definition) + 1];
+    strcpy(buffer, definition);
+
+    char buffer2[10 + 1];
+    snprintfz(buffer2, 10, "%d", default_port);
+
+    char *ip = buffer, *port = buffer2;
+
+    char *e = ip;
+    if(*e == '[') {
+        e = ++ip;
+        while(*e && *e != ']') e++;
+        if(*e == ']') {
+            *e = '\0';
+            e++;
+        }
+    }
+    else {
+        while(*e && *e != ':') e++;
+    }
+
+    if(*e == ':') {
+        port = e + 1;
+        *e = '\0';
+    }
+
+    if(!*ip)
+        return -1;
+
+    if(!*port)
+        port = buffer2;
+
+    memset(&hints, 0, sizeof(struct addrinfo));
+    hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
+    hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
+    hints.ai_flags = AI_PASSIVE;    /* For wildcard IP address */
+    hints.ai_protocol = 0;          /* Any protocol */
+    hints.ai_canonname = NULL;
+    hints.ai_addr = NULL;
+    hints.ai_next = NULL;
+
+    int r = getaddrinfo(ip, port, &hints, &result);
+    if (r != 0) {
+        error("Cannot resolve host '%s', port '%s': %s\n", ip, port, gai_strerror(r));
+        return -1;
+    }
+
+    int fd = -1;
+    for (rp = result; rp != NULL && fd == -1; rp = rp->ai_next) {
+        char rip[INET_ADDRSTRLEN + INET6_ADDRSTRLEN] = "INVALID";
+        int rport;
+
+        switch (rp->ai_addr->sa_family) {
+            case AF_INET: {
+                struct sockaddr_in *sin = (struct sockaddr_in *) rp->ai_addr;
+                inet_ntop(AF_INET, &sin->sin_addr, rip, INET_ADDRSTRLEN);
+                rport = ntohs(sin->sin_port);
+                fd = connect_to_socket4(rip, rport);
+                break;
+            }
+
+            case AF_INET6: {
+                struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) rp->ai_addr;
+                inet_ntop(AF_INET6, &sin6->sin6_addr, rip, INET6_ADDRSTRLEN);
+                rport = ntohs(sin6->sin6_port);
+                fd = connect_to_socket6(rip, rport);
+                break;
+            }
+        }
+    }
+
+    freeaddrinfo(result);
+
+    return fd;
+}
+
+static inline void format_dimension_collected_graphite_plaintext(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before) {
+    time_t last = rd->last_collected_time.tv_sec;
+    if(likely(last >= after && last < before))
+        buffer_sprintf(b, "%s.%s.%s.%s " COLLECTED_NUMBER_FORMAT " %u\n", prefix, host->hostname, st->id, rd->id, rd->last_collected_value, (uint32_t)last);
+}
+
+static inline void format_dimension_stored_graphite_plaintext(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before) {
+    time_t last = rd->last_collected_time.tv_sec;
+    if(likely(last >= after && last < before))
+        buffer_sprintf(b, "%s.%s.%s.%s " CALCULATED_NUMBER_FORMAT " %u\n", prefix, host->hostname, st->id, rd->id, rd->last_stored_value, (uint32_t)last);
+}
+
+static inline void format_dimension_collected_opentsdb_telnet(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before) {
+    time_t last = rd->last_collected_time.tv_sec;
+    if(likely(last >= after && last < before))
+        buffer_sprintf(b, "put %s.%s.%s %u " COLLECTED_NUMBER_FORMAT " host=%s\n", prefix, st->id, rd->id, (uint32_t)last, rd->last_collected_value, host->hostname);
+}
+
+static inline void format_dimension_stored_opentsdb_telnet(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before) {
+    time_t last = rd->last_collected_time.tv_sec;
+    if(likely(last >= after && last < before))
+        buffer_sprintf(b, "put %s.%s.%s %u " CALCULATED_NUMBER_FORMAT " host=%s\n", prefix, st->id, rd->id, (uint32_t)last, rd->last_stored_value, host->hostname);
+}
+
+void *backends_main(void *ptr) {
+    (void)ptr;
+    BUFFER *b = buffer_create(1);
+    void (*formatter)(BUFFER *b, const char *prefix, RRDHOST *host, RRDSET *st, RRDDIM *rd, time_t after, time_t before);
+
+    info("BACKENDs thread created with task id %d", gettid());
+
+    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+        error("Cannot set pthread cancel type to DEFERRED.");
+
+    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+        error("Cannot set pthread cancel state to ENABLE.");
+
+    int default_port = 0;
+    int enabled = config_get_boolean("backends", "enable", 0);
+    const char *source = config_get("backends", "data source", "as stored");
+    const char *type = config_get("backends", "type", "graphite");
+    const char *destination = config_get("backends", "destination", "localhost");
+    const char *prefix = config_get("backends", "prefix", "netdata");
+    int frequency = (int)config_get_number("backends", "update every", 10);
+
+    if(!enabled)
+        goto cleanup;
+
+    if(!strcmp(type, "graphite") || !strcmp(type, "graphite:plaintext")) {
+        default_port = 2003;
+        if(!strcmp(source, "as collected"))
+            formatter = format_dimension_collected_graphite_plaintext;
+        else
+            formatter = format_dimension_stored_graphite_plaintext;
+    }
+    else if(!strcmp(type, "opentsdb") || !strcmp(type, "opentsdb:telnet")) {
+        default_port = 2003;
+        if(!strcmp(source, "as collected"))
+            formatter = format_dimension_collected_opentsdb_telnet;
+        else
+            formatter = format_dimension_stored_opentsdb_telnet;
+    }
+    else {
+        error("Unknown backend type '%s'", type);
+        goto cleanup;
+    }
+
+    time_t after, before = (time_t)(time_usec() / 10000000ULL);
+
+    unsigned long long step = frequency * 1000000ULL;
+    for(;;) {
+        unsigned long long now = time_usec();
+        unsigned long long next = now - (now % step) + step + (step / 2);
+
+        while(now < next) {
+            sleep_usec(next - now);
+            now = time_usec();
+        }
+
+        after = before;
+        before = (time_t)(now / 10000000ULL);
+        RRDSET *st;
+        int pthreadoldcancelstate;
+        buffer_flush(b);
+
+        if(unlikely(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &pthreadoldcancelstate) != 0))
+            error("Cannot set pthread cancel state to DISABLE.");
+
+        rrdhost_rdlock(&localhost);
+        for(st = localhost.rrdset_root; st ;st = st->next) {
+            pthread_rwlock_rdlock(&st->rwlock);
+            RRDDIM *rd;
+            for(rd = st->dimensions; rd ;rd = rd->next) {
+                formatter(b, prefix, &localhost, st, rd, after, before);
+            }
+            pthread_rwlock_unlock(&st->rwlock);
+        }
+        rrdhost_unlock(&localhost);
+
+        if(unlikely(pthread_setcancelstate(pthreadoldcancelstate, NULL) != 0))
+            error("Cannot set pthread cancel state to RESTORE (%d).", pthreadoldcancelstate);
+
+        if(unlikely(netdata_exit)) break;
+
+        break;
+    }
+
+cleanup:
+    info("BACKENDs thread exiting");
+
+    pthread_exit(NULL);
+    return NULL;
+}

--- a/src/backends.h
+++ b/src/backends.h
@@ -1,0 +1,6 @@
+#ifndef NETDATA_BACKENDS_H
+#define NETDATA_BACKENDS_H 1
+
+void *backends_main(void *ptr);
+
+#endif /* NETDATA_BACKENDS_H */

--- a/src/common.h
+++ b/src/common.h
@@ -130,6 +130,7 @@
 #include "unit_test.h"
 
 #include "ipc.h"
+#include "backends.h"
 
 #ifdef abs
 #undef abs

--- a/src/main.c
+++ b/src/main.c
@@ -48,6 +48,7 @@ struct netdata_static_thread {
     {"proc",               "plugins",   "proc",       1, NULL, NULL, proc_main},
     {"cgroups",            "plugins",   "cgroups",    1, NULL, NULL, cgroups_main},
     {"check",              "plugins",   "checks",     0, NULL, NULL, checks_main},
+    {"backends",            NULL,       NULL,         1, NULL, NULL, backends_main},
     {"health",              NULL,       NULL,         1, NULL, NULL, health_main},
     {"plugins.d",           NULL,       NULL,         1, NULL, NULL, pluginsd_main},
     {"web",                 NULL,       NULL,         1, NULL, NULL, socket_listen_main_multi_threaded},

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -290,7 +290,7 @@ static inline int bind_to_one(const char *definition, int default_port, int list
         }
 
         if (fd == -1)
-            error("Cannot bind to ip '%s', port %d", rip, default_port);
+            error("Cannot bind to ip '%s', port %d", rip, rport);
         else {
             add_listen_socket(fd, rip, rport);
             added++;


### PR DESCRIPTION
This PR adds database backends support to netdata.

## features

1. Supported backends

   1. **graphite** (plaintext interface)

      metrics are sent to graphite as `prefix.hostname.chart.dimension`. `prefix` is configured below, `hostname` is the hostname of the machine.

   2. **opentsdb** (telnet interface)

      metrics are sent to opentsdb as `prefix.chart.dimension` with tag `host=hostname`.

2. Only one backed may be active at a time.

3. All metrics are transferred to the backend - netdata does not implement any metric filtering.

4. Three modes of operation (for both backends):

   1. `as collected`: the latest collected value is sent to the backend. This means that if netdata is configured to send data to the backend every 10 seconds, only 1 out of 10 values will appear at the backend server. The values are sent exactly as collected, before any multipliers or dividers applied and before any interpolation. This mode emulates other data collectors, such as `collectd`.

   2. `average`: the average of the interpolated values shown on the netdata graphs is sent to the backend. So, if netdata is configured to send data to the backend server every 10 seconds, the average of the 10 values shown on the netdata charts will be used.

   3. `sum` or `volume`: the sum of the interpolated values shown on the netdata graphs is sent to the backend. So, if netdata is configured to send data to the backend every 10 seconds, the sum of the 10 values shown on the netdata charts will be used.

5. This code is smart enough, not to slow down netdata, independently of the speed of the backend server.

## configuration

A new section will appear in netdata.conf, like this:

```
[backend]
	# enable = no
	# type = graphite
	# destination = localhost
	# data source = average
	# prefix = netdata
        # hostname = my-name
	# update every = 10
	# buffer on failures = 10
        # timeout ms = 20000
```

- `enable = yes/no`, enables or disables sending data to a backend

- `type = graphite` or `type = opentsdb`, selects the backend type

- `destination = host`, accepts a space separated list of hostnames, IPs (IPv4 and IPv6) and ports to connect to. Netdata will use the first available to send the metrics. The format is like this: `host1:port1 host2:port2 host3:port3 ...`. For IPv6 addresses this is supported: `[IPV6_IP]:PORT` (like the web clients).

- `data source = as collected`, or `data source = average`, or `data source = sum`, selects the kind of data that will be sent to the backend.

- `hostname = my-name`, is the hostname to be used for sending data to the backend server. By default this is `[global].hostname`.

- `prefix = netdata`, is the prefix to add to all metrics.

- `update every = 10`, is the number of seconds between sending data to the backend. netdata will add some randomness to this number, to prevent stressing the backend server when many netdata servers send data to the same backend. This randomness does not affect the quality of the data, only the time they are sent.

- `buffer on failures = 10`, is the number of iterations (each iteration is `[backend].update every` seconds) to buffer data, when the backend is not available. If the backend fails to receive the data after that many failures, data loss on the backend is expected (netdata will also log it).

- `timeout ms = 20000`, is the timeout in milliseconds to wait for the backend server to process the data. By default this is `2 * update_every * 1000`.

## monitoring operation

netdata provides 5 charts:

1. **Buffered metrics**, the number of metrics netdata added to the buffer for dispatching them to the backend server.
2. **Buffered data size**, the amount of data (in KB) netdata added the buffer.
3. **Backend latency**, the time the backend server needed to process the data netdata sent. If there was a re-connection involved, this includes the connection time.
4. **Backend operations**, the number of operations performed by netdata.
5. **Backend thread CPU usage**, the CPU resources consumed by the netdata thread, that is responsible for sending the metrics to the backend server.

![image](https://cloud.githubusercontent.com/assets/2662304/20463536/eb196084-af3d-11e6-8ee5-ddbd3b4d8449.png)

## alarms

netdata adds 4 alarms:

1. `backend_last_buffering`, number of seconds since the last successful buffering of backend data
2. `backend_metrics_sent`, percentage of metrics sent to the backend server
3. `backend_metrics_lost`, number of metrics lost due to repeating failures to contact the backend server
4. `backend_slow`, the percentage of time between iterations needed by the backend time to process the data sent by netdata

![image](https://cloud.githubusercontent.com/assets/2662304/20463779/a46ed1c2-af43-11e6-91a5-07ca4533cac3.png)

