### PR TITLE
Ensure netdata owns /var/lib/netdata/.

### DIFF
--- a/contrib/debian/netdata.postinst.in
+++ b/contrib/debian/netdata.postinst.in
@@ -14,7 +14,7 @@ case "$1" in
           fi
 
           if ! dpkg-statoverride --list /var/lib/netdata >/dev/null 2>&1; then
-              dpkg-statoverride --update --add root netdata 0755 /var/lib/netdata
+              dpkg-statoverride --update --add netdata netdata 0755 /var/lib/netdata
           fi
 
           if ! dpkg-statoverride --list /var/lib/netdata/www >/dev/null 2>&1; then


### PR DESCRIPTION
Netdata needs to be able to create the health and registry directories
on launch. The inability to do this prevents the daemon from starting.