### PR TITLE
Mdstat plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -34,6 +34,7 @@ dist_pythonconfig_DATA = \
     python.d/hddtemp.conf \
     python.d/ipfs.conf \
     python.d/isc_dhcpd.conf \
+    python.d/mdstat.conf \
     python.d/memcached.conf \
     python.d/mysql.conf \
     python.d/nginx.conf \
@@ -57,6 +58,7 @@ dist_healthconfig_DATA = \
     health.d/disks.conf \
     health.d/entropy.conf \
     health.d/ipc.conf \
+    health.d/mdstat.conf \
     health.d/memcached.conf \
     health.d/mysql.conf \
     health.d/named.conf \

--- a/conf.d/health.d/mdstat.conf
+++ b/conf.d/health.d/mdstat.conf
@@ -1,0 +1,18 @@
+template: mdstat_disks
+      on: md.disks
+   units: active devices
+   every: 1s
+    calc: $total - $inuse
+    crit: $this > 0
+    info: Array is degraded!
+      to: sysadmin
+
+template: mdstat_last_collected
+      on: md.disks
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 1s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+    info: number of seconds since the last successful data collection
+      to: sysadmin

--- a/conf.d/python.d/mdstat.conf
+++ b/conf.d/python.d/mdstat.conf
@@ -1,0 +1,26 @@
+# netdata python.d.plugin configuration for mdstat
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -19,6 +19,7 @@ dist_python_SCRIPTS = \
     hddtemp.chart.py \
     ipfs.chart.py \
     isc_dhcpd.chart.py \
+    mdstat.chart.py \
     memcached.chart.py \
     mysql.chart.py \
     nginx.chart.py \

--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Description: mdstat netdata python.d module
+# Author: l2isbad
+
+from base import SimpleService
+from re import compile
+priority = 60000
+retries = 60
+update_every = 1
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ['agr_health']
+        self.definitions = {'agr_health':
+                                {'options':
+                                     [None, 'Faulty devices in MD', 'failed disks', 'health', 'md.health', 'line'],
+                                 'lines': []}}
+        self.proc_mdstat = '/proc/mdstat'
+        self.regex_disks = compile(r'((?<= )[md_]+[0-9]+(?= : active)).*?((?<= \[)[0-9]+)/([0-9]+(?=\] ))')
+
+    def check(self):
+        raw_data = self._get_raw_data()
+        if not raw_data:
+            self.error('Cant read mdstat data from %s' % (self.proc_mdstat))
+            return False
+        else:
+            md_list = [md[0] for md in self.regex_disks.findall(raw_data)]
+            for md in md_list:
+                self.order.append(md)
+                self.definitions['agr_health']['lines'].append([''.join([md, '_health']), md, 'absolute'])
+                self.definitions[md] = {'options':
+                                            [None, 'MD disks stats', 'disks', md, 'md.stats', 'stacked'],
+                                        'lines': [[''.join([md, '_total']), 'total', 'absolute'],
+                                                  [''.join([md, '_inuse']), 'inuse', 'absolute']]}
+            self.info('Plugin was started successfully. MDs to monitor %s' % (md_list))
+
+            return True
+
+    def _get_raw_data(self):
+        """
+        Read data from /proc/mdstat
+        :return: str
+        """
+        try:
+            with open(self.proc_mdstat, 'rt') as proc_mdstat:
+                raw_result = proc_mdstat.read()
+        except Exception:
+            return None
+        else:
+            raw_result = ' '.join(raw_result.split())
+            return raw_result
+
+    def _get_data(self):
+        """
+        Parse data from _get_raw_data()
+        :return: dict
+        """
+        raw_mdstat = self._get_raw_data()
+        mdstat = self.regex_disks.findall(raw_mdstat)
+        to_netdata = {}
+
+        for md in mdstat:
+            to_netdata[''.join([md[0], '_total'])] = int(md[1])
+            to_netdata[''.join([md[0], '_inuse'])] = int(md[2])
+            to_netdata[''.join([md[0], '_health'])] = int(md[1]) - int(md[2])
+
+        return to_netdata

--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -33,15 +33,16 @@ class Service(SimpleService):
                 self.order.append(''.join([md, '_status']))
                 self.definitions['agr_health']['lines'].append([''.join([md, '_health']), md, 'absolute'])
                 self.definitions[md] = {'options':
-                                            [None, 'MD disks stats', 'disks', md, 'md.stats', 'stacked'],
+                                            [None, 'MD disks stats', 'disks', md, 'md.disks', 'stacked'],
                                         'lines': [[''.join([md, '_total']), 'total', 'absolute'],
                                                   [''.join([md, '_inuse']), 'inuse', 'absolute']]}
                 self.definitions[''.join([md, '_status'])] = {'options':
                                             [None, 'MD current status', 'percent', md, 'md.status', 'line'],
-                                        'lines': [[''.join([md, '_resync']), 'resync', 'absolute'],
-                                                  [''.join([md, '_recovery']), 'recovery', 'absolute'],
-                                                  [''.join([md, '_check']), 'check', 'absolute']]}
+                                        'lines': [[''.join([md, '_resync']), 'resync', 'absolute', 1, 100],
+                                                  [''.join([md, '_recovery']), 'recovery', 'absolute', 1, 100],
+                                                  [''.join([md, '_check']), 'check', 'absolute', 1, 100]]}
             self.info('Plugin was started successfully. MDs to monitor %s' % (md_list))
+            to_netdata = {}
 
             return True
 
@@ -78,6 +79,6 @@ class Service(SimpleService):
             to_netdata[''.join([md[0], '_recovery'])] = 0
         
         for md in mdstat_status:
-            to_netdata[''.join([md[0], '_' + md[2]])] = round(float(md[3]))
+            to_netdata[''.join([md[0], '_' + md[2]])] = round(float(md[3]) * 100)
 
         return to_netdata

--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -19,6 +19,7 @@ class Service(SimpleService):
                                  'lines': []}}
         self.proc_mdstat = '/proc/mdstat'
         self.regex_disks = compile(r'((?<=\ )[a-zA-Z_0-9]+(?= : active)).*?((?<= \[)[0-9]+)/([0-9]+(?=\] ))')
+        self.regex_status = compile(r'([a-zA-Z_0-9]+)( : active)[^:]*?([a-z]+) = ([0-9.]+(?=%))')
 
     def check(self):
         raw_data = self._get_raw_data()
@@ -29,11 +30,17 @@ class Service(SimpleService):
             md_list = [md[0] for md in self.regex_disks.findall(raw_data)]
             for md in md_list:
                 self.order.append(md)
+                self.order.append(''.join([md, '_status']))
                 self.definitions['agr_health']['lines'].append([''.join([md, '_health']), md, 'absolute'])
                 self.definitions[md] = {'options':
                                             [None, 'MD disks stats', 'disks', md, 'md.stats', 'stacked'],
                                         'lines': [[''.join([md, '_total']), 'total', 'absolute'],
                                                   [''.join([md, '_inuse']), 'inuse', 'absolute']]}
+                self.definitions[''.join([md, '_status'])] = {'options':
+                                            [None, 'MD current status', 'percent', md, 'md.status', 'line'],
+                                        'lines': [[''.join([md, '_resync']), 'resync', 'absolute'],
+                                                  [''.join([md, '_recovery']), 'recovery', 'absolute'],
+                                                  [''.join([md, '_check']), 'check', 'absolute']]}
             self.info('Plugin was started successfully. MDs to monitor %s' % (md_list))
 
             return True
@@ -58,12 +65,19 @@ class Service(SimpleService):
         :return: dict
         """
         raw_mdstat = self._get_raw_data()
-        mdstat = self.regex_disks.findall(raw_mdstat)
+        mdstat_disks = self.regex_disks.findall(raw_mdstat)
+        mdstat_status = self.regex_status.findall(raw_mdstat)
         to_netdata = {}
 
-        for md in mdstat:
+        for md in mdstat_disks:
             to_netdata[''.join([md[0], '_total'])] = int(md[1])
             to_netdata[''.join([md[0], '_inuse'])] = int(md[2])
             to_netdata[''.join([md[0], '_health'])] = int(md[1]) - int(md[2])
+            to_netdata[''.join([md[0], '_check'])] = 0
+            to_netdata[''.join([md[0], '_resync'])] = 0
+            to_netdata[''.join([md[0], '_recovery'])] = 0
+        
+        for md in mdstat_status:
+            to_netdata[''.join([md[0], '_' + md[2]])] = round(float(md[3]))
 
         return to_netdata

--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -18,7 +18,7 @@ class Service(SimpleService):
                                      [None, 'Faulty devices in MD', 'failed disks', 'health', 'md.health', 'line'],
                                  'lines': []}}
         self.proc_mdstat = '/proc/mdstat'
-        self.regex_disks = compile(r'((?<= )[md_]+[0-9]+(?= : active)).*?((?<= \[)[0-9]+)/([0-9]+(?=\] ))')
+        self.regex_disks = compile(r'((?<=\ )[a-zA-Z_0-9]+(?= : active)).*?((?<= \[)[0-9]+)/([0-9]+(?=\] ))')
 
     def check(self):
         raw_data = self._get_raw_data()


### PR DESCRIPTION
Draw all informatiom from /proc/mdstat

Charts
1. Faulty devices in MD (all arrays in one chart).

For every MD:
1. MD disks stats. Dimensions: **total** devices in array. **in use** devices in array

      1464725760 blocks level 5, 64k chunk, algorithm 2 [**6/5**] [UUUUU_]
2. MD current status. If **resync/check/recovery** is running it shows  progress %

      [==>..................]  recovery = **12.6**% (37043392/292945152) finish=234.5min speed=73440K/sec
3. MD operation status. If **resync/check/recovery** is running it shows : a) finish in min b) speed

      [==>..................]  recovery = 12.6% (37043392/292945152) finish=**234.5**min speed=**73440**K/sec

And two alarms