### PR TITLE
Freeradius plugin

### DIFF
--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -40,3 +40,4 @@ example: no
 # sensors: yes
 # squid: yes
 # tomcat: yes
+# freeradius: yes

--- a/conf.d/python.d/freeradius.conf
+++ b/conf.d/python.d/freeradius.conf
@@ -56,9 +56,12 @@
 #
 # Additionally to the above, freeradius also supports the following:
 #
-#     host: 'host'       # ip address or hostname
-#     port: 'port'       # port on which freeradius server listen (type = status)
-#     secret: 'secret'
+#     host: 'host'			# Default: 'localhost'. Server ip address or hostname.
+#     port: 'port'			# Default: '18121'. Port on which freeradius server listen (type = status).
+#     secret: 'secret'			# Default: 'adminsecret'. 
+#     acct: True/False		     	# Defalt: False. Freeradius accounting statistics.
+#     proxy_auth: True/False		# Default: False. Freeradius proxy authentication statistics. 
+#     proxy_acct: True/False		# Default: False. Freeradius proxy accounting statistics.
 #
 # ------------------------------------------------------------------------------------------------------------------
 # Freeradius server configuration:
@@ -78,3 +81,6 @@ local:
  host: 'localhost'
  port: '18121'
  secret: 'adminsecret'
+#acct: False
+#proxy_auth: False
+#proxy_acct: False

--- a/conf.d/python.d/freeradius.conf
+++ b/conf.d/python.d/freeradius.conf
@@ -1,0 +1,80 @@
+# netdata python.d.plugin configuration for freeradius
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, freeradius also supports the following:
+#
+#     host: 'host'       # ip address or hostname
+#     port: 'port'       # port on which freeradius server listen (type = status)
+#     secret: 'secret'
+#
+# ------------------------------------------------------------------------------------------------------------------
+# Freeradius server configuration:
+# The configuration for the status server is automatically created in the sites-available directory.
+# By default, server is enabled and can be queried from every client. 
+# FreeRADIUS will only respond to status-server messages, if the status-server virtual server has been enabled.
+# To do this, create a link from the sites-enabled directory to the status file in the sites-available directory:
+#    cd sites-enabled
+#    ln -s ../sites-available/status status
+# and restart/reload your FREERADIUS server. 
+# ------------------------------------------------------------------------------------------------------------------
+#
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+
+local:
+ host: 'localhost'
+ port: '18121'
+ secret: 'adminsecret'

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -10,11 +10,11 @@ from subprocess import Popen, PIPE
 # default module values (can be overridden per job in `config`)
 priority = 60000
 retries = 60
-update_every = 10
-directories = ['/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/']
+update_every = 15
+directories = ['/bin/', '/usr/bin/', '/sbin', '/usr/sbin/']
 
 # charts order (can be overridden if you want less charts, or different order)
-ORDER = ['authentication', 'accounting']
+ORDER = ['authentication', 'accounting', 'proxy-auth', 'proxy-acct']
 
 CHARTS = {
     'authentication': {
@@ -32,21 +32,39 @@ CHARTS = {
             ['acct-dropped-requests', None, 'incremental'], ['acct-duplicate-requests', None, 'incremental'],
             ['acct-invalid-requests', None, 'incremental'], ['acct-malformed-requests', None, 'incremental'],
             ['acct-unknown-types', None, 'incremental']
+        ]},
+    'proxy-auth': {
+        'options': [None, "Proxy Authentication", "packets/s", 'Authentication', 'freerad.proxy.auth', 'line'],
+        'lines': [
+            ['proxy-access-accepts', None, 'incremental'], ['proxy-access-rejects', None, 'incremental'],
+            ['proxy-auth-dropped-requests', None, 'incremental'], ['proxy-auth-duplicate-requests', None, 'incremental'],
+            ['proxy-auth-invalid-requests', None, 'incremental'], ['proxy-auth-malformed-requests', None, 'incremental'],
+            ['proxy-auth-unknown-types', None, 'incremental']
+        ]},
+     'proxy-acct': {
+        'options': [None, "Proxy Accounting", "packets/s", 'Accounting', 'freerad.proxy.acct', 'line'],
+        'lines': [
+            ['proxy-accounting-requests', None, 'incremental'], ['proxy-accounting-responses', None, 'incremental'],
+            ['proxy-acct-dropped-requests', None, 'incremental'], ['proxy-acct-duplicate-requests', None, 'incremental'],
+            ['proxy-acct-invalid-requests', None, 'incremental'], ['proxy-acct-malformed-requests', None, 'incremental'],
+            ['proxy-acct-unknown-types', None, 'incremental']
         ]}
+
 }
 
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
-        self.order = ORDER
-        self.definitions = CHARTS
         self.host = self.configuration.get('host', 'localhost')
         self.port = self.configuration.get('port', '18121')
         self.secret = self.configuration.get('secret', 'adminsecret')
+        self.acct = self.configuration.get('acct', False)
+        self.proxy_auth = self.configuration.get('proxy_auth', False)
+        self.proxy_acct = self.configuration.get('proxy_acct', False)
         self.echo = [''.join([directory, 'echo']) for directory in directories if isfile(''.join([directory, 'echo']))][0]
         self.radclient = [''.join([directory, 'radclient']) for directory in directories if isfile(''.join([directory, 'radclient']))][0]
-        self.sub_echo = [self.echo, 'Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 3, Response-Packet-Type = Access-Accept']
+        self.sub_echo = [self.echo, 'Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 15, Response-Packet-Type = Access-Accept']
         self.sub_radclient = [self.radclient, '-r', '1', '-t', '1', ':'.join([self.host, self.port]), 'status', self.secret]
     
     def check(self):
@@ -54,7 +72,10 @@ class Service(SimpleService):
             self.error('Command radclient not found')
             return False
         if self._get_raw_data():
-            self.info('plugin was started succesfully')
+            chart_choice = [True, bool(self.acct), bool(self.proxy_auth), bool(self.proxy_acct)]
+            self.order = [chart for chart, choice in zip(ORDER, chart_choice) if choice]
+            self.definitions = {k:v for k, v in CHARTS.items() if k in self.order}
+            self.info('Plugin was started succesfully')
             return True
         else:
             self.error('Request returned no data. Is server alive? Used options: host {}, port {}, secret {}'.format(self.host, self.port, self.secret))
@@ -72,7 +93,7 @@ class Service(SimpleService):
     def _get_raw_data(self):
         """
         The following code is equivalent to
-        'echo "Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 3, Response-Packet-Type = Access-Accept" | radclient -t 1 -r 1 host:port status secret'
+        'echo "Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 15, Response-Packet-Type = Access-Accept" | radclient -t 1 -r 1 host:port status secret'
         :return: str
         """
         try:

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Description: freeradius netdata python.d module
+# Author: l2isbad
+
+from base import SimpleService
+from os.path import isfile
+from re import findall
+from subprocess import Popen, PIPE
+
+# default module values (can be overridden per job in `config`)
+priority = 60000
+retries = 60
+update_every = 10
+directories = ['/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/']
+
+# charts order (can be overridden if you want less charts, or different order)
+ORDER = ['authentication', 'accounting']
+
+CHARTS = {
+    'authentication': {
+        'options': [None, "Authentication", "packets/s", 'Authentication', 'freerad.auth', 'line'],
+        'lines': [
+            ['access-accepts', None, 'incremental'], ['access-rejects', None, 'incremental'],
+            ['auth-dropped-requests', None, 'incremental'], ['auth-duplicate-requests', None, 'incremental'],
+            ['auth-invalid-requests', None, 'incremental'], ['auth-malformed-requests', None, 'incremental'],
+            ['auth-unknown-types', None, 'incremental']
+        ]},
+     'accounting': {
+        'options': [None, "Accounting", "packets/s", 'Accounting', 'freerad.acct', 'line'],
+        'lines': [
+            ['accounting-requests', None, 'incremental'], ['accounting-responses', None, 'incremental'],
+            ['acct-dropped-requests', None, 'incremental'], ['acct-duplicate-requests', None, 'incremental'],
+            ['acct-invalid-requests', None, 'incremental'], ['acct-malformed-requests', None, 'incremental'],
+            ['acct-unknown-types', None, 'incremental']
+        ]}
+}
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.host = self.configuration.get('host', 'localhost')
+        self.port = self.configuration.get('port', '18121')
+        self.secret = self.configuration.get('secret', 'adminsecret')
+        self.echo = [''.join([directory, 'echo']) for directory in directories if isfile(''.join([directory, 'echo']))][0]
+        self.radclient = [''.join([directory, 'radclient']) for directory in directories if isfile(''.join([directory, 'radclient']))][0]
+        self.sub_echo = [self.echo, 'Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 3, Response-Packet-Type = Access-Accept']
+        self.sub_radclient = [self.radclient, '-r', '1', '-t', '1', ':'.join([self.host, self.port]), 'status', self.secret]
+    
+    def check(self):
+        if not all([self.echo, self.radclient]):
+            self.error('Command radclient not found')
+            return False
+        if self._get_raw_data():
+            self.info('plugin was started succesfully')
+            return True
+        else:
+            self.error('Request returned no data. Is server alive? Used options: host {}, port {}, secret {}'.format(self.host, self.port, self.secret))
+            return False
+        
+
+    def _get_data(self):
+        """
+        Format data received from shell command
+        :return: dict
+        """
+        result = self._get_raw_data()
+        return {k.lower():int(v) for k, v in findall(r'((?<=-)[AP][a-zA-Z-]+) = (\d+)', result)}
+        
+    def _get_raw_data(self):
+        """
+        The following code is equivalent to
+        'echo "Message-Authenticator = 0x00, FreeRADIUS-Statistics-Type = 3, Response-Packet-Type = Access-Accept" | radclient -t 1 -r 1 host:port status secret'
+        :return: str
+        """
+        try:
+            process_echo = Popen(self.sub_echo,  stdout=PIPE, shell=False)
+            process_rad = Popen(self.sub_radclient, stdin=process_echo.stdout, stdout=PIPE,  shell=False)
+            process_echo.stdout.close()
+            raw_result = process_rad.communicate()[0]
+        except Exception:
+            return None
+        else:
+            if process_rad.returncode is 0:
+                return raw_result.decode()
+            else:
+                return None

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -11,7 +11,7 @@ from subprocess import Popen, PIPE
 priority = 60000
 retries = 60
 update_every = 15
-directories = ['/bin/', '/usr/bin/', '/sbin', '/usr/sbin/']
+directories = ['/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/']
 
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['authentication', 'accounting', 'proxy-auth', 'proxy-acct']


### PR DESCRIPTION
Added freeradius plugin.
Data is collected via status server queries.

**Authentication counters:**
- access-accepts
- access-rejects
- auth-dropped-requests
- auth-duplicate-requests
- auth-invalid-requests
- auth-malformed-requests
- auth-unknown-types

**Accounting counters: [optional]**

- accounting-requests
- accounting-responses
- acct-dropped-requests
- acct-duplicate-requests
- acct-invalid-requests
- acct-malformed-requests
- acct-unknown-types

**Proxy authentication counters: [optional]**
- proxy-access-accepts
- proxy-access-rejects
- proxy-auth-dropped-requests
- proxy-auth-duplicate-requests
- proxy-auth-invalid-requests
- proxy-auth-malformed-requests
- proxy-auth-unknown-types

**Proxy accounting counters: [optional]**

- proxy-accounting-requests
- proxy-accounting-responses
- proxy-acct-dropped-requests
- proxy-acct-duplicate-requests
- proxy-acct-invalid-requests
- proxy-acct-malformed-requests
- proxy-acct-unknown-types
