### PR TITLE
use monotonic clock for all time computations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(NETDATA_SOURCE_FILES
         src/avl.h
         src/backends.c
         src/backends.h
+        src/clocks.c
+        src/clocks.h
         src/common.c
         src/common.h
         src/daemon.c

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,9 @@ AC_PROG_INSTALL
 PKG_PROG_PKG_CONFIG
 AC_USE_SYSTEM_EXTENSIONS
 AC_CHECK_FUNCS_ONCE(accept4)
+AC_CHECK_TYPES([struct timespec, clockid_t], [], [], [[#include <time.h>]])
+AC_SEARCH_LIBS([clock_gettime], [rt posix4])
+AC_CHECK_FUNCS([clock_gettime])
 
 # Check system type
 case "$host_os" in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,7 @@ netdata_SOURCES = \
 	appconfig.c appconfig.h \
 	avl.c avl.h \
 	backends.c backends.h \
+	clocks.c clocks.h \
 	common.c common.h \
 	daemon.c daemon.h \
 	dictionary.c dictionary.h \
@@ -100,6 +101,7 @@ netdata_LDADD = \
 apps_plugin_SOURCES = \
 	apps_plugin.c \
 	avl.c avl.h \
+	clocks.c clocks.h \
 	common.c common.h \
 	log.c log.h \
 	procfile.c procfile.h \

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -592,7 +592,7 @@ int read_proc_pid_stat(struct pid_stat *p) {
     if(unlikely(!ff)) goto cleanup;
 
     p->last_stat_collected_usec = p->stat_collected_usec;
-    p->stat_collected_usec = time_usec();
+    p->stat_collected_usec = now_realtime_usec();
     file_counter++;
 
     // p->pid           = atol(procfile_lineword(ff, 0, 0+i));
@@ -774,7 +774,7 @@ int read_proc_pid_io(struct pid_stat *p) {
     file_counter++;
 
     p->last_io_collected_usec = p->io_collected_usec;
-    p->io_collected_usec = time_usec();
+    p->io_collected_usec = now_realtime_usec();
 
     unsigned long long last;
 
@@ -848,7 +848,7 @@ int read_proc_stat() {
     if(unlikely(!ff)) goto cleanup;
 
     last_collected_usec = collected_usec;
-    collected_usec = time_usec();
+    collected_usec = now_realtime_usec();
 
     file_counter++;
 
@@ -2843,12 +2843,12 @@ int main(int argc, char **argv)
     unsigned long long step = update_every * 1000000ULL;
     global_iterations_counter = 1;
     for(;1; global_iterations_counter++) {
-        unsigned long long now = time_usec();
+        unsigned long long now = now_realtime_usec();
         unsigned long long next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);
-            now = time_usec();
+            now = now_realtime_usec();
         }
 
         if(!collect_data_for_all_processes_from_proc()) {

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2173,7 +2173,7 @@ unsigned long long send_resource_usage_to_netdata() {
         gettimeofday(&now, NULL);
         getrusage(RUSAGE_SELF, &me);
 
-        usec = usec_dt(&now, &last);
+        usec = dt_usec(&now, &last);
         cpuuser = me.ru_utime.tv_sec * 1000000ULL + me.ru_utime.tv_usec;
         cpusyst = me.ru_stime.tv_sec * 1000000ULL + me.ru_stime.tv_usec;
 

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -611,35 +611,35 @@ int read_proc_pid_stat(struct pid_stat *p) {
 
     last = p->minflt_raw;
     p->minflt_raw       = strtoull(procfile_lineword(ff, 0, 9), NULL, 10);
-    p->minflt = (p->minflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->minflt = (p->minflt_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->cminflt_raw;
     p->cminflt_raw      = strtoull(procfile_lineword(ff, 0, 10), NULL, 10);
-    p->cminflt = (p->cminflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->cminflt = (p->cminflt_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->majflt_raw;
     p->majflt_raw       = strtoull(procfile_lineword(ff, 0, 11), NULL, 10);
-    p->majflt = (p->majflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->majflt = (p->majflt_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->cmajflt_raw;
     p->cmajflt_raw      = strtoull(procfile_lineword(ff, 0, 12), NULL, 10);
-    p->cmajflt = (p->cmajflt_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->cmajflt = (p->cmajflt_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->utime_raw;
     p->utime_raw        = strtoull(procfile_lineword(ff, 0, 13), NULL, 10);
-    p->utime = (p->utime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->utime = (p->utime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->stime_raw;
     p->stime_raw        = strtoull(procfile_lineword(ff, 0, 14), NULL, 10);
-    p->stime = (p->stime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->stime = (p->stime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->cutime_raw;
     p->cutime_raw       = strtoull(procfile_lineword(ff, 0, 15), NULL, 10);
-    p->cutime = (p->cutime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->cutime = (p->cutime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     last = p->cstime_raw;
     p->cstime_raw       = strtoull(procfile_lineword(ff, 0, 16), NULL, 10);
-    p->cstime = (p->cstime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+    p->cstime = (p->cstime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
     // p->priority      = strtoull(procfile_lineword(ff, 0, 17), NULL, 10);
     // p->nice          = strtoull(procfile_lineword(ff, 0, 18), NULL, 10);
@@ -670,11 +670,11 @@ int read_proc_pid_stat(struct pid_stat *p) {
     if(enable_guest_charts) {
         last = p->gtime_raw;
         p->gtime_raw        = strtoull(procfile_lineword(ff, 0, 42), NULL, 10);
-        p->gtime = (p->gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+        p->gtime = (p->gtime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
         last = p->cgtime_raw;
         p->cgtime_raw       = strtoull(procfile_lineword(ff, 0, 43), NULL, 10);
-        p->cgtime = (p->cgtime_raw - last) * (1000000ULL * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
+        p->cgtime = (p->cgtime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->stat_collected_usec - p->last_stat_collected_usec);
 
         if (show_guest_time || p->gtime || p->cgtime) {
             p->utime -= (p->utime >= p->gtime) ? p->gtime : p->utime;
@@ -780,31 +780,31 @@ int read_proc_pid_io(struct pid_stat *p) {
 
     last = p->io_logical_bytes_read_raw;
     p->io_logical_bytes_read_raw = strtoull(procfile_lineword(ff, 0, 1), NULL, 10);
-    p->io_logical_bytes_read = (p->io_logical_bytes_read_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    p->io_logical_bytes_read = (p->io_logical_bytes_read_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     last = p->io_logical_bytes_written_raw;
     p->io_logical_bytes_written_raw = strtoull(procfile_lineword(ff, 1, 1), NULL, 10);
-    p->io_logical_bytes_written = (p->io_logical_bytes_written_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    p->io_logical_bytes_written = (p->io_logical_bytes_written_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     // last = p->io_read_calls_raw;
     // p->io_read_calls_raw = strtoull(procfile_lineword(ff, 2, 1), NULL, 10);
-    // p->io_read_calls = (p->io_read_calls_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    // p->io_read_calls = (p->io_read_calls_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     // last = p->io_write_calls_raw;
     // p->io_write_calls_raw = strtoull(procfile_lineword(ff, 3, 1), NULL, 10);
-    // p->io_write_calls = (p->io_write_calls_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    // p->io_write_calls = (p->io_write_calls_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     last = p->io_storage_bytes_read_raw;
     p->io_storage_bytes_read_raw = strtoull(procfile_lineword(ff, 4, 1), NULL, 10);
-    p->io_storage_bytes_read = (p->io_storage_bytes_read_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    p->io_storage_bytes_read = (p->io_storage_bytes_read_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     last = p->io_storage_bytes_written_raw;
     p->io_storage_bytes_written_raw = strtoull(procfile_lineword(ff, 5, 1), NULL, 10);
-    p->io_storage_bytes_written = (p->io_storage_bytes_written_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    p->io_storage_bytes_written = (p->io_storage_bytes_written_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     // last = p->io_cancelled_write_bytes_raw;
     // p->io_cancelled_write_bytes_raw = strtoull(procfile_lineword(ff, 6, 1), NULL, 10);
-    // p->io_cancelled_write_bytes = (p->io_cancelled_write_bytes_raw - last) * (1000000ULL * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
+    // p->io_cancelled_write_bytes = (p->io_cancelled_write_bytes_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (p->io_collected_usec - p->last_io_collected_usec);
 
     if(unlikely(global_iterations_counter == 1)) {
         p->io_logical_bytes_read        = 0;
@@ -836,7 +836,8 @@ unsigned long long global_gtime = 0;
 int read_proc_stat() {
     static char filename[FILENAME_MAX + 1] = "";
     static procfile *ff = NULL;
-    static unsigned long long utime_raw = 0, stime_raw = 0, gtime_raw = 0, gntime_raw = 0, ntime_raw = 0, collected_usec = 0, last_collected_usec = 0;
+    static unsigned long long utime_raw = 0, stime_raw = 0, gtime_raw = 0, gntime_raw = 0, ntime_raw = 0;
+    static usec_t collected_usec = 0, last_collected_usec = 0;
 
     if(unlikely(!ff)) {
         snprintfz(filename, FILENAME_MAX, "%s/proc/stat", global_host_prefix);
@@ -856,26 +857,26 @@ int read_proc_stat() {
 
     last = utime_raw;
     utime_raw = strtoull(procfile_lineword(ff, 0, 1), NULL, 10);
-    global_utime = (utime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+    global_utime = (utime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
     // nice time, on user time
     last = ntime_raw;
     ntime_raw = strtoull(procfile_lineword(ff, 0, 2), NULL, 10);
-    global_utime += (ntime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+    global_utime += (ntime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
     last = stime_raw;
     stime_raw = strtoull(procfile_lineword(ff, 0, 3), NULL, 10);
-    global_stime = (stime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+    global_stime = (stime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
     last = gtime_raw;
     gtime_raw = strtoull(procfile_lineword(ff, 0, 10), NULL, 10);
-    global_gtime = (gtime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+    global_gtime = (gtime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
     if(enable_guest_charts) {
         // guest nice time, on guest time
         last = gntime_raw;
         gntime_raw = strtoull(procfile_lineword(ff, 0, 11), NULL, 10);
-        global_gtime += (gntime_raw - last) * (1000000ULL * RATES_DETAIL) / (collected_usec - last_collected_usec);
+        global_gtime += (gntime_raw - last) * (USEC_PER_SEC * RATES_DETAIL) / (collected_usec - last_collected_usec);
 
         // remove guest time from user time
         global_utime -= (global_utime > global_gtime) ? global_gtime : global_utime;
@@ -1441,11 +1442,11 @@ void process_exited_processes() {
                         );
             }
 
-            p->utime_raw   = utime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (1000000ULL * RATES_DETAIL);
-            p->stime_raw   = stime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (1000000ULL * RATES_DETAIL);
-            p->gtime_raw   = gtime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (1000000ULL * RATES_DETAIL);
-            p->minflt_raw  = minflt * (p->stat_collected_usec - p->last_stat_collected_usec) / (1000000ULL * RATES_DETAIL);
-            p->majflt_raw  = majflt * (p->stat_collected_usec - p->last_stat_collected_usec) / (1000000ULL * RATES_DETAIL);
+            p->utime_raw   = utime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (USEC_PER_SEC * RATES_DETAIL);
+            p->stime_raw   = stime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (USEC_PER_SEC * RATES_DETAIL);
+            p->gtime_raw   = gtime  * (p->stat_collected_usec - p->last_stat_collected_usec) / (USEC_PER_SEC * RATES_DETAIL);
+            p->minflt_raw  = minflt * (p->stat_collected_usec - p->last_stat_collected_usec) / (USEC_PER_SEC * RATES_DETAIL);
+            p->majflt_raw  = majflt * (p->stat_collected_usec - p->last_stat_collected_usec) / (USEC_PER_SEC * RATES_DETAIL);
             p->cutime_raw = p->cstime_raw = p->cgtime_raw = p->cminflt_raw = p->cmajflt_raw = 0;
 
             if(unlikely(debug))
@@ -2147,16 +2148,16 @@ static inline void send_END(void) {
 double utime_fix_ratio = 1.0, stime_fix_ratio = 1.0, gtime_fix_ratio = 1.0, cutime_fix_ratio = 1.0, cstime_fix_ratio = 1.0, cgtime_fix_ratio = 1.0;
 double minflt_fix_ratio = 1.0, majflt_fix_ratio = 1.0, cminflt_fix_ratio = 1.0, cmajflt_fix_ratio = 1.0;
 
-unsigned long long send_resource_usage_to_netdata() {
+usec_t send_resource_usage_to_netdata() {
     static struct timeval last = { 0, 0 };
     static struct rusage me_last;
 
     struct timeval now;
     struct rusage me;
 
-    unsigned long long usec;
-    unsigned long long cpuuser;
-    unsigned long long cpusyst;
+    usec_t usec;
+    usec_t cpuuser;
+    usec_t cpusyst;
 
     if(!last.tv_sec) {
         now_realtime_timeval(&last);
@@ -2164,7 +2165,7 @@ unsigned long long send_resource_usage_to_netdata() {
 
         // the first time, give a zero to allow
         // netdata calibrate to the current time
-        // usec = update_every * 1000000ULL;
+        // usec = update_every * USEC_PER_SEC;
         usec = 0ULL;
         cpuuser = 0;
         cpusyst = 0;
@@ -2174,8 +2175,8 @@ unsigned long long send_resource_usage_to_netdata() {
         getrusage(RUSAGE_SELF, &me);
 
         usec = dt_usec(&now, &last);
-        cpuuser = me.ru_utime.tv_sec * 1000000ULL + me.ru_utime.tv_usec;
-        cpusyst = me.ru_stime.tv_sec * 1000000ULL + me.ru_stime.tv_usec;
+        cpuuser = me.ru_utime.tv_sec * USEC_PER_SEC + me.ru_utime.tv_usec;
+        cpusyst = me.ru_stime.tv_sec * USEC_PER_SEC + me.ru_stime.tv_usec;
 
         memmove(&last, &now, sizeof(struct timeval));
         memmove(&me_last, &me, sizeof(struct rusage));
@@ -2381,7 +2382,7 @@ void normalize_data(struct target *root) {
     }
 }
 
-void send_collected_data_to_netdata(struct target *root, const char *type, unsigned long long usec) {
+void send_collected_data_to_netdata(struct target *root, const char *type, usec_t usec) {
     struct target *w;
 
     send_BEGIN(type, "cpu", usec);
@@ -2840,11 +2841,11 @@ int main(int argc, char **argv)
             , RATES_DETAIL
             );
 
-    unsigned long long step = update_every * 1000000ULL;
+    usec_t step = update_every * USEC_PER_SEC;
     global_iterations_counter = 1;
     for(;1; global_iterations_counter++) {
-        unsigned long long now = now_realtime_usec();
-        unsigned long long next = now - (now % step) + step;
+        usec_t now = now_realtime_usec();
+        usec_t next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);
@@ -2860,7 +2861,7 @@ int main(int argc, char **argv)
         calculate_netdata_statistics();
         normalize_data(apps_groups_root_target);
 
-        unsigned long long dt = send_resource_usage_to_netdata();
+        usec_t dt = send_resource_usage_to_netdata();
 
         // this is smart enough to show only newly added apps, when needed
         send_charts_updates_to_netdata(apps_groups_root_target, "apps", "Apps");

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2159,7 +2159,7 @@ unsigned long long send_resource_usage_to_netdata() {
     unsigned long long cpusyst;
 
     if(!last.tv_sec) {
-        gettimeofday(&last, NULL);
+        now_realtime_timeval(&last);
         getrusage(RUSAGE_SELF, &me_last);
 
         // the first time, give a zero to allow
@@ -2170,7 +2170,7 @@ unsigned long long send_resource_usage_to_netdata() {
         cpusyst = 0;
     }
     else {
-        gettimeofday(&now, NULL);
+        now_realtime_timeval(&now);
         getrusage(RUSAGE_SELF, &me);
 
         usec = dt_usec(&now, &last);

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2798,7 +2798,7 @@ int main(int argc, char **argv)
 
     procfile_adaptive_initial_allocation = 1;
 
-    time_t started_t = time(NULL);
+    time_t started_t = now_realtime_sec();
     get_system_HZ();
     get_system_pid_max();
     get_system_cpus();
@@ -2890,7 +2890,7 @@ int main(int argc, char **argv)
         if(unlikely(debug))
             fprintf(stderr, "apps.plugin: done Loop No %llu\n", global_iterations_counter);
 
-        time_t current_t = time(NULL);
+        time_t current_t = now_realtime_sec();
 
         // restart check (14400 seconds)
         if(current_t - started_t > 14400) exit(0);

--- a/src/backends.c
+++ b/src/backends.c
@@ -395,9 +395,9 @@ void *backends_main(void *ptr) {
 
     info("BACKEND configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, frequency, hostname, prefix);
 
-    unsigned long long step_ut = frequency * 1000000ULL;
-    unsigned long long random_ut = now_realtime_usec() % (step_ut / 2);
-    time_t before = (time_t)((now_realtime_usec() - step_ut) / 10000000ULL);
+    usec_t step_ut = frequency * USEC_PER_SEC;
+    usec_t random_ut = now_realtime_usec() % (step_ut / 2);
+    time_t before = (time_t)((now_realtime_usec() - step_ut) / USEC_PER_SEC);
     time_t after = before;
     int failures = 0;
 
@@ -405,9 +405,9 @@ void *backends_main(void *ptr) {
         // ------------------------------------------------------------------------
         // wait for the next iteration point
 
-        unsigned long long now_ut = now_realtime_usec();
-        unsigned long long next_ut = now_ut - (now_ut % step_ut) + step_ut;
-        before = (time_t)(next_ut / 1000000ULL);
+        usec_t now_ut = now_realtime_usec();
+        usec_t next_ut = now_ut - (now_ut % step_ut) + step_ut;
+        before = (time_t)(next_ut / USEC_PER_SEC);
 
         // add a little delay (1/4 of the step) plus some randomness
         next_ut += (step_ut / 4) + random_ut;
@@ -465,7 +465,7 @@ void *backends_main(void *ptr) {
         // connect to a backend server
 
         if(unlikely(sock == -1)) {
-            unsigned long long start_ut = now_realtime_usec();
+            usec_t start_ut = now_realtime_usec();
             const char *s = destination;
             while(*s) {
                 const char *e = s;
@@ -496,7 +496,7 @@ void *backends_main(void *ptr) {
 
         if(likely(sock != -1)) {
             size_t len = buffer_strlen(b);
-            unsigned long long start_ut = now_realtime_usec();
+            usec_t start_ut = now_realtime_usec();
             int flags = 0;
 #ifdef MSG_NOSIGNAL
             flags += MSG_NOSIGNAL;

--- a/src/backends.c
+++ b/src/backends.c
@@ -396,8 +396,8 @@ void *backends_main(void *ptr) {
     info("BACKEND configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, frequency, hostname, prefix);
 
     unsigned long long step_ut = frequency * 1000000ULL;
-    unsigned long long random_ut = time_usec() % (step_ut / 2);
-    time_t before = (time_t)((time_usec() - step_ut) / 10000000ULL);
+    unsigned long long random_ut = now_realtime_usec() % (step_ut / 2);
+    time_t before = (time_t)((now_realtime_usec() - step_ut) / 10000000ULL);
     time_t after = before;
     int failures = 0;
 
@@ -405,7 +405,7 @@ void *backends_main(void *ptr) {
         // ------------------------------------------------------------------------
         // wait for the next iteration point
 
-        unsigned long long now_ut = time_usec();
+        unsigned long long now_ut = now_realtime_usec();
         unsigned long long next_ut = now_ut - (now_ut % step_ut) + step_ut;
         before = (time_t)(next_ut / 1000000ULL);
 
@@ -414,7 +414,7 @@ void *backends_main(void *ptr) {
 
         while(now_ut < next_ut) {
             sleep_usec(next_ut - now_ut);
-            now_ut = time_usec();
+            now_ut = now_realtime_usec();
         }
 
         // ------------------------------------------------------------------------
@@ -465,7 +465,7 @@ void *backends_main(void *ptr) {
         // connect to a backend server
 
         if(unlikely(sock == -1)) {
-            unsigned long long start_ut = time_usec();
+            unsigned long long start_ut = now_realtime_usec();
             const char *s = destination;
             while(*s) {
                 const char *e = s;
@@ -486,7 +486,7 @@ void *backends_main(void *ptr) {
                 if(sock != -1) break;
                 s = e;
             }
-            chart_backend_latency += time_usec() - start_ut;
+            chart_backend_latency += now_realtime_usec() - start_ut;
         }
 
         if(unlikely(netdata_exit)) break;
@@ -496,13 +496,13 @@ void *backends_main(void *ptr) {
 
         if(likely(sock != -1)) {
             size_t len = buffer_strlen(b);
-            unsigned long long start_ut = time_usec();
+            unsigned long long start_ut = now_realtime_usec();
             int flags = 0;
 #ifdef MSG_NOSIGNAL
             flags += MSG_NOSIGNAL;
 #endif
             ssize_t written = send(sock, buffer_tostring(b), len, flags);
-            chart_backend_latency += time_usec() - start_ut;
+            chart_backend_latency += now_realtime_usec() - start_ut;
             if(written != -1 && (size_t)written == len) {
                 // we sent the data successfully
                 chart_transmission_successes++;

--- a/src/clocks.c
+++ b/src/clocks.c
@@ -1,0 +1,73 @@
+#include "common.h"
+
+#ifndef HAVE_CLOCK_GETTIME
+inline int clock_gettime(clockid_t clk_id, struct timespec *ts) {
+    struct timeval tv;
+    if(unlikely(gettimeofday(&tv, NULL) == -1))
+        return -1;
+    ts->tv_sec = tv.tv_sec;
+    ts->tv_nsec = tv.tv_usec * NSEC_PER_USEC;
+    return 0;
+}
+#endif
+
+inline time_t now_realtime_sec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_REALTIME, &ts) == -1))
+        return 0;
+    return ts.tv_sec;
+}
+
+inline int now_realtime_timeval(struct timeval *tv) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_REALTIME, &ts) == -1))
+        return -1;
+    tv->tv_sec = ts.tv_sec;
+    tv->tv_usec = ts.tv_nsec / NSEC_PER_USEC;
+    return 0;
+}
+
+inline usec_t now_realtime_usec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_REALTIME, &ts) == -1))
+        return 0;
+    return (usec_t)ts.tv_sec * USEC_PER_SEC + ts.tv_nsec / NSEC_PER_USEC;
+}
+
+inline time_t now_monotonic_sec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_MONOTONIC, &ts) == -1))
+        return 0;
+    return ts.tv_sec;
+}
+
+inline usec_t now_monotonic_usec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_MONOTONIC, &ts) == -1))
+        return 0;
+    return (usec_t)ts.tv_sec * USEC_PER_SEC + ts.tv_nsec / NSEC_PER_USEC;
+}
+
+inline time_t now_boottime_sec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_BOOTTIME, &ts) == -1))
+        return 0;
+    return ts.tv_sec;
+}
+
+inline usec_t now_boottime_usec(void) {
+    struct timespec ts;
+    if(unlikely(clock_gettime(CLOCK_BOOTTIME, &ts) == -1))
+        return 0;
+    return (usec_t)ts.tv_sec * USEC_PER_SEC + ts.tv_nsec / NSEC_PER_USEC;
+}
+
+inline usec_t timeval_usec(struct timeval *tv) {
+    return (usec_t)tv->tv_sec * USEC_PER_SEC + tv->tv_usec;
+}
+
+inline usec_t dt_usec(struct timeval *now, struct timeval *old) {
+    usec_t ts1 = timeval_usec(now);
+    usec_t ts2 = timeval_usec(old);
+    return (ts1 > ts2) ? (ts1 - ts2) : (ts2 - ts1);
+}

--- a/src/clocks.h
+++ b/src/clocks.h
@@ -1,0 +1,88 @@
+#ifndef NETDATA_CLOCKS_H
+#define NETDATA_CLOCKS_H 1
+
+#ifndef HAVE_STRUCT_TIMESPEC
+struct timespec {
+    time_t tv_sec;  /* seconds */
+    long   tv_nsec; /* nanoseconds */
+}
+#endif
+
+#ifndef HAVE_CLOCKID_T
+typedef int clockid_t
+#endif
+
+#ifndef HAVE_CLOCK_GETTIME
+int clock_gettime(clockid_t clk_id, struct timespec *ts);
+#endif
+
+/* Linux values are as good as any others */
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME  0
+#endif
+
+#ifndef CLOCK_MONOTONIC
+/* fallback to CLOCK_REALTIME if not available */
+#define CLOCK_MONOTONIC CLOCK_REALTIME
+#endif
+
+#ifndef CLOCK_BOOTTIME
+/* fallback to CLOCK_MONOTONIC if not available */
+#define CLOCK_BOOTTIME  CLOCK_MONOTONIC
+#endif
+
+typedef unsigned long long usec_t;
+
+#define NSEC_PER_SEC    1000000000ULL
+#define NSEC_PER_MSEC   1000000ULL
+#define NSEC_PER_USEC   1000ULL
+#define USEC_PER_SEC    1000000ULL
+
+#ifndef HAVE_CLOCK_GETTIME
+/* Fallback function for POSIX.1-2001 clock_gettime() function.
+ *
+ * We use a realtime clock from gettimeofday(), this will
+ * make systems without clock_gettime() support sensitive
+ * to time jumps or hibernation/suspend side effects.
+ */
+extern int clock_gettime(clockid_t clk_id, struct timespec *ts);
+#endif
+
+/* Fills struct timeval with time since EPOCH from real-time clock (i.e. wall-clock).
+ * - Hibernation/suspend time is included
+ * - adjtime()/NTP adjustments affect this clock
+ * Return 0 on succes, -1 else with errno set appropriately.
+ */
+extern int now_realtime_timeval(struct timeval *tv);
+
+/* Returns time since EPOCH from real-time clock (i.e. wall-clock).
+ * - Hibernation/suspend time is included
+ * - adjtime()/NTP adjustments affect this clock
+ */
+extern time_t now_realtime_sec(void);
+extern usec_t now_realtime_usec(void);
+
+/* Returns time from monotonic clock if available, real-time clock else.
+ * If monotonic clock is available:
+ * - hibernation/suspend time is not included
+ * - adjtime()/NTP adjusments affect this clock
+ * If monotonic clock is not available, this fallbacks to now_realtime().
+ */
+extern time_t now_monotonic_sec(void);
+extern usec_t now_monotonic_usec(void);
+
+/* Returns time from boottime clock if available,
+ * monotonic clock else if available, real-time clock else.
+ * If boottime clock is available:
+ * - hibernation/suspend time is included
+ * - adjtime()/NTP adjusments affect this clock
+ * If boottime clock is not available, this fallbacks to now_monotonic().
+ * If monotonic clock is not available, this fallbacks to now_realtime().
+ */
+extern time_t now_boottime_sec(void);
+extern usec_t now_boottime_usec(void);
+
+extern usec_t timeval_usec(struct timeval *ts);
+extern usec_t dt_usec(struct timeval *now, struct timeval *old);
+
+#endif /* NETDATA_CLOCKS_H */

--- a/src/common.c
+++ b/src/common.c
@@ -197,16 +197,6 @@ void freez(void *ptr) {
     free(ptr);
 }
 
-// ----------------------------------------------------------------------------
-// time functions
-
-// time(NULL) in nanoseconds
-inline unsigned long long time_usec(void) {
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    return timeval_usec(&now);
-}
-
 int sleep_usec(unsigned long long usec) {
 
 #ifndef NETDATA_WITH_USLEEP

--- a/src/common.c
+++ b/src/common.c
@@ -207,12 +207,6 @@ inline unsigned long long time_usec(void) {
     return timeval_usec(&now);
 }
 
-inline unsigned long long usec_dt(struct timeval *now, struct timeval *old) {
-    unsigned long long tv1 = timeval_usec(now);
-    unsigned long long tv2 = timeval_usec(old);
-    return (tv1 > tv2) ? (tv1 - tv2) : (tv2 - tv1);
-}
-
 int sleep_usec(unsigned long long usec) {
 
 #ifndef NETDATA_WITH_USLEEP

--- a/src/common.c
+++ b/src/common.c
@@ -200,10 +200,6 @@ void freez(void *ptr) {
 // ----------------------------------------------------------------------------
 // time functions
 
-inline unsigned long long timeval_usec(struct timeval *tv) {
-    return tv->tv_sec * 1000000ULL + tv->tv_usec;
-}
-
 // time(NULL) in nanoseconds
 inline unsigned long long time_usec(void) {
     struct timeval now;

--- a/src/common.c
+++ b/src/common.c
@@ -197,7 +197,7 @@ void freez(void *ptr) {
     free(ptr);
 }
 
-int sleep_usec(unsigned long long usec) {
+int sleep_usec(usec_t usec) {
 
 #ifndef NETDATA_WITH_USLEEP
     // we expect microseconds (1.000.000 per second)

--- a/src/common.h
+++ b/src/common.h
@@ -100,6 +100,7 @@
 #endif // __GNUC__
 
 #include "avl.h"
+#include "clocks.h"
 #include "log.h"
 #include "global_statistics.h"
 #include "storage_number.h"
@@ -123,7 +124,6 @@
 #include "plugin_tc.h"
 #include "plugins_d.h"
 
-#include "clocks.h"
 #include "eval.h"
 #include "health.h"
 
@@ -191,7 +191,7 @@ extern int enable_ksm;
 
 extern pid_t gettid(void);
 
-extern int sleep_usec(unsigned long long usec);
+extern int sleep_usec(usec_t usec);
 
 extern char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
 

--- a/src/common.h
+++ b/src/common.h
@@ -191,7 +191,6 @@ extern int enable_ksm;
 
 extern pid_t gettid(void);
 
-extern unsigned long long time_usec(void);
 extern int sleep_usec(unsigned long long usec);
 
 extern char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);

--- a/src/common.h
+++ b/src/common.h
@@ -146,10 +146,6 @@
 #endif
 #define abs(x) ((x < 0)? -x : x)
 
-extern unsigned long long usec_dt(struct timeval *now, struct timeval *old);
-
-// #define usec_dt(now, last) (((((now)->tv_sec * 1000000ULL) + (now)->tv_usec) - (((last)->tv_sec * 1000000ULL) + (last)->tv_usec)))
-
 extern void netdata_fix_chart_id(char *s);
 extern void netdata_fix_chart_name(char *s);
 

--- a/src/common.h
+++ b/src/common.h
@@ -123,6 +123,7 @@
 #include "plugin_tc.h"
 #include "plugins_d.h"
 
+#include "clocks.h"
 #include "eval.h"
 #include "health.h"
 
@@ -146,7 +147,6 @@
 #define abs(x) ((x < 0)? -x : x)
 
 extern unsigned long long usec_dt(struct timeval *now, struct timeval *old);
-extern unsigned long long timeval_usec(struct timeval *tv);
 
 // #define usec_dt(now, last) (((((now)->tv_sec * 1000000ULL) + (now)->tv_usec) - (((last)->tv_sec * 1000000ULL) + (last)->tv_usec)))
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -102,7 +102,7 @@ static inline calculated_number eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABL
     }
 
     if(unlikely(v->hash == now_hash && !strcmp(v->name, "now"))) {
-        n = time(NULL);
+        n = now_realtime_sec();
         buffer_strcat(exp->error_msg, "[ $now = ");
         print_parsed_as_constant(exp->error_msg, n);
         buffer_strcat(exp->error_msg, " ] ");

--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -12,7 +12,7 @@
 // FreeBSD calculates load averages once every 5 seconds
 #define MIN_LOADAVG_UPDATE_EVERY 5
 
-int do_freebsd_sysctl(int update_every, unsigned long long dt) {
+int do_freebsd_sysctl(int update_every, usec_t dt) {
     (void)dt;
 
     static int do_cpu = -1, do_cpu_cores = -1, do_interrupts = -1, do_context = -1, do_forks = -1, do_processes = -1,
@@ -42,7 +42,7 @@ int do_freebsd_sysctl(int update_every, unsigned long long dt) {
     int i;
 
 // NEEDED BY: do_loadavg
-    static unsigned long long last_loadavg_usec = 0;
+    static usec_t last_loadavg_usec = 0;
     struct loadavg sysload;
 
 // NEEDED BY: do_cpu, do_cpu_cores
@@ -125,7 +125,7 @@ int do_freebsd_sysctl(int update_every, unsigned long long dt) {
             }
         }
 
-        last_loadavg_usec = st->update_every * 1000000ULL;
+        last_loadavg_usec = st->update_every * USEC_PER_SEC;
     }
     else last_loadavg_usec -= dt;
 

--- a/src/health.c
+++ b/src/health.c
@@ -3101,7 +3101,7 @@ void *health_main(void *ptr) {
         if(now < next_run) {
             debug(D_HEALTH, "Health monitoring iteration no %u done. Next iteration in %d secs",
                   loop, (int) (next_run - now));
-            sleep_usec(1000000 * (unsigned long long) (next_run - now));
+            sleep_usec(USEC_PER_SEC * (usec_t) (next_run - now));
         }
         else {
             debug(D_HEALTH, "Health monitoring iteration no %u done. Next iteration now", loop);

--- a/src/health.c
+++ b/src/health.c
@@ -314,8 +314,8 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
 
     freez(buf);
 
-    if(!max_unique_id) max_unique_id = (uint32_t)time(NULL);
-    if(!max_alarm_id)  max_alarm_id  = (uint32_t)time(NULL);
+    if(!max_unique_id) max_unique_id = (uint32_t)now_realtime_sec();
+    if(!max_alarm_id)  max_alarm_id  = (uint32_t)now_realtime_sec();
 
     host->health_log.next_log_id = max_unique_id + 1;
     host->health_log.next_alarm_id = max_alarm_id + 1;
@@ -1053,7 +1053,7 @@ static inline const char *rrdcalc_status2string(int status) {
 static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
     debug(D_HEALTH, "Health linking alarm '%s.%s' to chart '%s' of host '%s'", rc->chart?rc->chart:"NOCHART", rc->name, st->id, st->rrdhost->hostname);
 
-    rc->last_status_change = time(NULL);
+    rc->last_status_change = now_realtime_sec();
     rc->rrdset = st;
 
     rc->rrdset_next = st->alarms;
@@ -1092,7 +1092,7 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
 	if(!rc->units) rc->units = strdupz(st->units);
 
     {
-        time_t now = time(NULL);
+        time_t now = now_realtime_sec();
         health_alarm_log(st->rrdhost, rc->id, rc->next_event_id++, now, rc->name, rc->rrdset->id, rc->rrdset->family, rc->exec, rc->recipient, now - rc->last_status_change, rc->old_value, rc->value, rc->status, RRDCALC_STATUS_UNINITIALIZED, rc->source, rc->units, rc->info, 0);
     }
 }
@@ -1130,7 +1130,7 @@ inline void rrdsetcalc_unlink(RRDCALC *rc) {
     }
 
     {
-        time_t now = time(NULL);
+        time_t now = now_realtime_sec();
         health_alarm_log(st->rrdhost, rc->id, rc->next_event_id++, now, rc->name, rc->rrdset->id, rc->rrdset->family, rc->exec, rc->recipient, now - rc->last_status_change, rc->old_value, rc->value, rc->status, RRDCALC_STATUS_REMOVED, rc->source, rc->units, rc->info, 0);
     }
 
@@ -2492,7 +2492,7 @@ void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {
                         host->hostname,
                         (host->health_log.next_log_id > 0)?(host->health_log.next_log_id - 1):0,
                         health_enabled?"true":"false",
-                        (unsigned long)time(NULL));
+                        (unsigned long)now_realtime_sec());
 
     RRDCALC *rc;
     for(i = 0, rc = host->alarms; rc ; rc = rc->next) {
@@ -2652,7 +2652,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     );
 
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_RUN;
-    ae->exec_run_timestamp = time(NULL);
+    ae->exec_run_timestamp = now_realtime_sec();
 
     debug(D_HEALTH, "executing command '%s'", command_to_run);
     FILE *fp = mypopen(command_to_run, &command_pid);
@@ -2688,7 +2688,7 @@ static inline void health_process_notifications(RRDHOST *host, ALARM_ENTRY *ae) 
 static inline void health_alarm_log_process(RRDHOST *host) {
     static uint32_t stop_at_id = 0;
     uint32_t first_waiting = (host->health_log.alarms)?host->health_log.alarms->unique_id:0;
-    time_t now = time(NULL);
+    time_t now = now_realtime_sec();
 
     pthread_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
 
@@ -2825,7 +2825,7 @@ void *health_main(void *ptr) {
         debug(D_HEALTH, "Health monitoring iteration no %u started", loop);
 
         int oldstate, runnable = 0;
-        time_t now = time(NULL);
+        time_t now = now_realtime_sec();
         time_t next_run = now + min_run_every;
         RRDCALC *rc;
 
@@ -3097,7 +3097,7 @@ void *health_main(void *ptr) {
         if(unlikely(netdata_exit))
             break;
         
-        now = time(NULL);
+        now = now_realtime_sec();
         if(now < next_run) {
             debug(D_HEALTH, "Health monitoring iteration no %u done. Next iteration in %d secs",
                   loop, (int) (next_run - now));

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -160,7 +160,7 @@ static inline int ipc_sem_get_status(struct ipc_status *st) {
     return 0;
 }
 
-int do_ipc(int update_every, unsigned long long dt) {
+int do_ipc(int update_every, usec_t dt) {
     (void)dt;
 
     static int initialized = 0, read_limits_next = 0;

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -1,7 +1,7 @@
 #ifndef NETDATA_PLUGIN_IPC_H
 #define NETDATA_PLUGIN_IPC_H 1
 
-extern int do_ipc(int update_every, unsigned long long dt);
+extern int do_ipc(int update_every, usec_t dt);
 
 #endif /* NETDATA_PLUGIN_IPC_H */
 

--- a/src/log.c
+++ b/src/log.c
@@ -131,7 +131,7 @@ int error_log_limit(int reset) {
         return 1;
 #endif
 
-    time_t now = time(NULL);
+    time_t now = now_realtime_sec();
     if(!start) start = now;
 
     if(reset) {
@@ -212,7 +212,7 @@ void log_date(FILE *out)
         time_t t;
         struct tm *tmp, tmbuf;
 
-        t = time(NULL);
+        t = now_realtime_sec();
         tmp = localtime_r(&t, &tmbuf);
 
         if (tmp == NULL) return;

--- a/src/log.c
+++ b/src/log.c
@@ -131,7 +131,7 @@ int error_log_limit(int reset) {
         return 1;
 #endif
 
-    time_t now = now_realtime_sec();
+    time_t now = now_monotonic_sec();
     if(!start) start = now;
 
     if(reset) {

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -12,7 +12,7 @@ void *checks_main(void *ptr)
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
         error("Cannot set pthread cancel state to ENABLE.");
 
-    unsigned long long usec = 0, susec = rrd_update_every * 1000000ULL, loop_usec = 0, total_susec = 0;
+    usec_t usec = 0, susec = rrd_update_every * USEC_PER_SEC, loop_usec = 0, total_susec = 0;
     struct timeval now, last, loop;
 
     RRDSET *check1, *check2, *check3, *apps_cpu = NULL;
@@ -40,8 +40,8 @@ void *checks_main(void *ptr)
         usec = loop_usec - susec;
         debug(D_PROCNETDEV_LOOP, "CHECK: last loop took %llu usec (worked for %llu, sleeped for %llu).", loop_usec, usec, susec);
 
-        if(usec < (rrd_update_every * 1000000ULL / 2ULL)) susec = (rrd_update_every * 1000000ULL) - usec;
-        else susec = rrd_update_every * 1000000ULL / 2ULL;
+        if(usec < (rrd_update_every * USEC_PER_SEC / 2ULL)) susec = (rrd_update_every * USEC_PER_SEC) - usec;
+        else susec = rrd_update_every * USEC_PER_SEC / 2ULL;
 
         // --------------------------------------------------------------------
         // Calculate loop time

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -36,7 +36,7 @@ void *checks_main(void *ptr)
 
         // find the time to sleep in order to wait exactly update_every seconds
         gettimeofday(&now, NULL);
-        loop_usec = usec_dt(&now, &last);
+        loop_usec = dt_usec(&now, &last);
         usec = loop_usec - susec;
         debug(D_PROCNETDEV_LOOP, "CHECK: last loop took %llu usec (worked for %llu, sleeped for %llu).", loop_usec, usec, susec);
 
@@ -72,9 +72,9 @@ void *checks_main(void *ptr)
         if(!apps_cpu) apps_cpu = rrdset_find("apps.cpu");
         if(check3->counter_done) rrdset_next_usec(check3, loop_usec);
         gettimeofday(&loop, NULL);
-        rrddim_set(check3, "caller", (long long) usec_dt(&loop, &check1->last_collected_time));
-        rrddim_set(check3, "netdata", (long long) usec_dt(&loop, &check2->last_collected_time));
-        if(apps_cpu) rrddim_set(check3, "apps.plugin", (long long) usec_dt(&loop, &apps_cpu->last_collected_time));
+        rrddim_set(check3, "caller", (long long) dt_usec(&loop, &check1->last_collected_time));
+        rrddim_set(check3, "netdata", (long long) dt_usec(&loop, &check2->last_collected_time));
+        if(apps_cpu) rrddim_set(check3, "apps.plugin", (long long) dt_usec(&loop, &apps_cpu->last_collected_time));
         rrdset_done(check3);
     }
 

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -30,12 +30,12 @@ void *checks_main(void *ptr)
     rrddim_add(check3, "netdata", NULL, 1, 1, RRDDIM_ABSOLUTE);
     rrddim_add(check3, "apps.plugin", NULL, 1, 1, RRDDIM_ABSOLUTE);
 
-    gettimeofday(&last, NULL);
+    now_realtime_timeval(&last);
     while(1) {
         usleep(susec);
 
         // find the time to sleep in order to wait exactly update_every seconds
-        gettimeofday(&now, NULL);
+        now_realtime_timeval(&now);
         loop_usec = dt_usec(&now, &last);
         usec = loop_usec - susec;
         debug(D_PROCNETDEV_LOOP, "CHECK: last loop took %llu usec (worked for %llu, sleeped for %llu).", loop_usec, usec, susec);
@@ -71,7 +71,7 @@ void *checks_main(void *ptr)
 
         if(!apps_cpu) apps_cpu = rrdset_find("apps.cpu");
         if(check3->counter_done) rrdset_next_usec(check3, loop_usec);
-        gettimeofday(&loop, NULL);
+        now_realtime_timeval(&loop);
         rrddim_set(check3, "caller", (long long) dt_usec(&loop, &check1->last_collected_time));
         rrddim_set(check3, "netdata", (long long) dt_usec(&loop, &check2->last_collected_time));
         if(apps_cpu) rrddim_set(check3, "apps.plugin", (long long) dt_usec(&loop, &apps_cpu->last_collected_time));

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -27,12 +27,12 @@ void *freebsd_main(void *ptr)
 
     unsigned long long step = rrd_update_every * 1000000ULL;
     for(;;) {
-        unsigned long long now = time_usec();
+        unsigned long long now = now_realtime_usec();
         unsigned long long next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);
-            now = time_usec();
+            now = now_realtime_usec();
         }
 
         if(unlikely(netdata_exit)) break;
@@ -41,7 +41,7 @@ void *freebsd_main(void *ptr)
 
         if(!vdo_freebsd_sysctl) {
             debug(D_PROCNETDEV_LOOP, "FREEBSD: calling do_freebsd_sysctl().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_freebsd_sysctl = do_freebsd_sysctl(rrd_update_every, (sutime_freebsd_sysctl > 0)?now - sutime_freebsd_sysctl:0ULL);
             sutime_freebsd_sysctl = now;
         }

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -25,10 +25,10 @@ void *freebsd_main(void *ptr)
     // keep track of the time each module was called
     unsigned long long sutime_freebsd_sysctl = 0ULL;
 
-    unsigned long long step = rrd_update_every * 1000000ULL;
+    usec_t step = rrd_update_every * USEC_PER_SEC;
     for(;;) {
-        unsigned long long now = now_realtime_usec();
-        unsigned long long next = now - (now % step) + step;
+        usec_t now = now_realtime_usec();
+        usec_t next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);

--- a/src/plugin_freebsd.h
+++ b/src/plugin_freebsd.h
@@ -7,6 +7,6 @@ void *freebsd_main(void *ptr);
 
 int getsysctl(const char *name, void *ptr, size_t len);
 
-extern int do_freebsd_sysctl(int update_every, unsigned long long dt);
+extern int do_freebsd_sysctl(int update_every, usec_t dt);
 
 #endif /* NETDATA_PLUGIN_FREEBSD_H */

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -38,7 +38,7 @@ void *cpuidlejitter_main(void *ptr)
             gettimeofday(&after, NULL);
 
             // calculate the time it took for a full loop
-            usec = usec_dt(&after, &before);
+            usec = dt_usec(&after, &before);
             susec += usec;
         }
         usec -= (sleep_ms * 1000);

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -33,9 +33,9 @@ void *cpuidlejitter_main(void *ptr)
 
         while(susec < (rrd_update_every * 1000000ULL)) {
 
-            gettimeofday(&before, NULL);
+            now_realtime_timeval(&before);
             sleep_usec(sleep_ms * 1000);
-            gettimeofday(&after, NULL);
+            now_realtime_timeval(&after);
 
             // calculate the time it took for a full loop
             usec = dt_usec(&after, &before);

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -29,9 +29,9 @@ void *cpuidlejitter_main(void *ptr)
     struct timeval before, after;
     unsigned long long counter;
     for(counter = 0; 1 ;counter++) {
-        unsigned long long usec = 0, susec = 0;
+        usec_t usec = 0, susec = 0;
 
-        while(susec < (rrd_update_every * 1000000ULL)) {
+        while(susec < (rrd_update_every * USEC_PER_SEC)) {
 
             now_realtime_timeval(&before);
             sleep_usec(sleep_ms * 1000);

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -132,7 +132,7 @@ void *nfacct_main(void *ptr) {
         // --------------------------------------------------------------------
 
         gettimeofday(&now, NULL);
-        usec = usec_dt(&now, &last) - susec;
+        usec = dt_usec(&now, &last) - susec;
         debug(D_NFACCT_LOOP, "nfacct.plugin: last loop took %llu usec (worked for %llu, sleeped for %llu).", usec + susec, usec, susec);
 
         if(usec < (rrd_update_every * 1000000ULL / 2ULL)) susec = (rrd_update_every * 1000000ULL) - usec;

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -93,7 +93,7 @@ void *nfacct_main(void *ptr) {
     unsigned long long usec = 0, susec = 0;
     RRDSET *st = NULL;
 
-    gettimeofday(&last, NULL);
+    now_realtime_timeval(&last);
 
     // ------------------------------------------------------------------------
 
@@ -131,7 +131,7 @@ void *nfacct_main(void *ptr) {
 
         // --------------------------------------------------------------------
 
-        gettimeofday(&now, NULL);
+        now_realtime_timeval(&now);
         usec = dt_usec(&now, &last) - susec;
         debug(D_NFACCT_LOOP, "nfacct.plugin: last loop took %llu usec (worked for %llu, sleeped for %llu).", usec + susec, usec, susec);
 

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -90,7 +90,7 @@ void *nfacct_main(void *ptr) {
     // ------------------------------------------------------------------------
 
     struct timeval last, now;
-    unsigned long long usec = 0, susec = 0;
+    usec_t usec = 0, susec = 0;
     RRDSET *st = NULL;
 
     now_realtime_timeval(&last);

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -70,7 +70,7 @@ void *nfacct_main(void *ptr) {
     struct nlmsghdr *nlh = NULL;
     unsigned int seq = 0, portid = 0;
 
-    seq = time(NULL) - 1;
+    seq = now_realtime_sec() - 1;
 
     nl  = mnl_socket_open(NETLINK_NETFILTER);
     if(!nl) {

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -63,12 +63,12 @@ void *proc_main(void *ptr)
 
     unsigned long long step = rrd_update_every * 1000000ULL;
     for(;;) {
-        unsigned long long now = time_usec();
+        unsigned long long now = now_realtime_usec();
         unsigned long long next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);
-            now = time_usec();
+            now = now_realtime_usec();
         }
 
         if(unlikely(netdata_exit)) break;
@@ -78,7 +78,7 @@ void *proc_main(void *ptr)
         if(!vdo_sys_kernel_mm_ksm) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_sys_kernel_mm_ksm().");
 
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_sys_kernel_mm_ksm = do_sys_kernel_mm_ksm(rrd_update_every, (sutime_sys_kernel_mm_ksm > 0)?now - sutime_sys_kernel_mm_ksm:0ULL);
             sutime_sys_kernel_mm_ksm = now;
         }
@@ -86,7 +86,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_loadavg) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_loadavg().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_loadavg = do_proc_loadavg(rrd_update_every, (sutime_proc_loadavg > 0)?now - sutime_proc_loadavg:0ULL);
             sutime_proc_loadavg = now;
         }
@@ -94,7 +94,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_ipc) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_ipc().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_ipc = do_ipc(rrd_update_every, (sutime_ipc > 0)?now - sutime_ipc:0ULL);
             sutime_ipc = now;
         }
@@ -102,7 +102,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_interrupts) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_interrupts().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_interrupts = do_proc_interrupts(rrd_update_every, (sutime_proc_interrupts > 0)?now - sutime_proc_interrupts:0ULL);
             sutime_proc_interrupts = now;
         }
@@ -110,7 +110,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_softirqs) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_softirqs().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_softirqs = do_proc_softirqs(rrd_update_every, (sutime_proc_softirqs > 0)?now - sutime_proc_softirqs:0ULL);
             sutime_proc_softirqs = now;
         }
@@ -118,7 +118,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_softnet_stat) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_softnet_stat().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_softnet_stat = do_proc_net_softnet_stat(rrd_update_every, (sutime_proc_net_softnet_stat > 0)?now - sutime_proc_net_softnet_stat:0ULL);
             sutime_proc_net_softnet_stat = now;
         }
@@ -126,7 +126,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_sys_kernel_random_entropy_avail) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_sys_kernel_random_entropy_avail().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_sys_kernel_random_entropy_avail = do_proc_sys_kernel_random_entropy_avail(rrd_update_every, (sutime_proc_sys_kernel_random_entropy_avail > 0)?now - sutime_proc_sys_kernel_random_entropy_avail:0ULL);
             sutime_proc_sys_kernel_random_entropy_avail = now;
         }
@@ -134,7 +134,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_dev) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_dev().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_dev = do_proc_net_dev(rrd_update_every, (sutime_proc_net_dev > 0)?now - sutime_proc_net_dev:0ULL);
             sutime_proc_net_dev = now;
         }
@@ -142,7 +142,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_diskstats) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_diskstats().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_diskstats = do_proc_diskstats(rrd_update_every, (sutime_proc_diskstats > 0)?now - sutime_proc_diskstats:0ULL);
             sutime_proc_diskstats = now;
         }
@@ -150,7 +150,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_snmp) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_snmp().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_snmp = do_proc_net_snmp(rrd_update_every, (sutime_proc_net_snmp > 0)?now - sutime_proc_net_snmp:0ULL);
             sutime_proc_net_snmp = now;
         }
@@ -158,7 +158,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_snmp6) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_snmp6().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_snmp6 = do_proc_net_snmp6(rrd_update_every, (sutime_proc_net_snmp6 > 0)?now - sutime_proc_net_snmp6:0ULL);
             sutime_proc_net_snmp6 = now;
         }
@@ -166,7 +166,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_netstat) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_netstat().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_netstat = do_proc_net_netstat(rrd_update_every, (sutime_proc_net_netstat > 0)?now - sutime_proc_net_netstat:0ULL);
             sutime_proc_net_netstat = now;
         }
@@ -174,7 +174,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_stat_conntrack) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_stat_conntrack().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_stat_conntrack = do_proc_net_stat_conntrack(rrd_update_every, (sutime_proc_net_stat_conntrack > 0)?now - sutime_proc_net_stat_conntrack:0ULL);
             sutime_proc_net_stat_conntrack = now;
         }
@@ -182,7 +182,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_ip_vs_stats) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling vdo_proc_net_ip_vs_stats().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_ip_vs_stats = do_proc_net_ip_vs_stats(rrd_update_every, (sutime_proc_net_ip_vs_stats > 0)?now - sutime_proc_net_ip_vs_stats:0ULL);
             sutime_proc_net_ip_vs_stats = now;
         }
@@ -190,7 +190,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_stat_synproxy) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling vdo_proc_net_stat_synproxy().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_stat_synproxy = do_proc_net_stat_synproxy(rrd_update_every, (sutime_proc_net_stat_synproxy > 0)?now - sutime_proc_net_stat_synproxy:0ULL);
             sutime_proc_net_stat_synproxy = now;
         }
@@ -198,7 +198,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_stat) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_stat().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_stat = do_proc_stat(rrd_update_every, (sutime_proc_stat > 0)?now - sutime_proc_stat:0ULL);
             sutime_proc_stat = now;
         }
@@ -206,7 +206,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_meminfo) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling vdo_proc_meminfo().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_meminfo = do_proc_meminfo(rrd_update_every, (sutime_proc_meminfo > 0)?now - sutime_proc_meminfo:0ULL);
             sutime_proc_meminfo = now;
         }
@@ -214,7 +214,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_vmstat) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling vdo_proc_vmstat().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_vmstat = do_proc_vmstat(rrd_update_every, (sutime_proc_vmstat > 0)?now - sutime_proc_vmstat:0ULL);
             sutime_proc_vmstat = now;
         }
@@ -222,7 +222,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_rpc_nfsd) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_rpc_nfsd().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_rpc_nfsd = do_proc_net_rpc_nfsd(rrd_update_every, (sutime_proc_net_rpc_nfsd > 0)?now - sutime_proc_net_rpc_nfsd:0ULL);
             sutime_proc_net_rpc_nfsd = now;
         }
@@ -230,7 +230,7 @@ void *proc_main(void *ptr)
 
         if(!vdo_proc_net_rpc_nfs) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_proc_net_rpc_nfs().");
-            now = time_usec();
+            now = now_realtime_usec();
             vdo_proc_net_rpc_nfs = do_proc_net_rpc_nfs(rrd_update_every, (sutime_proc_net_rpc_nfs > 0)?now - sutime_proc_net_rpc_nfs:0ULL);
             sutime_proc_net_rpc_nfs = now;
         }

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -40,31 +40,31 @@ void *proc_main(void *ptr)
     int vdo_cpu_netdata             = !config_get_boolean("plugin:proc", "netdata server resources", 1);
 
     // keep track of the time each module was called
-    unsigned long long sutime_proc_net_dev = 0ULL;
-    unsigned long long sutime_proc_diskstats = 0ULL;
-    unsigned long long sutime_proc_net_snmp = 0ULL;
-    unsigned long long sutime_proc_net_snmp6 = 0ULL;
-    unsigned long long sutime_proc_net_netstat = 0ULL;
-    unsigned long long sutime_proc_net_stat_conntrack = 0ULL;
-    unsigned long long sutime_proc_net_ip_vs_stats = 0ULL;
-    unsigned long long sutime_proc_net_stat_synproxy = 0ULL;
-    unsigned long long sutime_proc_stat = 0ULL;
-    unsigned long long sutime_proc_meminfo = 0ULL;
-    unsigned long long sutime_proc_vmstat = 0ULL;
-    unsigned long long sutime_proc_net_rpc_nfs = 0ULL;
-    unsigned long long sutime_proc_net_rpc_nfsd = 0ULL;
-    unsigned long long sutime_proc_sys_kernel_random_entropy_avail = 0ULL;
-    unsigned long long sutime_proc_interrupts = 0ULL;
-    unsigned long long sutime_proc_softirqs = 0ULL;
-    unsigned long long sutime_proc_net_softnet_stat = 0ULL;
-    unsigned long long sutime_proc_loadavg = 0ULL;
-    unsigned long long sutime_ipc = 0ULL;
-    unsigned long long sutime_sys_kernel_mm_ksm = 0ULL;
+    usec_t sutime_proc_net_dev = 0ULL;
+    usec_t sutime_proc_diskstats = 0ULL;
+    usec_t sutime_proc_net_snmp = 0ULL;
+    usec_t sutime_proc_net_snmp6 = 0ULL;
+    usec_t sutime_proc_net_netstat = 0ULL;
+    usec_t sutime_proc_net_stat_conntrack = 0ULL;
+    usec_t sutime_proc_net_ip_vs_stats = 0ULL;
+    usec_t sutime_proc_net_stat_synproxy = 0ULL;
+    usec_t sutime_proc_stat = 0ULL;
+    usec_t sutime_proc_meminfo = 0ULL;
+    usec_t sutime_proc_vmstat = 0ULL;
+    usec_t sutime_proc_net_rpc_nfs = 0ULL;
+    usec_t sutime_proc_net_rpc_nfsd = 0ULL;
+    usec_t sutime_proc_sys_kernel_random_entropy_avail = 0ULL;
+    usec_t sutime_proc_interrupts = 0ULL;
+    usec_t sutime_proc_softirqs = 0ULL;
+    usec_t sutime_proc_net_softnet_stat = 0ULL;
+    usec_t sutime_proc_loadavg = 0ULL;
+    usec_t sutime_ipc = 0ULL;
+    usec_t sutime_sys_kernel_mm_ksm = 0ULL;
 
-    unsigned long long step = rrd_update_every * 1000000ULL;
+    usec_t step = rrd_update_every * USEC_PER_SEC;
     for(;;) {
-        unsigned long long now = now_realtime_usec();
-        unsigned long long next = now - (now % step) + step;
+        usec_t now = now_realtime_usec();
+        usec_t next = now - (now % step) + step;
 
         while(now < next) {
             sleep_usec(next - now);

--- a/src/plugin_proc.h
+++ b/src/plugin_proc.h
@@ -3,24 +3,24 @@
 
 void *proc_main(void *ptr);
 
-extern int do_proc_net_dev(int update_every, unsigned long long dt);
-extern int do_proc_diskstats(int update_every, unsigned long long dt);
-extern int do_proc_net_snmp(int update_every, unsigned long long dt);
-extern int do_proc_net_snmp6(int update_every, unsigned long long dt);
-extern int do_proc_net_netstat(int update_every, unsigned long long dt);
-extern int do_proc_net_stat_conntrack(int update_every, unsigned long long dt);
-extern int do_proc_net_ip_vs_stats(int update_every, unsigned long long dt);
-extern int do_proc_stat(int update_every, unsigned long long dt);
-extern int do_proc_meminfo(int update_every, unsigned long long dt);
-extern int do_proc_vmstat(int update_every, unsigned long long dt);
-extern int do_proc_net_rpc_nfs(int update_every, unsigned long long dt);
-extern int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt);
-extern int do_proc_sys_kernel_random_entropy_avail(int update_every, unsigned long long dt);
-extern int do_proc_interrupts(int update_every, unsigned long long dt);
-extern int do_proc_softirqs(int update_every, unsigned long long dt);
-extern int do_sys_kernel_mm_ksm(int update_every, unsigned long long dt);
-extern int do_proc_loadavg(int update_every, unsigned long long dt);
-extern int do_proc_net_stat_synproxy(int update_every, unsigned long long dt);
-extern int do_proc_net_softnet_stat(int update_every, unsigned long long dt);
+extern int do_proc_net_dev(int update_every, usec_t dt);
+extern int do_proc_diskstats(int update_every, usec_t dt);
+extern int do_proc_net_snmp(int update_every, usec_t dt);
+extern int do_proc_net_snmp6(int update_every, usec_t dt);
+extern int do_proc_net_netstat(int update_every, usec_t dt);
+extern int do_proc_net_stat_conntrack(int update_every, usec_t dt);
+extern int do_proc_net_ip_vs_stats(int update_every, usec_t dt);
+extern int do_proc_stat(int update_every, usec_t dt);
+extern int do_proc_meminfo(int update_every, usec_t dt);
+extern int do_proc_vmstat(int update_every, usec_t dt);
+extern int do_proc_net_rpc_nfs(int update_every, usec_t dt);
+extern int do_proc_net_rpc_nfsd(int update_every, usec_t dt);
+extern int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt);
+extern int do_proc_interrupts(int update_every, usec_t dt);
+extern int do_proc_softirqs(int update_every, usec_t dt);
+extern int do_sys_kernel_mm_ksm(int update_every, usec_t dt);
+extern int do_proc_loadavg(int update_every, usec_t dt);
+extern int do_proc_net_stat_synproxy(int update_every, usec_t dt);
+extern int do_proc_net_softnet_stat(int update_every, usec_t dt);
 
 #endif /* NETDATA_PLUGIN_PROC_H */

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -509,7 +509,7 @@ void *pluginsd_main(void *ptr) {
 
                 cd->enabled = enabled;
                 cd->update_every = (int) config_get_number(cd->id, "update every", rrd_update_every);
-                cd->started_t = time(NULL);
+                cd->started_t = now_realtime_sec();
 
                 char *def = "";
                 snprintfz(cd->cmd, PLUGINSD_CMD_MAX, "exec %s %d %s", cd->fullfilename, cd->update_every, config_get(cd->id, "command options", def));

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -341,7 +341,7 @@ void *pluginsd_worker_thread(void *arg)
             else if(likely(hash == STOPPING_WAKE_ME_UP_PLEASE_HASH && !strcmp(s, "STOPPING_WAKE_ME_UP_PLEASE"))) {
                 error("PLUGINSD: '%s' (pid %d) called STOPPING_WAKE_ME_UP_PLEASE.", cd->fullfilename, cd->pid);
 
-                gettimeofday(&now, NULL);
+                now_realtime_timeval(&now);
                 if(unlikely(!usec && !susec)) {
                     // our first run
                     susec = cd->rrd_update_every * 1000000ULL;

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -348,7 +348,7 @@ void *pluginsd_worker_thread(void *arg)
                 }
                 else {
                     // second+ run
-                    usec = usec_dt(&now, &last) - susec;
+                    usec = dt_usec(&now, &last) - susec;
                     error("PLUGINSD: %s last loop took %llu usec (worked for %llu, sleeped for %llu).\n", cd->fullfilename, usec + susec, usec, susec);
                     if(unlikely(usec < (rrd_update_every * 1000000ULL / 2ULL))) susec = (rrd_update_every * 1000000ULL) - usec;
                     else susec = rrd_update_every * 1000000ULL / 2ULL;

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -90,7 +90,7 @@ void *pluginsd_worker_thread(void *arg)
     char line[PLUGINSD_LINE_MAX + 1];
 
 #ifdef DETACH_PLUGINS_FROM_NETDATA
-    unsigned long long usec = 0, susec = 0;
+    usec_t usec = 0, susec = 0;
     struct timeval last = {0, 0} , now = {0, 0};
 #endif
 
@@ -185,7 +185,7 @@ void *pluginsd_worker_thread(void *arg)
                 }
 
                 if(likely(st->counter_done)) {
-                    unsigned long long microseconds = 0;
+                    usec_t microseconds = 0;
                     if(microseconds_txt && *microseconds_txt) microseconds = strtoull(microseconds_txt, NULL, 10);
                     if(microseconds) rrdset_next_usec(st, microseconds);
                     else rrdset_next(st);
@@ -344,14 +344,14 @@ void *pluginsd_worker_thread(void *arg)
                 now_realtime_timeval(&now);
                 if(unlikely(!usec && !susec)) {
                     // our first run
-                    susec = cd->rrd_update_every * 1000000ULL;
+                    susec = cd->rrd_update_every * USEC_PER_SEC;
                 }
                 else {
                     // second+ run
                     usec = dt_usec(&now, &last) - susec;
                     error("PLUGINSD: %s last loop took %llu usec (worked for %llu, sleeped for %llu).\n", cd->fullfilename, usec + susec, usec, susec);
-                    if(unlikely(usec < (rrd_update_every * 1000000ULL / 2ULL))) susec = (rrd_update_every * 1000000ULL) - usec;
-                    else susec = rrd_update_every * 1000000ULL / 2ULL;
+                    if(unlikely(usec < (rrd_update_every * USEC_PER_SEC / 2ULL))) susec = (rrd_update_every * USEC_PER_SEC) - usec;
+                    else susec = rrd_update_every * USEC_PER_SEC / 2ULL;
                 }
 
                 error("PLUGINSD: %s sleeping for %llu. Will kill with SIGCONT pid %d to wake it up.\n", cd->fullfilename, susec, cd->pid);

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -129,7 +129,7 @@ struct mount_point_metadata {
     int do_inodes;
 };
 
-static inline void do_disk_space_stats(struct mountinfo *mi, int update_every, unsigned long long dt) {
+static inline void do_disk_space_stats(struct mountinfo *mi, int update_every, usec_t dt) {
     (void)dt;
 
     const char *family = mi->mount_point;
@@ -411,7 +411,7 @@ static inline int select_positive_option(int option1, int option2) {
     return CONFIG_ONDEMAND_NO;
 }
 
-int do_proc_diskstats(int update_every, unsigned long long dt) {
+int do_proc_diskstats(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -39,7 +39,7 @@ static struct mountinfo *disk_mountinfo_root = NULL;
 
 static inline void mountinfo_reload(int force) {
     static time_t last_loaded = 0;
-    time_t now = time(NULL);
+    time_t now = now_realtime_sec();
 
     if(force || now - last_loaded >= NETDATA_RELOAD_MOUNTINFO_EVERY) {
 //#ifdef NETDATA_INTERNAL_CHECKS

--- a/src/proc_interrupts.c
+++ b/src/proc_interrupts.c
@@ -29,7 +29,7 @@ static inline struct interrupt *get_interrupts_array(int lines, int cpus) {
     return irrs;
 }
 
-int do_proc_interrupts(int update_every, unsigned long long dt) {
+int do_proc_interrupts(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_loadavg.c
+++ b/src/proc_loadavg.c
@@ -3,12 +3,12 @@
 // linux calculates this once every 5 seconds
 #define MIN_LOADAVG_UPDATE_EVERY 5
 
-int do_proc_loadavg(int update_every, unsigned long long dt) {
+int do_proc_loadavg(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;
     static int do_loadavg = -1, do_all_processes = -1;
-    static unsigned long long last_loadavg_usec = 0;
+    static usec_t last_loadavg_usec = 0;
     static RRDSET *load_chart = NULL, *processes_chart = NULL;
 
     if(unlikely(!ff)) {
@@ -68,7 +68,7 @@ int do_proc_loadavg(int update_every, unsigned long long dt) {
             rrdset_done(load_chart);
         }
 
-        last_loadavg_usec = load_chart->update_every * 1000000ULL;
+        last_loadavg_usec = load_chart->update_every * USEC_PER_SEC;
     }
     else last_loadavg_usec -= dt;
 

--- a/src/proc_meminfo.c
+++ b/src/proc_meminfo.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-int do_proc_meminfo(int update_every, unsigned long long dt) {
+int do_proc_meminfo(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_net_dev.c
+++ b/src/proc_net_dev.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-int do_proc_net_dev(int update_every, unsigned long long dt) {
+int do_proc_net_dev(int update_every, usec_t dt) {
     static procfile *ff = NULL;
     static int enable_new_interfaces = -1, enable_ifb_interfaces = -1;
     static int do_bandwidth = -1, do_packets = -1, do_errors = -1, do_drops = -1, do_fifo = -1, do_compressed = -1, do_events = -1;

--- a/src/proc_net_ip_vs_stats.c
+++ b/src/proc_net_ip_vs_stats.c
@@ -3,7 +3,7 @@
 #define RRD_TYPE_NET_IPVS           "ipvs"
 #define RRD_TYPE_NET_IPVS_LEN       strlen(RRD_TYPE_NET_IPVS)
 
-int do_proc_net_ip_vs_stats(int update_every, unsigned long long dt) {
+int do_proc_net_ip_vs_stats(int update_every, usec_t dt) {
     static int do_bandwidth = -1, do_sockets = -1, do_packets = -1;
     static procfile *ff = NULL;
 

--- a/src/proc_net_netstat.c
+++ b/src/proc_net_netstat.c
@@ -191,7 +191,7 @@ static void parse_line_pair(procfile *ff, struct netstat_columns *nc, uint32_t h
 }
 
 
-int do_proc_net_netstat(int update_every, unsigned long long dt) {
+int do_proc_net_netstat(int update_every, usec_t dt) {
     (void)dt;
 
     static int do_bandwidth = -1, do_inerrors = -1, do_mcast = -1, do_bcast = -1, do_mcast_p = -1, do_bcast_p = -1, do_ecn = -1, \

--- a/src/proc_net_rpc_nfs.c
+++ b/src/proc_net_rpc_nfs.c
@@ -127,7 +127,7 @@ struct nfs_procs nfs_proc4_values[] = {
     { "", 0ULL, 0 }
 };
 
-int do_proc_net_rpc_nfs(int update_every, unsigned long long dt) {
+int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_net_rpc_nfsd.c
+++ b/src/proc_net_rpc_nfsd.c
@@ -209,7 +209,7 @@ struct nfsd_procs nfsd4_ops_values[] = {
 };
 
 
-int do_proc_net_rpc_nfsd(int update_every, unsigned long long dt) {
+int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
     static procfile *ff = NULL;
     static int do_rc = -1, do_fh = -1, do_io = -1, do_th = -1, do_ra = -1, do_net = -1, do_rpc = -1, do_proc2 = -1, do_proc3 = -1, do_proc4 = -1, do_proc4ops = -1;
     static int ra_warning = 0, th_warning = 0, proc2_warning = 0, proc3_warning = 0, proc4_warning = 0, proc4ops_warning = 0;

--- a/src/proc_net_snmp.c
+++ b/src/proc_net_snmp.c
@@ -197,7 +197,7 @@ static void parse_line_pair(procfile *ff, struct netstat_columns *nc, uint32_t h
     }
 }
 
-int do_proc_net_snmp(int update_every, unsigned long long dt) {
+int do_proc_net_snmp(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_net_snmp6.c
+++ b/src/proc_net_snmp6.c
@@ -3,7 +3,7 @@
 #define RRD_TYPE_NET_SNMP6          "ipv6"
 #define RRD_TYPE_NET_SNMP6_LEN      strlen(RRD_TYPE_NET_SNMP6)
 
-int do_proc_net_snmp6(int update_every, unsigned long long dt) {
+int do_proc_net_snmp6(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_net_softnet_stat.c
+++ b/src/proc_net_softnet_stat.c
@@ -12,7 +12,7 @@ static inline char *softnet_column_name(uint32_t column) {
     }
 }
 
-int do_proc_net_softnet_stat(int update_every, unsigned long long dt) {
+int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_net_stat_conntrack.c
+++ b/src/proc_net_stat_conntrack.c
@@ -3,10 +3,10 @@
 #define RRD_TYPE_NET_STAT_NETFILTER     "netfilter"
 #define RRD_TYPE_NET_STAT_CONNTRACK     "conntrack"
 
-int do_proc_net_stat_conntrack(int update_every, unsigned long long dt) {
+int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
     static procfile *ff = NULL;
     static int do_sockets = -1, do_new = -1, do_changes = -1, do_expect = -1, do_search = -1, do_errors = -1;
-    static unsigned long long get_max_every = 10 * 1000000ULL, usec_since_last_max = 0;
+    static usec_t get_max_every = 10 * USEC_PER_SEC, usec_since_last_max = 0;
     static int read_full = 1;
     static char *nf_conntrack_filename, *nf_conntrack_count_filename, *nf_conntrack_max_filename;
     static RRDVAR *rrdvar_max = NULL;
@@ -21,7 +21,7 @@ int do_proc_net_stat_conntrack(int update_every, unsigned long long dt) {
 
         snprintfz(filename, FILENAME_MAX, "%s%s", global_host_prefix, "/proc/sys/net/netfilter/nf_conntrack_max");
         nf_conntrack_max_filename = config_get("plugin:proc:/proc/sys/net/netfilter/nf_conntrack_max", "filename to monitor", filename);
-        usec_since_last_max = get_max_every = config_get_number("plugin:proc:/proc/sys/net/netfilter/nf_conntrack_max", "read every seconds", 10) * 1000000ULL;
+        usec_since_last_max = get_max_every = config_get_number("plugin:proc:/proc/sys/net/netfilter/nf_conntrack_max", "read every seconds", 10) * USEC_PER_SEC;
 
         read_full = 1;
         ff = procfile_open(nf_conntrack_filename, " \t:", PROCFILE_FLAG_DEFAULT);

--- a/src/proc_net_stat_synproxy.c
+++ b/src/proc_net_stat_synproxy.c
@@ -3,7 +3,7 @@
 #define RRD_TYPE_NET_STAT_NETFILTER         "netfilter"
 #define RRD_TYPE_NET_STAT_SYNPROXY          "synproxy"
 
-int do_proc_net_stat_synproxy(int update_every, unsigned long long dt) {
+int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
     (void)dt;
 
     static int do_entries = -1, do_cookies = -1, do_syns = -1, do_reopened = -1;

--- a/src/proc_softirqs.c
+++ b/src/proc_softirqs.c
@@ -29,7 +29,7 @@ static inline struct interrupt *get_interrupts_array(int lines, int cpus) {
     return irrs;
 }
 
-int do_proc_softirqs(int update_every, unsigned long long dt) {
+int do_proc_softirqs(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-int do_proc_stat(int update_every, unsigned long long dt) {
+int do_proc_stat(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_sys_kernel_random_entropy_avail.c
+++ b/src/proc_sys_kernel_random_entropy_avail.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-int do_proc_sys_kernel_random_entropy_avail(int update_every, unsigned long long dt) {
+int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/proc_vmstat.c
+++ b/src/proc_vmstat.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-int do_proc_vmstat(int update_every, unsigned long long dt) {
+int do_proc_vmstat(int update_every, usec_t dt) {
     (void)dt;
 
     static procfile *ff = NULL;

--- a/src/registry.c
+++ b/src/registry.c
@@ -1010,7 +1010,7 @@ const char *registry_to_announce(void) {
 
 void registry_set_cookie(struct web_client *w, const char *guid) {
     char edate[100];
-    time_t et = time(NULL) + registry.persons_expiration;
+    time_t et = now_realtime_sec() + registry.persons_expiration;
     struct tm etmbuf, *etm = gmtime_r(&et, &etmbuf);
     strftime(edate, sizeof(edate), "%a, %d %b %Y %H:%M:%S %Z", etm);
 

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -685,7 +685,7 @@ RRDDIM *rrddim_add(RRDSET *st, const char *id, const char *name, long multiplier
             error("File %s does not have the same refresh frequency. Clearing it.", fullfilename);
             memset(rd, 0, size);
         }
-        else if(usec_dt(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * 1000000ULL)) {
+        else if(dt_usec(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * 1000000ULL)) {
             errno = 0;
             error("File %s is too old. Clearing it.", fullfilename);
             memset(rd, 0, size);
@@ -1018,13 +1018,13 @@ void rrdset_next_usec(RRDSET *st, unsigned long long microseconds)
     }
     else if(unlikely(!microseconds)) {
         // no dt given by the plugin
-        microseconds = usec_dt(&now, &st->last_collected_time);
+        microseconds = dt_usec(&now, &st->last_collected_time);
     }
     else {
         // microseconds has the time since the last collection
         unsigned long long now_usec = timeval_usec(&now);
         unsigned long long last_usec = timeval_usec(&st->last_collected_time);
-        unsigned long long since_last_usec = usec_dt(&now, &st->last_collected_time);
+        unsigned long long since_last_usec = dt_usec(&now, &st->last_collected_time);
 
         // verify the microseconds given is good
         if(unlikely(microseconds > since_last_usec)) {
@@ -1139,7 +1139,7 @@ unsigned long long rrdset_done(RRDSET *st)
     }
 
     // check if we will re-write the entire data set
-    if(unlikely(usec_dt(&st->last_collected_time, &st->last_updated) > st->entries * update_every_ut)) {
+    if(unlikely(dt_usec(&st->last_collected_time, &st->last_updated) > st->entries * update_every_ut)) {
         info("%s: too old data (last updated at %ld.%ld, last collected at %ld.%ld). Reseting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
         rrdset_reset(st);
 

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -653,7 +653,7 @@ RRDDIM *rrddim_add(RRDSET *st, const char *id, const char *name, long multiplier
     if(rrd_memory_mode != RRD_MEMORY_MODE_RAM) rd = (RRDDIM *)mymmap(fullfilename, size, ((rrd_memory_mode == RRD_MEMORY_MODE_MAP)?MAP_SHARED:MAP_PRIVATE), 1);
     if(rd) {
         struct timeval now;
-        gettimeofday(&now, NULL);
+        now_realtime_timeval(&now);
 
         if(strcmp(rd->magic, RRDDIMENSION_MAGIC) != 0) {
             errno = 0;
@@ -977,7 +977,7 @@ collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number 
 {
     debug(D_RRD_CALLS, "rrddim_set_by_pointer() for chart %s, dimension %s, value " COLLECTED_NUMBER_FORMAT, st->name, rd->name, value);
 
-    gettimeofday(&rd->last_collected_time, NULL);
+    now_realtime_timeval(&rd->last_collected_time);
     rd->collected_value = value;
     rd->updated = 1;
     rd->counter++;
@@ -1010,7 +1010,7 @@ void rrdset_next_usec_unfiltered(RRDSET *st, unsigned long long microseconds)
 void rrdset_next_usec(RRDSET *st, unsigned long long microseconds)
 {
     struct timeval now;
-    gettimeofday(&now, NULL);
+    now_realtime_timeval(&now);
 
     if(unlikely(!st->last_collected_time.tv_sec)) {
         // the first entry
@@ -1102,7 +1102,7 @@ unsigned long long rrdset_done(RRDSET *st)
     if(unlikely(!st->last_collected_time.tv_sec)) {
         // it is the first entry
         // set the last_collected_time to now
-        gettimeofday(&st->last_collected_time, NULL);
+        now_realtime_timeval(&st->last_collected_time);
         timeval_align(&st->last_collected_time, st->update_every);
 
         last_collect_ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - update_every_ut;
@@ -1145,7 +1145,7 @@ unsigned long long rrdset_done(RRDSET *st)
 
         st->usec_since_last_update = update_every_ut;
 
-        gettimeofday(&st->last_collected_time, NULL);
+        now_realtime_timeval(&st->last_collected_time);
         timeval_align(&st->last_collected_time, st->update_every);
 
         unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -685,7 +685,7 @@ RRDDIM *rrddim_add(RRDSET *st, const char *id, const char *name, long multiplier
             error("File %s does not have the same refresh frequency. Clearing it.", fullfilename);
             memset(rd, 0, size);
         }
-        else if(dt_usec(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * 1000000ULL)) {
+        else if(dt_usec(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * USEC_PER_SEC)) {
             errno = 0;
             error("File %s is too old. Clearing it.", fullfilename);
             memset(rd, 0, size);
@@ -998,23 +998,23 @@ collected_number rrddim_set(RRDSET *st, const char *id, collected_number value)
     return rrddim_set_by_pointer(st, rd, value);
 }
 
-void rrdset_next_usec_unfiltered(RRDSET *st, unsigned long long microseconds)
+void rrdset_next_usec_unfiltered(RRDSET *st, usec_t microseconds)
 {
     if(unlikely(!st->last_collected_time.tv_sec || !microseconds)) {
         // the first entry
-        microseconds = st->update_every * 1000000ULL;
+        microseconds = st->update_every * USEC_PER_SEC;
     }
     st->usec_since_last_update = microseconds;
 }
 
-void rrdset_next_usec(RRDSET *st, unsigned long long microseconds)
+void rrdset_next_usec(RRDSET *st, usec_t microseconds)
 {
     struct timeval now;
     now_realtime_timeval(&now);
 
     if(unlikely(!st->last_collected_time.tv_sec)) {
         // the first entry
-        microseconds = st->update_every * 1000000ULL;
+        microseconds = st->update_every * USEC_PER_SEC;
     }
     else if(unlikely(!microseconds)) {
         // no dt given by the plugin
@@ -1022,9 +1022,9 @@ void rrdset_next_usec(RRDSET *st, unsigned long long microseconds)
     }
     else {
         // microseconds has the time since the last collection
-        unsigned long long now_usec = timeval_usec(&now);
-        unsigned long long last_usec = timeval_usec(&st->last_collected_time);
-        unsigned long long since_last_usec = dt_usec(&now, &st->last_collected_time);
+        usec_t now_usec = timeval_usec(&now);
+        usec_t last_usec = timeval_usec(&st->last_collected_time);
+        usec_t since_last_usec = dt_usec(&now, &st->last_collected_time);
 
         // verify the microseconds given is good
         if(unlikely(microseconds > since_last_usec)) {
@@ -1052,7 +1052,7 @@ void rrdset_next_usec(RRDSET *st, unsigned long long microseconds)
     st->usec_since_last_update = microseconds;
 }
 
-unsigned long long rrdset_done(RRDSET *st)
+usec_t rrdset_done(RRDSET *st)
 {
     if(unlikely(netdata_exit)) return 0;
 
@@ -1070,12 +1070,12 @@ unsigned long long rrdset_done(RRDSET *st)
     unsigned int
         stored_entries = 0;     // the number of entries we have stored in the db, during this call to rrdset_done()
 
-    unsigned long long
+    usec_t
         last_collect_ut,        // the timestamp in microseconds, of the last collected value
         now_collect_ut,         // the timestamp in microseconds, of this collected value (this is NOW)
         last_stored_ut,         // the timestamp in microseconds, of the last stored entry in the db
         next_store_ut,          // the timestamp in microseconds, of the next entry to store in the db
-        update_every_ut = st->update_every * 1000000ULL; // st->update_every in microseconds
+        update_every_ut = st->update_every * USEC_PER_SEC; // st->update_every in microseconds
 
     if(unlikely(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &pthreadoldcancelstate) != 0))
         error("Cannot set pthread cancel state to DISABLE.");
@@ -1105,7 +1105,7 @@ unsigned long long rrdset_done(RRDSET *st)
         now_realtime_timeval(&st->last_collected_time);
         timeval_align(&st->last_collected_time, st->update_every);
 
-        last_collect_ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - update_every_ut;
+        last_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec - update_every_ut;
 
         // the first entry should not be stored
         store_this_entry = 0;
@@ -1116,10 +1116,10 @@ unsigned long long rrdset_done(RRDSET *st)
     else {
         // it is not the first entry
         // calculate the proper last_collected_time, using usec_since_last_update
-        last_collect_ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec;
-        unsigned long long ut = last_collect_ut + st->usec_since_last_update;
-        st->last_collected_time.tv_sec = (time_t) (ut / 1000000ULL);
-        st->last_collected_time.tv_usec = (suseconds_t) (ut % 1000000ULL);
+        last_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec;
+        usec_t ut = last_collect_ut + st->usec_since_last_update;
+        st->last_collected_time.tv_sec = (time_t) (ut / USEC_PER_SEC);
+        st->last_collected_time.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
     }
 
     // if this set has not been updated in the past
@@ -1127,9 +1127,9 @@ unsigned long long rrdset_done(RRDSET *st)
     if(unlikely(!st->last_updated.tv_sec)) {
         // it has never been updated before
         // set a fake last_updated, in the past using usec_since_last_update
-        unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;
-        st->last_updated.tv_sec = (time_t) (ut / 1000000ULL);
-        st->last_updated.tv_usec = (suseconds_t) (ut % 1000000ULL);
+        usec_t ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec - st->usec_since_last_update;
+        st->last_updated.tv_sec = (time_t) (ut / USEC_PER_SEC);
+        st->last_updated.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
 
         // the first entry should not be stored
         store_this_entry = 0;
@@ -1148,9 +1148,9 @@ unsigned long long rrdset_done(RRDSET *st)
         now_realtime_timeval(&st->last_collected_time);
         timeval_align(&st->last_collected_time, st->update_every);
 
-        unsigned long long ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec - st->usec_since_last_update;
-        st->last_updated.tv_sec = (time_t) (ut / 1000000ULL);
-        st->last_updated.tv_usec = (suseconds_t) (ut % 1000000ULL);
+        usec_t ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec - st->usec_since_last_update;
+        st->last_updated.tv_sec = (time_t) (ut / USEC_PER_SEC);
+        st->last_updated.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
 
         // the first entry should not be stored
         store_this_entry = 0;
@@ -1161,9 +1161,9 @@ unsigned long long rrdset_done(RRDSET *st)
     // last_stored_ut = the last time we added a value to the storage
     // now_collect_ut = the time the current value has been collected
     // next_store_ut  = the time of the next interpolation point
-    last_stored_ut = st->last_updated.tv_sec * 1000000ULL + st->last_updated.tv_usec;
-    now_collect_ut = st->last_collected_time.tv_sec * 1000000ULL + st->last_collected_time.tv_usec;
-    next_store_ut  = (st->last_updated.tv_sec + st->update_every) * 1000000ULL;
+    last_stored_ut = st->last_updated.tv_sec * USEC_PER_SEC + st->last_updated.tv_usec;
+    now_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec;
+    next_store_ut  = (st->last_updated.tv_sec + st->update_every) * USEC_PER_SEC;
 
     if(unlikely(st->debug)) {
         debug(D_RRD_STATS, "%s: last_collect_ut = %0.3Lf (last collection time)", st->name, (long double)last_collect_ut/1000000.0);
@@ -1366,7 +1366,7 @@ unsigned long long rrdset_done(RRDSET *st)
 #endif
     }
 
-    unsigned long long first_ut = last_stored_ut;
+    usec_t first_ut = last_stored_ut;
     long long iterations = (now_collect_ut - last_stored_ut) / (update_every_ut);
     if((now_collect_ut % (update_every_ut)) == 0) iterations++;
 
@@ -1380,7 +1380,7 @@ unsigned long long rrdset_done(RRDSET *st)
             debug(D_RRD_STATS, "%s: next_store_ut  = %0.3Lf (next interpolation point)", st->name, (long double)next_store_ut/1000000.0);
         }
 
-        st->last_updated.tv_sec = (time_t) (next_store_ut / 1000000ULL);
+        st->last_updated.tv_sec = (time_t) (next_store_ut / USEC_PER_SEC);
         st->last_updated.tv_usec = 0;
 
         for( rd = st->dimensions ; likely(rd) ; rd = rd->next ) {

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -56,7 +56,7 @@ RRDHOST localhost = {
 void rrdhost_init(char *hostname) {
     localhost.hostname = hostname;
     localhost.health_log.next_log_id =
-        localhost.health_log.next_alarm_id = time(NULL);
+        localhost.health_log.next_alarm_id = now_realtime_sec();
 }
 
 void rrdhost_rwlock(RRDHOST *host) {
@@ -525,7 +525,7 @@ RRDSET *rrdset_create(const char *type, const char *id, const char *name, const 
             error("File %s does not have the desired update frequency. Clearing it.", fullfilename);
             memset(st, 0, size);
         }
-        else if((time(NULL) - st->last_updated.tv_sec) > update_every * entries) {
+        else if((now_realtime_sec() - st->last_updated.tv_sec) > update_every * entries) {
             errno = 0;
             error("File %s is too old. Clearing it.", fullfilename);
             memset(st, 0, size);

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -244,7 +244,7 @@ struct rrdset {
 
     uint32_t hash_name;                             // a simple hash on the name
 
-    unsigned long long usec_since_last_update;      // the time in microseconds since the last collection of data
+    usec_t usec_since_last_update;                  // the time in microseconds since the last collection of data
 
     struct timeval last_updated;                    // when this data set was last updated (updated every time the rrd_stats_done() function)
     struct timeval last_collected_time;             // when did this data set last collected values
@@ -355,11 +355,11 @@ extern RRDSET *rrdset_find(const char *id);
 extern RRDSET *rrdset_find_bytype(const char *type, const char *id);
 extern RRDSET *rrdset_find_byname(const char *name);
 
-extern void rrdset_next_usec_unfiltered(RRDSET *st, unsigned long long microseconds);
-extern void rrdset_next_usec(RRDSET *st, unsigned long long microseconds);
+extern void rrdset_next_usec_unfiltered(RRDSET *st, usec_t microseconds);
+extern void rrdset_next_usec(RRDSET *st, usec_t microseconds);
 #define rrdset_next(st) rrdset_next_usec(st, 0ULL)
 
-extern unsigned long long rrdset_done(RRDSET *st);
+extern usec_t rrdset_done(RRDSET *st);
 
 // get the total duration in seconds of the round robin database
 #define rrdset_duration(st) ((time_t)( (((st)->counter >= ((unsigned long)(st)->entries))?(unsigned long)(st)->entries:(st)->counter) * (st)->update_every ))

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -127,7 +127,7 @@ void rrd_stats_api_v1_charts(BUFFER *wb)
 
 unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb)
 {
-    time_t now = time(NULL);
+    time_t now = now_realtime_sec();
 
     pthread_rwlock_rdlock(&st->rwlock);
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1396,7 +1396,7 @@ int do_sys_fs_cgroup(int update_every, unsigned long long dt) {
 
     static int cgroup_global_config_read = 0;
     static time_t last_run = 0;
-    time_t now = time(NULL);
+    time_t now = now_realtime_sec();
 
     if(unlikely(!cgroup_global_config_read)) {
         read_cgroup_plugin_configuration();
@@ -1436,7 +1436,7 @@ void *cgroups_main(void *ptr)
     unsigned long long sutime_sys_fs_cgroup = 0ULL;
 
     // the next time we will run - aligned properly
-    unsigned long long sunext = (time(NULL) - (time(NULL) % rrd_update_every) + rrd_update_every) * 1000000ULL;
+    unsigned long long sunext = (now_realtime_sec() - (now_realtime_sec() % rrd_update_every) + rrd_update_every) * 1000000ULL;
 
     RRDSET *stcpu_thread = NULL;
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1445,11 +1445,11 @@ void *cgroups_main(void *ptr)
         if(unlikely(netdata_exit)) break;
 
         // delay until it is our time to run
-        while((sunow = time_usec()) < sunext)
+        while((sunow = now_realtime_usec()) < sunext)
             sleep_usec(sunext - sunow);
 
         // find the next time we need to run
-        while(time_usec() > sunext)
+        while(now_realtime_usec() > sunext)
             sunext += rrd_update_every * 1000000ULL;
 
         if(unlikely(netdata_exit)) break;
@@ -1458,7 +1458,7 @@ void *cgroups_main(void *ptr)
 
         if(!vdo_sys_fs_cgroup) {
             debug(D_PROCNETDEV_LOOP, "PROCNETDEV: calling do_sys_fs_cgroup().");
-            sunow = time_usec();
+            sunow = now_realtime_usec();
             vdo_sys_fs_cgroup = do_sys_fs_cgroup(rrd_update_every, (sutime_sys_fs_cgroup > 0)?sunow - sutime_sys_fs_cgroup:0ULL);
             sutime_sys_fs_cgroup = sunow;
         }

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1391,7 +1391,7 @@ void update_cgroup_charts(int update_every) {
 // ----------------------------------------------------------------------------
 // cgroups main
 
-int do_sys_fs_cgroup(int update_every, unsigned long long dt) {
+int do_sys_fs_cgroup(int update_every, usec_t dt) {
     (void)dt;
 
     static int cgroup_global_config_read = 0;
@@ -1433,15 +1433,15 @@ void *cgroups_main(void *ptr)
     int vdo_cpu_netdata             = !config_get_boolean("plugin:cgroups", "cgroups plugin resources", 1);
 
     // keep track of the time each module was called
-    unsigned long long sutime_sys_fs_cgroup = 0ULL;
+    usec_t sutime_sys_fs_cgroup = 0ULL;
 
     // the next time we will run - aligned properly
-    unsigned long long sunext = (now_realtime_sec() - (now_realtime_sec() % rrd_update_every) + rrd_update_every) * 1000000ULL;
+    usec_t sunext = (now_realtime_sec() - (now_realtime_sec() % rrd_update_every) + rrd_update_every) * USEC_PER_SEC;
 
     RRDSET *stcpu_thread = NULL;
 
     for(;;) {
-        unsigned long long sunow;
+        usec_t sunow;
         if(unlikely(netdata_exit)) break;
 
         // delay until it is our time to run
@@ -1450,7 +1450,7 @@ void *cgroups_main(void *ptr)
 
         // find the next time we need to run
         while(now_realtime_usec() > sunext)
-            sunext += rrd_update_every * 1000000ULL;
+            sunext += rrd_update_every * USEC_PER_SEC;
 
         if(unlikely(netdata_exit)) break;
 

--- a/src/sys_kernel_mm_ksm.c
+++ b/src/sys_kernel_mm_ksm.c
@@ -19,7 +19,7 @@ KSM_NAME_VALUE values[] = {
         [PAGES_TO_SCAN] = { "/sys/kernel/mm/ksm/pages_to_scan", 0ULL },
 };
 
-int do_sys_kernel_mm_ksm(int update_every, unsigned long long dt) {
+int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
     static procfile *ff_pages_shared = NULL, *ff_pages_sharing = NULL, *ff_pages_unshared = NULL, *ff_pages_volatile = NULL, *ff_pages_to_scan = NULL;
     static long page_size = -1;
 

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -1130,7 +1130,7 @@ int unit_test(long delay, long shift)
         if(do_absi) rrddim_set(st, "percentage-of-incremental-row", i);
 
         if(!c) {
-            gettimeofday(&st->last_collected_time, NULL);
+            now_realtime_timeval(&st->last_collected_time);
             st->last_collected_time.tv_usec = shift;
         }
 

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -901,7 +901,7 @@ int run_test(struct test *test)
     st->debug = 1;
 
     // feed it with the test data
-    time_t time_now = 0, time_start = time(NULL);
+    time_t time_now = 0, time_start = now_realtime_sec();
     unsigned long c;
     collected_number last = 0;
     for(c = 0; c < test->feed_entries; c++) {

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -940,7 +940,7 @@ int web_client_api_request_v1_badge(struct web_client *w, char *url) {
 
         if (refresh > 0) {
             buffer_sprintf(w->response.header, "Refresh: %d\r\n", refresh);
-            w->response.data->expires = time(NULL) + refresh;
+            w->response.data->expires = now_realtime_sec() + refresh;
         }
         else buffer_no_cacheable(w->response.data);
 
@@ -989,7 +989,7 @@ int web_client_api_request_v1_badge(struct web_client *w, char *url) {
         ret = 500;
 
         // if the collected value is too old, don't calculate its value
-        if (rrdset_last_entry_t(st) >= (time(NULL) - (st->update_every * st->gap_when_lost_iterations_above)))
+        if (rrdset_last_entry_t(st) >= (now_realtime_sec() - (st->update_every * st->gap_when_lost_iterations_above)))
             ret = rrd2value(st,
                             w->response.data,
                             &n,
@@ -1012,7 +1012,7 @@ int web_client_api_request_v1_badge(struct web_client *w, char *url) {
         }
         else if (refresh > 0) {
             buffer_sprintf(w->response.header, "Refresh: %d\r\n", refresh);
-            w->response.data->expires = time(NULL) + refresh;
+            w->response.data->expires = now_realtime_sec() + refresh;
         }
         else buffer_no_cacheable(w->response.data);
 
@@ -1404,19 +1404,19 @@ int web_client_api_request_v1_registry(struct web_client *w, char *url)
             if(unlikely(cookie && person_guid[0] && !strcmp(person_guid, REGISTRY_VERIFY_COOKIES_GUID)))
                 person_guid[0] = '\0';
 
-            return registry_request_access_json(w, person_guid, machine_guid, machine_url, url_name, time(NULL));
+            return registry_request_access_json(w, person_guid, machine_guid, machine_url, url_name, now_realtime_sec());
 
         case 'D':
             w->tracking_required = 1;
-            return registry_request_delete_json(w, person_guid, machine_guid, machine_url, delete_url, time(NULL));
+            return registry_request_delete_json(w, person_guid, machine_guid, machine_url, delete_url, now_realtime_sec());
 
         case 'S':
             w->tracking_required = 1;
-            return registry_request_search_json(w, person_guid, machine_guid, machine_url, search_machine_guid, time(NULL));
+            return registry_request_search_json(w, person_guid, machine_guid, machine_url, search_machine_guid, now_realtime_sec());
 
         case 'W':
             w->tracking_required = 1;
-            return registry_request_switch_json(w, person_guid, machine_guid, machine_url, to_person_guid, time(NULL));
+            return registry_request_switch_json(w, person_guid, machine_guid, machine_url, to_person_guid, now_realtime_sec());
 
         case 'H':
             return registry_request_hello_json(w);

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -136,7 +136,7 @@ void web_client_reset(struct web_client *w) {
         // --------------------------------------------------------------------
         // global statistics
 
-        finished_web_request_statistics(usec_dt(&tv, &w->tv_in),
+        finished_web_request_statistics(dt_usec(&tv, &w->tv_in),
                                         w->stats_received_bytes,
                                         w->stats_sent_bytes,
                                         size,
@@ -152,9 +152,9 @@ void web_client_reset(struct web_client *w) {
         log_access("%llu: (sent/all = %zu/%zu bytes %0.0f%%, prep/sent/total = %0.2f/%0.2f/%0.2f ms) %s: %d '%s'",
                    w->id,
                    sent, size, -((size > 0) ? ((size - sent) / (double) size * 100.0) : 0.0),
-                   usec_dt(&w->tv_ready, &w->tv_in) / 1000.0,
-                   usec_dt(&tv, &w->tv_ready) / 1000.0,
-                   usec_dt(&tv, &w->tv_in) / 1000.0,
+                   dt_usec(&w->tv_ready, &w->tv_in) / 1000.0,
+                   dt_usec(&tv, &w->tv_ready) / 1000.0,
+                   dt_usec(&tv, &w->tv_in) / 1000.0,
                    (w->mode == WEB_CLIENT_MODE_FILECOPY) ? "filecopy" : ((w->mode == WEB_CLIENT_MODE_OPTIONS)
                                                                          ? "options" : "data"),
                    w->response.code,

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -125,7 +125,7 @@ void web_client_reset(struct web_client *w) {
 
     if(likely(w->last_url[0])) {
         struct timeval tv;
-        gettimeofday(&tv, NULL);
+        now_realtime_timeval(&tv);
 
         size_t size = (w->mode == WEB_CLIENT_MODE_FILECOPY)?w->response.rlen:w->response.data->len;
         size_t sent = size;
@@ -1953,7 +1953,7 @@ void web_client_process(struct web_client *w) {
 #endif
 
     // start timing us
-    gettimeofday(&w->tv_in, NULL);
+    now_realtime_timeval(&w->tv_in);
 
     if(unlikely(!hash_api)) {
         hash_api = simple_hash("api");
@@ -2165,7 +2165,7 @@ void web_client_process(struct web_client *w) {
         }
     }
 
-    gettimeofday(&w->tv_ready, NULL);
+    now_realtime_timeval(&w->tv_ready);
     w->response.sent = 0;
     w->response.code = code;
 


### PR DESCRIPTION
**netdata** currently uses a realtime clock for all time computations (sleep times, updated values time checks, ...), this leads to several issues when the system date/time changes brutally (date command, ntpdate).

This patchset is a draft to try to resolve this issue.

The usual good practice is too use a monotonic clock for all time computations to avoid this, this is what this patch does except for a few places when a realtime clock is really needed (and not dangerous).

First, let's see the impacts on current master when we change the system date a few years in the future, then going back (I also added a log in sleep_usec to illustrate more issues):

With release 1.2, netdata was taking 100% cpu on one core after the date change, with release 1.4, this does not seem to be the case anymore but there are still some issues, a few examples:

```
2016-12-01 17:18:06: apps.plugin: INFO: sleeping 0.989672000
2016-12-01 17:18:07: apps.plugin: INFO: sleeping 0.991512000
2020-01-01 00:00:00: netdata: Resuming logging from process 'netdata' (prevented 3669 logs in the last 1200 seconds).
2020-01-01 00:00:00: netdata: INFO: sensors.coretemp_isa_0000_temperature: took too long to be updated (97224112.995 secs). Reseting it.
2020-01-01 00:00:00: netdata: INFO: sensors.radeon_pci_0100_temperature: took too long to be updated (97224112.995 secs). Reseting it.
2020-01-01 00:00:00: netdata: INFO: netdata.plugin_pythond_sensors: took too long to be updated (97224112.995 secs). Reseting it.
2020-01-01 00:00:00: netdata: INFO: cpu.cpufreq: took too long to be updated (97224112.995 secs). Reseting it.
...
```

then going back:

```
2016-12-01 17:19:00: apps.plugin: INFO: sleeping 97224112.004799000
```
More generally, it is very difficult to know the impact everywhere in the code and to be robust when using a realtime clock.

By using a monotonic clock (clock_gettime(CLOCK_MONOTONIC, ...)), we don't have anymore issues, however the main drawback is that graphs time labels and values are not based on current time anymore (monotonic clock is usually closed to uptime). This could make system issues investigations more difficult.

The approach taken is to transmit to the web client the current monotonic time and to use the graphs formatters to add the offset with the web client time, so all graphs are displayed based on the client time (which could also be usefull for a system without a correct date, for example embedded systems without a CMOS battery).

The main drawbacks I see are:
* on reboot, the clock restarts from 0, so rrd values go in the past.  I have not checked yet but this could raise issues with the cache
* this is implemented only for dygraph for now
* could this raise issues when monitoring several systems ?

Notes:
* we could add a setting in the web client to choose between monotonic or realtime clock time value in the graphs
* I didn't change profiles/*.c files as they don't seem to compile anymore, should they be removed ?
* I still use a realtime clock for the following cases, I may have forgotten ones or let too much, this is only a draft:
  * healths/alarms logs (I'm not sure about my modifications there)
  * logs date/time
  * registry expiration date
  * unit tests
* there are likely shell, python or javascript scripts that have the same issues, I have not checked them

Tell me what you think.

Thanks
