### PR TITLE
FreeNAS support

### DIFF
--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -15,6 +15,7 @@
 // NEEDED BY: struct sysctl_netisr_workstream, struct sysctl_netisr_work
 #include <net/netisr.h>
 // NEEDED BY: struct ifaddrs, getifaddrs()
+#define _IFI_OQDROPS // It is for FreeNAS only. Most probably in future releases of FreeNAS it will be removed
 #include <net/if.h>
 #include <ifaddrs.h>
 // NEEDED BY: do_disk_io


### PR DESCRIPTION
This definition looks strange and is rooted in times, when FreeBSD didn't collect statistics for output packets drops. I think it should be removed in future releases of FreeNAS.