### PR TITLE
node.d.plugin logging fixes

### DIFF
--- a/node.d/node_modules/netdata.js
+++ b/node.d/node_modules/netdata.js
@@ -139,7 +139,7 @@ var netdata = {
 
     logdate: function(d) {
         if(typeof d === 'undefined') d = new Date();
-        return this.zeropad2(d.getFullYear()) + '-' + this.zeropad2(d.getMonth()) + '-' + this.zeropad2(d.getDate())
+        return d.getFullYear().toString() + '-' + this.zeropad2(d.getMonth()) + '-' + this.zeropad2(d.getDate())
             + ' ' + this.zeropad2(d.getHours()) + ':' + this.zeropad2(d.getMinutes()) + ':' + this.zeropad2(d.getSeconds());
     },
 

--- a/node.d/node_modules/netdata.js
+++ b/node.d/node_modules/netdata.js
@@ -139,7 +139,7 @@ var netdata = {
 
     logdate: function(d) {
         if(typeof d === 'undefined') d = new Date();
-        return d.getFullYear().toString() + '-' + this.zeropad2(d.getMonth()) + '-' + this.zeropad2(d.getDate())
+        return d.getFullYear().toString() + '-' + this.zeropad2(d.getMonth() + 1) + '-' + this.zeropad2(d.getDate())
             + ' ' + this.zeropad2(d.getHours()) + ':' + this.zeropad2(d.getMinutes()) + ':' + this.zeropad2(d.getSeconds());
     },
 

--- a/node.d/node_modules/netdata.js
+++ b/node.d/node_modules/netdata.js
@@ -139,7 +139,7 @@ var netdata = {
 
     logdate: function(d) {
         if(typeof d === 'undefined') d = new Date();
-        return this.zeropad2(d.getFullYear()) + '-' + this.zeropad2(d.getMonth()) + '-' + this.zeropad2(d.getDay())
+        return this.zeropad2(d.getFullYear()) + '-' + this.zeropad2(d.getMonth()) + '-' + this.zeropad2(d.getDate())
             + ' ' + this.zeropad2(d.getHours()) + ':' + this.zeropad2(d.getMinutes()) + ':' + this.zeropad2(d.getSeconds());
     },
 


### PR DESCRIPTION
1. wrong date of month printed; fixes #1287 
2. wrong fullyear printed (after PR #1284 the fullyear was printed as a 2-digit number)
3. wrong month number printed (node gives the month zero-based)
