### PR TITLE
Print useful error message when postgres plugin job fails.

### DIFF
--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 
 import psycopg2
 from psycopg2 import extensions
-from psycopg2._psycopg import DatabaseError
 from psycopg2.extras import DictCursor
 
 from base import SimpleService
@@ -222,10 +221,8 @@ class Service(SimpleService):
 
             self._create_definitions()
             return True
-        except DatabaseError:
-            return False
         except Exception as e:
-            self.error(e)
+            self.error(str(e))
             return False
 
     def _discover_databases(self, cursor):


### PR DESCRIPTION
Finally fix poor error reporting identified in #1183. 