### PR TITLE
detect if running inside a container to avoid using setcap for apps.plugin

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -839,6 +839,15 @@ if [ ${UID} -eq 0 ]
         then
         run setcap cap_dac_read_search,cap_sys_ptrace+ep "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin"
         setcap_ret=$?
+
+        if [ ${setcap_ret} -eq 0 ]
+            then
+            # if we managed to setcap
+            # but we fail to execute apps.plugin
+            # trigger setuid to root
+            "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin" -v >/dev/null 2>&1
+            setcap_ret=$?
+        fi
     fi
 
     if [ ${setcap_ret} -ne 0 ]

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2680,6 +2680,11 @@ static void parse_args(int argc, char **argv)
             }
         }
 
+        if(strcmp("version", argv[i]) == 0 || strcmp("-v", argv[i]) == 0) {
+            printf("apps.plugin %s\n", VERSION);
+            exit(0);
+        }
+
         if(strcmp("debug", argv[i]) == 0) {
             debug = 1;
             // debug_flags = 0xffffffff;
@@ -2728,7 +2733,7 @@ static void parse_args(int argc, char **argv)
 
         if(strcmp("-h", argv[i]) == 0 || strcmp("--help", argv[i]) == 0) {
             fprintf(stderr,
-                    "apps.plugin\n"
+                    "apps.plugin %s\n"
                     "(C) 2016 Costa Tsaousis"
                     "GPL v3+\n"
                     "This program is a data collector plugin for netdata.\n"
@@ -2755,6 +2760,10 @@ static void parse_args(int argc, char **argv)
                     "NAME              read apps_NAME.conf instead of\n"
                     "                  apps_groups.conf\n"
                     "                  (default NAME=groups)\n"
+                    "\n"
+                    "version           print program version and exit\n"
+                    "\n"
+                    , VERSION
             );
             exit(1);
         }


### PR DESCRIPTION
netdata-installer normally uses `setcap` to set capabilities on `apps.plugin`.

However, when running in containers, `setcap` completes reporting it has set the required capabilities, but `apps.plugin` fails to start.

To work-around this issue, `netdata-installer` can now detect if it is running inside a container and setuid to root `apps.plugin`.

This is only used if container detection works.

fixes #1331