### PR TITLE
Fail2ban plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -29,6 +29,7 @@ dist_pythonconfig_DATA = \
     python.d/dovecot.conf \
     python.d/example.conf \
     python.d/exim.conf \
+    python.d/fail2ban.conf \
     python.d/freeradius.conf \
     python.d/hddtemp.conf \
     python.d/ipfs.conf \

--- a/conf.d/python.d/fail2ban.conf
+++ b/conf.d/python.d/fail2ban.conf
@@ -1,0 +1,77 @@
+# netdata python.d.plugin configuration for fail2ban
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, fail2ban also supports the following:
+#
+#     log_path: 'path to fail2ban.log'			        # Default: '/var/log/fail2ban.log'
+#     conf_path: 'path to jail.local/jail.conf'			# Default: '/etc/fail2ban/jail.local'
+#     exclude: 'jails you want to exclude from autodetection'	# Default: '[]' empty list
+#------------------------------------------------------------------------------------------------------------------
+# IMPORTANT Information
+#
+# fail2ban.log file MUST BE readable by netdata.
+# A good idea is to do this by adding the 
+# # create 0640 root netdata
+# to fail2ban conf at logrotate.d
+#
+# ------------------------------------------------------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+
+#local:
+# log_path: '/var/log/fail2ban.log'
+# conf_path: '/etc/fail2ban/jail.local'
+# exclude: 'dropbear apache'

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -14,6 +14,7 @@ dist_python_SCRIPTS = \
     dovecot.chart.py \
     example.chart.py \
     exim.chart.py \
+    fail2ban.chart.py \
     freeradius.chart.py \
     hddtemp.chart.py \
     ipfs.chart.py \

--- a/python.d/fail2ban.chart.py
+++ b/python.d/fail2ban.chart.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Description: fail2ban log netdata python.d module
+# Author: l2isbad
+
+from base import LogService
+from re import compile
+try:
+    from itertools import filterfalse
+except ImportError:
+    from itertools import ifilterfalse as filterfalse
+from os import access as is_accessible, R_OK
+
+priority = 60000
+retries = 60
+regex = compile(r'([A-Za-z-]+\]) enabled = ([a-z]+)')
+
+ORDER = ['jails_group']
+
+
+class Service(LogService):
+    def __init__(self, configuration=None, name=None):
+        LogService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.log_path = self.configuration.get('log_path', '/var/log/fail2ban.log')
+        self.conf_path = self.configuration.get('conf_path', '/etc/fail2ban/jail.local')
+        self.default_jails = ['ssh']
+        try:
+            self.exclude = self.configuration['exclude'].split()
+        except (KeyError, AttributeError):
+            self.exclude = []
+        
+
+    def _get_data(self):
+        """
+        Parse new log lines
+        :return: dict
+        """
+
+        # If _get_raw_data returns empty list (no new lines in log file) we will send to Netdata this
+        self.data = {jail: 0 for jail in self.jails_list}
+        
+        try:
+            raw = self._get_raw_data()
+            if raw is None:
+                return None
+            elif not raw:
+                return self.data
+        except (ValueError, AttributeError):
+            return None
+
+        # Fail2ban logs looks like
+        # 2016-12-25 12:36:04,711 fail2ban.actions[2455]: WARNING [ssh] Ban 178.156.32.231
+        self.data = dict(
+            zip(
+                self.jails_list,
+                [len(list(filterfalse(lambda line: (jail + '] Ban') not in line, raw))) for jail in self.jails_list]
+            ))
+
+        return self.data
+
+    def check(self):
+            
+        # Check "log_path" is accessible.
+        # If NOT STOP plugin
+        if not is_accessible(self.log_path, R_OK):
+            self.error('Cannot access file %s' % (self.log_path))
+            return False
+
+        # Check "conf_path" is accessible.
+        # If "conf_path" is accesible try to parse it to find enabled jails
+        if is_accessible(self.conf_path, R_OK):
+            with open(self.conf_path, 'rt') as jails_conf:
+                jails_list = regex.findall(' '.join(jails_conf.read().split()))
+            self.jails_list = [jail[:-1] for jail, status in jails_list if status == 'true']
+        else:
+            self.jails_list = []
+            self.error('Cannot access jail.local file %s.' % (self.conf_path))
+        
+        # If for some reason parse failed we still can START with default jails_list.
+        self.jails_list = [jail for jail in self.jails_list if jail not in self.exclude]\
+                                              if self.jails_list else self.default_jails
+        self.create_dimensions()
+        self.info('Plugin succefully started. Jails: %s' % (self.jails_list))
+        return True
+
+    def create_dimensions(self):
+        self.definitions = {'jails_group':
+                                {'options':
+                                     [None, "Jails ban statistics", "bans/s", 'Jails', 'jail.ban', 'line'], 'lines': []}}
+        for jail in self.jails_list:
+            self.definitions['jails_group']['lines'].append([jail, jail, 'absolute'])


### PR DESCRIPTION
One more to security section.
Simple plugin to monitor fail2ban logs
It parses conf file to find all enabled jails then parses log file to count all bans for all active jails
You can exclude certain jails via plugin conf file