### PR TITLE
macOS: get rid of compilation errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,9 @@ case "$host_os" in
 freebsd*)
 	build_target=freebsd
 	;;
+darwin*)
+	build_target=freebsd
+	;;
 *)
 	;;
 esac

--- a/src/common.c
+++ b/src/common.c
@@ -1,9 +1,12 @@
 #include "common.h"
 
-#ifdef __FreeBSD__
+#ifdef __APPLE__
+#define INHERIT_NONE 0
+#endif /* __APPLE__ */
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #    define O_NOATIME     0
 #    define MADV_DONTFORK INHERIT_NONE
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
 
 char *global_host_prefix = "";
 int enable_ksm = 1;
@@ -1027,9 +1030,13 @@ int fd_is_valid(int fd) {
 pid_t gettid(void) {
 #ifdef __FreeBSD__
     return (pid_t)pthread_getthreadid_np();
+#elif defined(__APPLE__)
+    uint64_t curthreadid;
+    pthread_threadid_np(NULL, &curthreadid);
+    return (pid_t)curthreadid;
 #else
     return (pid_t)syscall(SYS_gettid);
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__, __APPLE__*/
 }
 
 char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len) {

--- a/src/common.h
+++ b/src/common.h
@@ -20,9 +20,9 @@
 
 #else /* !defined(ENABLE_JEMALLOC) && !defined(ENABLE_TCMALLOC) */
 
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
 #include <malloc.h>
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__ */
 
 #endif
 
@@ -54,9 +54,9 @@
 #include <signal.h>
 #include <syslog.h>
 #include <sys/mman.h>
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
 #include <sys/prctl.h>
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -116,11 +116,11 @@
 #include "plugin_checks.h"
 #include "plugin_idlejitter.h"
 #include "plugin_nfacct.h"
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
 #include "plugin_proc.h"
 #else
 #include "plugin_freebsd.h"
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
 #include "plugin_tc.h"
 #include "plugins_d.h"
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -117,12 +117,20 @@ int become_user(const char *username, int pid_fd)
         ngroups = 0;
     }
 
+#ifdef __APPLE__
+    if(setregid(gid, gid) != 0) {
+#else
     if(setresgid(gid, gid, gid) != 0) {
+#endif /* __APPLE__ */
         error("Cannot switch to user's %s group (gid: %u).", username, gid);
         return -1;
     }
 
+#ifdef __APPLE__
+    if(setreuid(uid, uid) != 0) {
+#else
     if(setresuid(uid, uid, uid) != 0) {
+#endif /* __APPLE__ */
         error("Cannot switch to user %s (uid: %u).", username, uid);
         return -1;
     }

--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#ifndef __APPLE__
 // NEEDED BY: struct vmtotal, struct vmmeter
 #include <sys/vmmeter.h>
 // NEEDED BY: struct devstat
@@ -18,6 +19,7 @@
 #define _IFI_OQDROPS // It is for FreeNAS only. Most probably in future releases of FreeNAS it will be removed
 #include <net/if.h>
 #include <ifaddrs.h>
+#endif /* __APPLE__ */
 // NEEDED BY: do_disk_io
 #define RRD_TYPE_DISK "disk"
 
@@ -71,6 +73,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
     static usec_t last_loadavg_usec = 0;
     struct loadavg sysload;
 
+#ifndef __APPLE__
     // NEEDED BY: do_cpu, do_cpu_cores
     long cp_time[CPUSTATES];
 
@@ -177,6 +180,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
+#endif /* __APPLE__ */
     if (last_loadavg_usec <= dt) {
         if (likely(do_loadavg)) {
             if (unlikely(GETSYSCTL("vm.loadavg", sysload))) {
@@ -203,6 +207,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
         last_loadavg_usec = st->update_every * USEC_PER_SEC;
     }
     else last_loadavg_usec -= dt;
+#ifndef __APPLE__
 
     // --------------------------------------------------------------------
 
@@ -1188,6 +1193,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
             freeifaddrs(ifap);
         }
     }
+#endif /* __APPLE__ */
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -45,11 +45,11 @@ struct netdata_static_thread {
 
     {"tc",                 "plugins",   "tc",         1, NULL, NULL, tc_main},
     {"idlejitter",         "plugins",   "idlejitter", 1, NULL, NULL, cpuidlejitter_main},
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
     {"proc",               "plugins",   "proc",       1, NULL, NULL, proc_main},
 #else
     {"freebsd",            "plugins",   "freebsd",    1, NULL, NULL, freebsd_main},
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
     {"cgroups",            "plugins",   "cgroups",    1, NULL, NULL, cgroups_main},
     {"check",              "plugins",   "checks",     0, NULL, NULL, checks_main},
     {"backends",            NULL,       NULL,         1, NULL, NULL, backends_main},
@@ -467,9 +467,9 @@ int main(int argc, char **argv)
             if(setrlimit(RLIMIT_CORE, &rl) != 0)
                 error("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
 
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
             prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
         }
 
         // --------------------------------------------------------------------
@@ -644,9 +644,9 @@ int main(int argc, char **argv)
         struct rlimit rl = { RLIM_INFINITY, RLIM_INFINITY };
         if(setrlimit(RLIMIT_CORE, &rl) != 0)
             error("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
-#ifndef __FreeBSD__
+#if !(defined(__FreeBSD__) || defined(__APPLE__))
         prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __APPLE__*/
     }
 #endif /* NETDATA_INTERNAL_CHECKS */
 

--- a/src/plugin_freebsd.h
+++ b/src/plugin_freebsd.h
@@ -1,6 +1,8 @@
 #ifndef NETDATA_PLUGIN_FREEBSD_H
 #define NETDATA_PLUGIN_FREEBSD_H 1
 
+#include <sys/sysctl.h>
+
 #define GETSYSCTL(name, var) getsysctl(name, &(var), sizeof(var))
 
 void *freebsd_main(void *ptr);

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -414,7 +414,11 @@ int mysendfile(struct web_client *w, char *filename)
     w->wait_send = 0;
     buffer_flush(w->response.data);
     w->response.rlen = stat.st_size;
+#ifdef __APPLE__
+    w->response.data->date = stat.st_mtimespec.tv_sec;
+#else
     w->response.data->date = stat.st_mtim.tv_sec;
+#endif /* __APPLE__ */
     buffer_cacheable(w->response.data);
 
     return 200;


### PR DESCRIPTION
These changes are safe for Linux and FreeBSD. I think they can be merged.

I can build and run `netdata` on macOS. Right now it shows only three charts: system load averages, jitter and one netdata specific. There are a lot of differences in sysctls and kernel structures between FreeBSD and macOS so more time is needed to resolve them.

But there is an issue. I've spent almost two days trying to solve it yet without any results. After the first start `netdata` runs well. But after restarting it randomly gets stuck in RRD related functions with `EXC_BAD_ACCESS` in `pthread_rwlock_init`.

@ktsaou, probably you have a quick idea where to search for a bug, don't you?

```
(lldb) thread select 2
* thread #2: tid = 0x955b, 0x00007fffa917b182 libsystem_pthread.dylib`pthread_rwlock_init + 87, stop reason = EXC_BAD_ACCESS (code=1, address=0x104f188d8)
    frame #0: 0x00007fffa917b182 libsystem_pthread.dylib`pthread_rwlock_init + 87
libsystem_pthread.dylib`pthread_rwlock_init:
->  0x7fffa917b182 <+87>: andl   (%rax), %edx
    0x7fffa917b184 <+89>: movl   $0x10, %eax
    0x7fffa917b189 <+94>: cmpl   (%rcx), %edx
    0x7fffa917b18b <+96>: jne    0x7fffa917b1a0            ; <+117>
(lldb) thread backtrace
* thread #2: tid = 0x955b, 0x00007fffa917b182 libsystem_pthread.dylib`pthread_rwlock_init + 87, stop reason = EXC_BAD_ACCESS (code=1, address=0x104f188d8)
  * frame #0: 0x00007fffa917b182 libsystem_pthread.dylib`pthread_rwlock_init + 87
    frame #1: 0x0000000101304f8e netdata`avl_init_lock(t=0x00000001013eb8b0, compar=(netdata`rrddim_compare at rrd.c:219)) + 46 at avl.c:345
    frame #2: 0x000000010134607e netdata`rrdset_create(type="system", id="idlejitter", name=0x0000000000000000, family="processes", context=0x0000000000000000, title="CPU Idle Jitter", units="microseconds lost/s", priority=9999, update_every=1, chart_type=0) + 3054 at rrd.c:601
    frame #3: 0x000000010132776f netdata`cpuidlejitter_main(ptr=0x0000000000000000) + 463 at plugin_idlejitter.c:25
    frame #4: 0x00007fffa917aabb libsystem_pthread.dylib`_pthread_body + 180
    frame #5: 0x00007fffa917aa07 libsystem_pthread.dylib`_pthread_start + 286
    frame #6: 0x00007fffa917a231 libsystem_pthread.dylib`thread_start + 13
(lldb) frame variable
(lldb) frame select 2
frame #2: 0x000000010134607e netdata`rrdset_create(type="system", id="idlejitter", name=0x0000000000000000, family="processes", context=0x0000000000000000, title="CPU Idle Jitter", units="microseconds lost/s", priority=9999, update_every=1, chart_type=0) + 3054 at rrd.c:601
   598      st->gap_when_lost_iterations_above = (int) (
   599              config_get_number(st->id, "gap when lost iterations above", RRD_DEFAULT_GAP_INTERPOLATIONS) + 2);
   600
-> 601      avl_init_lock(&st->dimensions_index, rrddim_compare);
   602      avl_init_lock(&st->variables_root_index, rrdvar_compare);
   603
   604      pthread_rwlock_init(&st->rwlock, NULL);
(lldb) frame variable
(const char *) type = 0x000000010136e169 "system"
(const char *) id = 0x0000000101372dbb "idlejitter"
(const char *) name = 0x0000000000000000
(const char *) family = 0x00000001013740f5 "processes"
(const char *) context = 0x0000000000000000
(const char *) title = 0x00000001013740ff "CPU Idle Jitter"
(const char *) units = 0x000000010137410f "microseconds lost/s"
(long) priority = 9999
(int) update_every = 1
(int) chart_type = 0
(char [401]) fullid = "system.idlejitter"
(char [1025]) fullfilename = "/Users/volodymyr/opt/netdata/var/cache/netdata/system.idlejitter/main.db"
(RRDSET *) st = 0x00000001013eb000
(long) rentries = 3600
(long) entries = 3600
(int) enabled = 1
(unsigned long) size = 2448
(char *) cache_dir = 0x00007febf8628930 "/Users/volodymyr/opt/netdata/var/cache/netdata/system.idlejitter"
(lldb)
```