### PR TITLE
SNMP with string OIDs; python.d.plugin now exits properly

### DIFF
--- a/node.d/snmp.node.js
+++ b/node.d/snmp.node.js
@@ -249,7 +249,11 @@ netdata.processors.snmp = {
                         if(netdata.options.DEBUG === true)
                             netdata.debug(service.module.name + ': ' + service.name + ': found ' + service.module.name + ' value of OIDs ' + varbinds[i].oid + " = " + varbinds[i].value);
 
-                        value = varbinds[i].value;
+                        if(varbinds[i].type === net_snmp.ObjectType.OctetString)
+                            value = parseFloat(varbinds[i].value) * 1000;
+                        else
+                            value = varbinds[i].value;
+
                         ok++;
                     }
 

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -320,7 +320,10 @@ class SimpleService(threading.Thread):
         """
         Upload new data to netdata.
         """
-        print(self._data_stream)
+        try:
+            print(self._data_stream)
+        except Exception as e:
+            msg.fatal('cannot send data to netdata:', str(e))
         self._data_stream = ""
 
     # --- ERROR HANDLING ---

--- a/python.d/python_modules/msg.py
+++ b/python.d/python_modules/msg.py
@@ -93,8 +93,9 @@ def fatal(*args):
     """
     Print message on stderr and exit.
     """
-    log_msg("FATAL", *args)
-    # using sys.stdout causes IOError: Broken Pipe
-    print('DISABLE')
-    # sys.stdout.write('DISABLE\n')
+    try:
+        log_msg("FATAL", *args)
+        print('DISABLE')
+    except:
+        pass
     sys.exit(1)


### PR DESCRIPTION
1. fixes #1236 so that netdata can collect values from SNMP string OIDs
2. fixes #1155, python.d.plugin did not exit when netdata exited. Now it does.
