### PR TITLE
fixed name of openSUSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ It should run on **any Linux** system (including IoT). It has been tested on:
 - Debian
 - Fedora
 - Gentoo
-- OpenSuse
+- openSUSE
 - PLD Linux
 - RedHat Enterprise Linux
 - SUSE


### PR DESCRIPTION
As you can see, your have a typo .