### PR TITLE
pagerduty.com notifications

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -9,6 +9,7 @@
 # - messages to your slack team (slack.com),
 # - messages to your telegram chat / group chat (telegram.org)
 # - sms messages to your cell phone or any sms enabled device (twilio.com)
+# - notifications to users on pagerduty.com
 #
 # The 'to' line given at netdata alarms defines a *role*, so that many
 # people can be notified for each role.
@@ -62,6 +63,7 @@ curl=""
 #  - telegram chat ids
 #  - slack channels
 #  - sms phone numbers
+#  - pagerduty.com (pd) services
 #
 # You can append |critical to limit the notifications to be sent.
 #
@@ -73,9 +75,10 @@ curl=""
 #  telegram: "111827421 112746832|critical"
 #  slack   : "alarms disasters|critical"
 #  twilio  : "+15555555555 +17777777777|critical"
+#  pd      : "<pd_service_key_1> <pd_service_key_2>|critical"
 #
 # If a recipient is set to empty string, the default recipient of the given
-# notification method (email, pushover, telegram, slack) will be used.
+# notification method (email, pushover, telegram, slack, pd) will be used.
 # To disable a notification, use the recipient called: disabled
 # This works for all notification methods (including the default recipients).
 
@@ -219,11 +222,16 @@ KAFKA_SENDER_IP=""
 # a "Generic API" pagerduty service.
 # https://www.pagerduty.com/docs/guides/agent-install-guide/
 
+# multiple recipients can be given like this:
+#              "<pd_service_key_1> <pd_service_key_2> ..."
+
 # enable/disable sending pagerduty notifications
 SEND_PD="YES"
 
-# The service key for your "General API" pagerduty service.
-PD_SERVICE_KEY=''
+# if a role's recipients are not configured, a notification will be sent to
+# the "General API" pagerduty.com service that uses this service key.
+# (empty = do not send a notification for unconfigured roles):
+DEFAULT_RECIPIENT_PD=""
 
 
 ###############################################################################
@@ -245,6 +253,8 @@ role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[sysadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
+
 # -----------------------------------------------------------------------------
 # DNS related alarms
 
@@ -259,6 +269,8 @@ role_recipients_telegram[domainadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[domainadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+
+role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
 
 # -----------------------------------------------------------------------------
 # database servers alarms
@@ -276,6 +288,8 @@ role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[dba]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
+
 # -----------------------------------------------------------------------------
 # web servers alarms
 # apache, nginx, etc
@@ -292,6 +306,8 @@ role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[webmaster]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
+
 # -----------------------------------------------------------------------------
 # proxy servers alarms
 # apache, nginx, etc
@@ -307,3 +323,5 @@ role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[proxyadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+
+role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -212,6 +212,20 @@ KAFKA_URL=""
 KAFKA_SENDER_IP=""
 
 
+#------------------------------------------------------------------------------
+# pagerduty.com notification options
+#
+# pagerduty.com notifications require the pagerduty agent to be installed and 
+# a "Generic API" pagerduty service.
+# https://www.pagerduty.com/docs/guides/agent-install-guide/
+
+# enable/disable sending pagerduty notifications
+SEND_PD="YES"
+
+# The service key for your "General API" pagerduty service.
+PD_SERVICE_KEY=''
+
+
 ###############################################################################
 # RECIPIENTS PER ROLE
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -385,6 +385,7 @@ done
 [ -z "${PD_SERVICE_KEY}" ] && SEND_PD="NO"
 
 # if we need pd-send, check for the pd-send command
+# https://www.pagerduty.com/docs/guides/agent-install-guide/
 if [ "${SEND_PD}" = "YES" ]
     then
     pd_send="$(which pd-send 2>/dev/null || command -v pd-send 2>/dev/null)"
@@ -677,9 +678,24 @@ send_pd() {
                    -d "${host} ${chart}.${name} is ${status}" \
                    -i ${alarm_id} \
                    -f 'info'="${info}" \
-                   -f 'value'="${value} ${units}" \
+                   -f 'value_w_units'="${value} ${units}" \
                    -f 'when'="${when}" \
-                   -f 'duration'="${duration}"
+                   -f 'duration'="${duration}" \
+                   -f 'roles'="${roles}" \
+                   -f 'host'="${host}" \
+                   -f 'unique_id'="${unique_id}" \
+                   -f 'alarm_id'="${alarm_id}" \
+                   -f 'event_id'="${event_id}" \
+                   -f 'name'="${name}" \
+                   -f 'chart'="${chart}" \
+                   -f 'family'="${family}" \
+                   -f 'status'="${status}" \
+                   -f 'old_status'="${old_status}" \
+                   -f 'value'="${value}" \
+                   -f 'old_value'="${old_value}" \
+                   -f 'src'="${src}" \
+                   -f 'non_clear_duration'="${non_clear_duration}" \
+                   -f 'units'="${units}"
         retval=$?
         if [ ${retval} -eq 0 ]
             then

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -21,7 +21,7 @@
 #  - telegram.org notifications by @hashworks PR #1002
 #  - twilio.com notifications by Levi Blaney @shadycuz PR #1211
 #  - kafka notifications
-#  - pagerduty.com notifications by Jim Cooley @jimcooley PR#????
+#  - pagerduty.com notifications by Jim Cooley @jimcooley PR #1373
 
 # -----------------------------------------------------------------------------
 # testing notifications

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -675,7 +675,7 @@ send_pd() {
         then
         ${pd_send} -k ${PD_SERVICE_KEY} \
                    -t ${t} \
-                   -d "${host} ${chart}.${name} is ${status}" \
+                   -d "${status} ${name}=${value} ${units} - ${host}, ${family}" \
                    -i ${alarm_id} \
                    -f 'info'="${info}" \
                    -f 'value_w_units'="${value} ${units}" \


### PR DESCRIPTION
This PR adds pagerduty.com notifications to alarm-notify.sh.

This requires the pagerduty agent to be installed.
https://www.pagerduty.com/docs/guides/agent-install-guide/

health_alarm_notify.conf configs:
```
SEND_PD="YES"
DEFAULT_RECIPIENT_PD="<service key for your pagerduty service>"
```