### PR TITLE
fix cache misses chart

### DIFF
--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -142,7 +142,7 @@ CHARTS = {
     'thread_cache_misses': {
         'options': [None, 'mysql Threads Cache Misses', 'misses', 'threads', 'mysql.thread_cache_misses', 'area'],
         'lines': [
-            ["Thread_cache_misses", "misses", "absolute", 1, 10000]
+            ["Thread_cache_misses", "misses", "absolute", 1, 100]
         ]},
     'innodb_io': {
         'options': [None, 'mysql InnoDB I/O Bandwidth', 'kilobytes/s', 'innodb', 'mysql.innodb_io', 'area'],
@@ -473,7 +473,7 @@ class Service(SimpleService):
 
         # do calculations
         try:
-            data["Thread_cache_misses"] = round(float(data["Threads_created"]) * 10000 / float(data["Connections"]) * 10000)
+            data["Thread_cache_misses"] = round(float(data["Threads_created"]) / float(data["Connections"]) * 10000)
         except:
             data["Thread_cache_misses"] = None
 

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -142,7 +142,7 @@ CHARTS = {
     'thread_cache_misses': {
         'options': [None, 'mysql Threads Cache Misses', 'misses', 'threads', 'mysql.thread_cache_misses', 'area'],
         'lines': [
-            ["Thread_cache_misses", "misses", "absolute", 1, 100]
+            ["Thread_cache_misses", "misses", "absolute", 1, 10000]
         ]},
     'innodb_io': {
         'options': [None, 'mysql InnoDB I/O Bandwidth', 'kilobytes/s', 'innodb', 'mysql.innodb_io', 'area'],
@@ -473,7 +473,7 @@ class Service(SimpleService):
 
         # do calculations
         try:
-            data["Thread_cache_misses"] = int(data["Threads_created"] * 10000 / float(data["Connections"]))
+            data["Thread_cache_misses"] = round(float(data["Threads_created"]) * 10000 / float(data["Connections"]) * 10000)
         except:
             data["Thread_cache_misses"] = None
 


### PR DESCRIPTION
Cache misses chart not working now 

```
In [50]: type(data["Threads_created"])
Out[50]: str
```
```
In [48]: int(data["Threads_created"] * 10000 / float(data["Connections"]))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-48-c48db05e2d88> in <module>()
----> 1 int(data["Threads_created"] * 10000 / float(data["Connections"]))

TypeError: unsupported operand type(s) for /: 'str' and 'float'
```

I'm not quite sure about calculation of cache miss rate. 
If I add * 10000 in formula then i must to change divisor to 10000  in charts too. Am i right?
