### PR TITLE
Extend displayed disk types on FreeBSD

### DIFF
--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -516,7 +516,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
                 collected_number total_disk_writes = 0;
 
                 for (i = 0; i < numdevs; i++) {
-                    if ((dstat[i].device_type == (DEVSTAT_TYPE_IF_SCSI | DEVSTAT_TYPE_DIRECT)) || (dstat[i].device_type == (DEVSTAT_TYPE_IF_IDE | DEVSTAT_TYPE_DIRECT))) {
+                    if (((dstat[i].device_type & DEVSTAT_TYPE_MASK) == DEVSTAT_TYPE_DIRECT) || ((dstat[i].device_type & DEVSTAT_TYPE_MASK) == DEVSTAT_TYPE_STORARRAY)) {
 
                         // --------------------------------------------------------------------
 


### PR DESCRIPTION
Direct and storage array devices with any interfaces and correspondent pass-through devices are now displayed.

These types of devices are filtered out:
```
	DEVSTAT_TYPE_SEQUENTIAL
	DEVSTAT_TYPE_PRINTER
	DEVSTAT_TYPE_PROCESSOR
	DEVSTAT_TYPE_WORM
	DEVSTAT_TYPE_CDROM
	DEVSTAT_TYPE_SCANNER
	DEVSTAT_TYPE_OPTICAL
	DEVSTAT_TYPE_CHANGER
	DEVSTAT_TYPE_COMM	
	DEVSTAT_TYPE_ASC0
	DEVSTAT_TYPE_ASC1
	DEVSTAT_TYPE_ENCLOSURE
	DEVSTAT_TYPE_FLOPPY
```
@ktsaou if you think some of them are useful and have to be displayed in disk charts i'll add them.

The commit should fix an issue you mentioned in #1474:
> 2. disk I/O is always zero (I did quite some work there, and it did not show anything but zero).