### PR TITLE
Fix pull requests from external repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,7 @@ addons:
 #
 # Setup environment
 before_install:
- # Decrypt our private files for CI use only
- - openssl aes-256-cbc -K $encrypted_decb6f6387c4_key -iv $encrypted_decb6f6387c4_iv -in .travis/travis_rsa.enc -out .travis/travis_rsa -d
- - eval "$(ssh-agent -s)"        # start the ssh agent
- - chmod 600 .travis/travis_rsa  # add our key
- - ssh-add .travis/travis_rsa    # add our key
- - rm -f .travis/travis_rsa      # remove to prevent leaks
- # WARNING: Any changes to the above 5 lines should be monitored closely
+ - ./.travis/decrypt-if-have-key decb6f6387c4
  - ssh-keyscan -H firehol.org >> ~/.ssh/known_hosts
 #
 # Run
@@ -42,7 +36,7 @@ script:
 # Deploy as required
 after_success:
   - for i in *.tar.*; do md5sum -b $i > $i.md5; sha512sum -b $i > $i.sha; done
-  - "case \"$TRAVIS_BRANCH\" in master|stable-*) if [ $TRAVIS_PULL_REQUEST = false -a \"$TRAVIS_TAG\" = \"\" -a \"$CC\" = \"gcc\" ]; then ssh travis@firehol.org mkdir -p uploads/netdata/$TRAVIS_BRANCH/ && scp -p *.tar.* travis@firehol.org:uploads/netdata/$TRAVIS_BRANCH/ && ssh travis@firehol.org touch uploads/netdata/$TRAVIS_BRANCH/complete.txt; fi;; esac"
+  - ./travis/deploy-if-have-key
 deploy:
   # Upload results to GitHub (tag only)
   - provider: releases

--- a/.travis/decrypt-if-have-key
+++ b/.travis/decrypt-if-have-key
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+# Decrypt our private files; changes to this file should be inspected
+# closely to ensure they do not create information leaks
+
+key=`eval \$encrypted_$1_key`
+iv=`eval \$encrypted_$1_iv`
+
+if [ ! "$key" ]
+then
+  echo "No aes key present - skipping decryption"
+  exit 0
+fi
+
+for i in .travis/*.enc
+do
+  u=$(echo $i | sed -e 's/.enc$//')
+  openssl aes-256-cbc -K "$key" -iv "$iv" -in $i -out $u -d
+done
+
+if [ -f .travis/travis_rsa ]
+then
+  echo "ssh key present - loading agent"
+  eval "$(ssh-agent -s)"
+
+  # add key, then remove to prevent leaks
+  chmod 600 .travis/travis_rsa
+  ssh-add .travis/travis_rsa
+  rm -f .travis/travis_rsa
+  touch  .travis/travis_rsa.ready
+else
+  echo "No ssh key present - skipping agent start"
+fi

--- a/.travis/deploy-if-have-key
+++ b/.travis/deploy-if-have-key
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+# Deploy tar-files and checksums to the firehol website
+
+key=`eval \$encrypted_$1_key`
+
+if [ ! -f .travis/travis_rsa.ready ]
+then
+  echo "No ssh key decrypted - skipping deployment to website"
+  exit 0
+fi
+
+case "$TRAVIS_BRANCH" in
+  master|stable-*)
+    :
+  ;;
+  *)
+    echo "Not on master or stable-* branch - skipping deployment to website"
+    exit 0
+  ;;
+esac
+
+if [ "$TRAVIS_PULL_REQUEST" = "true" ]
+then
+  echo "Building pull request - skipping deployment to website"
+  exit 0
+fi
+
+if [ "$TRAVIS_TAG" != "" ]
+then
+  echo "Building tag - skipping deployment to website"
+  exit 0
+fi
+
+if [ "$CC" != "gcc" ]
+then
+  echo "Building non-gcc version - skipping deployment to website"
+  exit 0
+fi
+
+ssh travis@firehol.org mkdir -p uploads/netdata/$TRAVIS_BRANCH/
+scp -p *.tar.* travis@firehol.org:uploads/netdata/$TRAVIS_BRANCH/
+ssh travis@firehol.org touch uploads/netdata/$TRAVIS_BRANCH/complete.txt


### PR DESCRIPTION
Github/travis integration does not make available the encryption keys
for pull requests from remote repositories. Move direct commands from
travis into scripts so that we decrypt and deploy only when we can.