### PR TITLE
Rpm packaging

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -41,8 +41,18 @@ BuildRequires:	pkgconfig
 BuildRequires:	xz
 BuildRequires:	zlib-devel
 BuildRequires:	libuuid-devel
-Requires: zlib
-Requires: libuuid
+Requires:	zlib
+Requires:	libuuid
+Requires(post): libcap
+Recommends:	curl
+Recommends:	iproute-tc
+Recommends:	lm_sensors
+Recommends:	nmap-ncat
+Recommends:	nodejs
+Recommends:	python
+Recommends:	PyYAML
+Recommends:	python2-PyMySQL
+Recommends:	python2-psycopg2
 
 # Packages can be found in the EPEL repo
 %if %{with nfacct}
@@ -129,8 +139,9 @@ setcap cap_dac_read,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
 %pre
 # Add the "netdata" user
 getent group netdata >/dev/null || groupadd -r netdata
+getent group docker >/dev/null || groupadd -r docker
 getent passwd netdata >/dev/null || \
-  useradd -r -g netdata -s /sbin/nologin \
+  useradd -r -g netdata -G docker -s /sbin/nologin \
     -d %{contentdir} -c "netdata" netdata
 exit 0
 
@@ -173,12 +184,14 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/%{name}/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/charts.d/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/health.d/*.conf
-%config(noreplace) %{_sysconfdir}/%{name}/node.d/*.conf
+#%%config(noreplace) %{_sysconfdir}/%{name}/node.d/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/python.d/*.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 
 # To be eventually moved to %%_defaultdocdir
 %{_sysconfdir}/%{name}/node.d/*.md
+
+%caps(cap_dac_read_search,cap_sys_ptrace=ep) %{_libexecdir}/%{name}/plugins.d/apps.plugin
 
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -35,6 +35,8 @@ Group:		Applications/System
 Source0:	http://firehol.org/download/netdata/releases/v@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.xz
 URL:		http://my-netdata.io/
 %distro_buildrequires
+BuildRequires:	/usr/bin/autoconf
+BuildRequires:	/usr/bin/automake
 BuildRequires:	pkgconfig
 BuildRequires:	xz
 BuildRequires:	zlib-devel
@@ -79,6 +81,7 @@ happened, on your systems and applications.
 %setup -q
 
 %build
+./autogen.sh
 %configure \
 	--with-zlib \
 	--with-math \
@@ -115,6 +118,7 @@ install -m755 system/netdata-init-d \
 
 %post
 %distro_post
+setcap cap_dac_read,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin || chmod 1755 /usr/libexec/netdata/plugins.d/apps.plugin
 
 %preun
 %distro_preun
@@ -131,6 +135,7 @@ getent passwd netdata >/dev/null || \
 exit 0
 
 %post
+setcap cap_dac_read,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin || chmod 1755 /usr/libexec/netdata/plugins.d/apps.plugin
 # Register the netdata service
 /sbin/chkconfig --add netdata
 # Only gets run on initial install (not upgrades or uninstalls)
@@ -160,16 +165,20 @@ exit 0
 rm -rf $RPM_BUILD_ROOT
 
 %files
+%doc README.md
 %defattr(-,root,root)
 
 %dir %{_sysconfdir}/%{name}
 
 %config(noreplace) %{_sysconfdir}/%{name}/*.conf
-#%config(noreplace) %{_sysconfdir}/%{name}/charts.d/*.conf
+%config(noreplace) %{_sysconfdir}/%{name}/charts.d/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/health.d/*.conf
-#%config(noreplace) %{_sysconfdir}/%{name}/node.d/*.conf
+%config(noreplace) %{_sysconfdir}/%{name}/node.d/*.conf
 %config(noreplace) %{_sysconfdir}/%{name}/python.d/*.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
+
+# To be eventually moved to %%_defaultdocdir
+%{_sysconfdir}/%{name}/node.d/*.md
 
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}


### PR DESCRIPTION
Referencing desired package state from #1302 

- [x] Create the `netdata` user and group
- [x] If the `docker` group is available, add `netdata` user to the `docker` group
- [x] Install the netdata files and make sure they have the proper permissions (make also sure `/var/lib/netdata` and `/var/cache/netdata` are created with the correct permissions).
- [x] Make sure `setcap` is used on `apps.plugin` (or setuid to root if `setcap` does not work)
- [x] Install the proper start-up file
- [x] Install the logrotate configuration
- [x] Install an empty `/etc/netdata/netdata.conf`
- [x] Soft packages runtime dependencies (curl, python, nodejs, etc)
- [x] Preservation of configuration files with `%config(noreplace)`
- [x] `/var/lib/netdata` and `/var/cache/netdata` are created

@ktsau this will create the `docker` group if it does not already exist, and add the `netdata` user to it.
Can you let me know what capabilities `apps.plugin` will need from `setcap` so I can add that?
Let me know if anything is missing from the above task list and I will add it.