### PR TITLE
Bind rndc plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -25,6 +25,7 @@ pythonconfigdir=$(configdir)/python.d
 dist_pythonconfig_DATA = \
     python.d/apache.conf \
     python.d/apache_cache.conf \
+    python.d/bind_rndc.conf \
     python.d/cpufreq.conf \
     python.d/dovecot.conf \
     python.d/example.conf \
@@ -54,6 +55,7 @@ healthconfigdir=$(configdir)/health.d
 dist_healthconfig_DATA = \
     health.d/apache.conf \
     health.d/backend.conf \
+    health.d/bind_rndc.conf \
     health.d/cpu.conf \
     health.d/disks.conf \
     health.d/entropy.conf \

--- a/conf.d/health.d/bind_rndc.conf
+++ b/conf.d/health.d/bind_rndc.conf
@@ -1,0 +1,9 @@
+ alarm: bind_rndc_stats_file_size
+      on: bind_rndc.stats_size
+   units: megabytes
+   every: 60
+    calc: $stats_size
+    warn: $this > 512
+    crit: $this > 1024
+    info: Bind stats file is very large! Consider to create logrotate conf file for it!
+      to: sysadmin

--- a/conf.d/python.d/bind_rndc.conf
+++ b/conf.d/python.d/bind_rndc.conf
@@ -1,0 +1,109 @@
+# netdata python.d.plugin configuration for bind_rndc
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, bind_rndc also supports the following:
+#
+#     named_stats_path: 'path to named.stats'		# Default: '/var/log/bind/named.stats'
+#------------------------------------------------------------------------------------------------------------------
+# IMPORTANT Information
+#
+# BIND APPEND logs at EVERY RUN. Its NOT RECOMMENDED to set update_every below 30 sec.
+# STRONGLY RECOMMENDED to create a bind-rndc conf file for logrotate
+#
+# To set up your BIND to dump stats do the following:
+#
+# 1. add to 'named.conf.options' options {}: 
+# statistics-file "/var/log/bind/named.stats";
+#
+# 2. Create bind/ directory in /var/log
+# cd /var/log/ && mkdir bind
+#
+# 3. Change owner of directory to 'bind' user
+# chown bind bind/
+#
+# 4. RELOAD (NOT restart) BIND
+# systemctl reload bind9.serice
+#
+# 5. Run as a root 'rndc stats' to dump (BIND will create named.stats in new directory)
+# 
+#
+# To ALLOW NETDATA TO RUN 'rndc stats' change '/etc/bind/rndc.key' group to netdata
+# chown :netdata rndc.key
+#
+# The last BUT NOT least is to create bind-rndc.conf in logrotate.d/
+# The working one
+#  /var/log/bind/named.stats {
+#   
+#     daily
+#     rotate 4
+#     compress
+#     delaycompress
+#     create 0644 bind bind
+#     missingok
+#     postrotate
+#         rndc reload > /dev/null
+#     endscript
+# }
+#
+# To test your logrotate conf file run as root:
+#
+# logrotate /etc/logrotate.d/bind-rndc -d (debug dry-run mode)
+# ------------------------------------------------------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+#
+#local:
+# named_stats_path: '/var/log/bind/named.stats'  

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -10,6 +10,7 @@ SUFFIXES = .in
 dist_python_SCRIPTS = \
     apache.chart.py \
     apache_cache.chart.py \
+    bind_rndc.chart.py \
     cpufreq.chart.py \
     dovecot.chart.py \
     example.chart.py \

--- a/python.d/bind_rndc.chart.py
+++ b/python.d/bind_rndc.chart.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+# Description: bind rndc netdata python.d module
+# Author: l2isbad
+
+from base import SimpleService
+from re import compile, findall
+from os.path import getsize, isfile, split
+from os import access as is_accessible, R_OK
+from subprocess import Popen
+
+priority = 60000
+retries = 60
+update_every = 30
+
+DIRECTORIES = ['/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/']
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.named_stats_path = self.configuration.get('named_stats_path', '/var/log/bind/named.stats')
+        self.regex_values = compile(r'([0-9]+) ([^\n]+)')
+        # self.options = ['Incoming Requests', 'Incoming Queries', 'Outgoing Queries',
+        # 'Name Server Statistics', 'Zone Maintenance Statistics', 'Resolver Statistics',
+        # 'Cache DB RRsets', 'Socket I/O Statistics']
+        self.options = ['Name Server Statistics']
+        self.regex_options = [r'(%s(?= \+\+)) \+\+([^\+]+)' % option for option in self.options]
+        try:
+            self.rndc = [''.join([directory, 'rndc']) for directory in DIRECTORIES
+                         if isfile(''.join([directory, 'rndc']))][0]
+        except IndexError:
+            self.rndc = False
+
+    def check(self):
+
+        # We cant start without 'rndc' command 
+        if not self.rndc:
+            self.error('Command "rndc" not found')
+            return False
+
+        # We cant if stats file is not exist or not readable by netdata user
+        if not is_accessible(self.named_stats_path, R_OK):
+            self.error('Cannot access file %s' % self.named_stats_path)
+            return False
+
+        size_before = getsize(self.named_stats_path)
+        run_rndc = Popen([self.rndc, 'stats'], shell=False)
+        run_rndc.wait()
+        size_after = getsize(self.named_stats_path)
+
+        # We cant start if netdata user has no permissions to run 'rndc stats'
+        if not run_rndc.returncode:
+            # 'rndc' was found, stats file is exist and readable and we can run 'rndc stats'. Lets go!
+            self.create_charts()
+            
+            # BIND APPEND dump on every run 'rndc stats'
+            # that is why stats file size can be VERY large if update_interval too small
+            dump_size_24hr = round(86400 / self.update_every * (int(size_after) - int(size_before)) / 1048576, 3)
+            
+            # If update_every too small we should WARN user
+            if self.update_every < 30:
+                self.info('Update_every %s is NOT recommended for use. Increase the value to > 30' % self.update_every)
+            
+            self.info('With current update_interval it will be + %s MB every 24hr. '
+                      'Don\'t forget to create logrotate conf file for %s' % (dump_size_24hr, self.named_stats_path))
+
+            self.info('Plugin was started successfully.')
+
+            return True
+        else:
+            self.error('Not enough permissions to run "%s stats"' % self.rndc)
+            return False
+
+    def _get_raw_data(self):
+
+        """
+        Run 'rndc stats' and read last dump from named.stats
+        :return: tuple(
+                       file.read() obj,
+                       named.stats file size
+                      )
+        """
+
+        try:
+            current_size = getsize(self.named_stats_path)
+        except OSError:
+            return None, None
+        
+        run_rndc = Popen([self.rndc, 'stats'], shell=False)
+        run_rndc.wait()
+
+        if run_rndc.returncode:     
+            return None, None
+
+        try:
+            with open(self.named_stats_path) as bind_rndc:
+                bind_rndc.seek(current_size)
+                result = bind_rndc.read()
+        except OSError:
+            return None, None
+        else:
+            return result, current_size
+
+    def _get_data(self):
+
+        """
+        Parse data from _get_raw_data()
+        :return: dict
+        """
+
+        raw_data, size = self._get_raw_data()
+
+        if raw_data is None:
+            return None
+
+        rndc_stats = dict()
+        
+        for regex in self.regex_options:
+            rndc_stats.update({k: [(y, int(x)) for x, y in self.regex_values.findall(v)]
+                               for k, v in findall(regex, raw_data)})
+        
+        nms = dict(rndc_stats.get('Name Server Statistics', []))
+
+        to_netdata = dict()
+
+        to_netdata['requests'] = sum([v for k, v in nms.items() if 'request' in k and 'received' in k])
+        to_netdata['responses'] = sum([v for k, v in nms.items() if 'responses' in k and 'sent' in k])
+        to_netdata['success'] = nms.get('queries resulted in successful answer', 0)
+        to_netdata['auth_answer'] = nms.get('queries resulted in authoritative answer', 0)
+        to_netdata['nonauth_answer'] = nms.get('queries resulted in non authoritative answer', 0)
+        to_netdata['nxrrset'] = nms.get('queries resulted in nxrrset', 0)
+        to_netdata['failure'] = sum([nms.get('queries resulted in SERVFAIL', 0), nms.get('other query failures', 0)])
+        to_netdata['nxdomain'] = nms.get('queries resulted in NXDOMAIN', 0)
+        to_netdata['recursion'] = nms.get('queries caused recursion', 0)
+        to_netdata['duplicate'] = nms.get('duplicate queries received', 0)
+        to_netdata['rejections'] = nms.get('recursive queries rejected', 0)
+        to_netdata['stats_size'] = size
+        
+        return to_netdata
+
+    def create_charts(self):
+
+        self.order = ['stats_size', 'bind_stats']
+        self.definitions = {
+            'bind_stats': {
+                'options': [None, 'Name Server Statistics', 'stats', 'NS Statistics', 'bind_rndc.stats', 'line'],
+                'lines': [
+                         ["requests", None, "incremental"], ["responses", None, "incremental"],
+                         ["success", None, "incremental"], ["auth_answer", None, "incremental"],
+                         ["nonauth_answer", None, "incremental"], ["nxrrset", None, "incremental"],
+                         ["failure", None, "incremental"], ["nxdomain", None, "incremental"],
+                         ["recursion", None, "incremental"], ["duplicate", None, "incremental"],
+                         ["rejections", None, "incremental"]
+                         ]},
+                'stats_size': {
+                'options': [None, '%s file size' % split(self.named_stats_path)[1].capitalize(), 'megabyte',
+                            '%s size' % split(self.named_stats_path)[1].capitalize(), 'bind_rndc.size', 'line'],
+                'lines': [
+                         ["stats_size", None, "absolute", 1, 1048576]
+                        ]}
+                     }


### PR DESCRIPTION
Unfortunately bind9 package in debian repository compiled without --with-libjson.

All our nameservers are debian7/debian8 and since they work well nobody will upgrade bind (compile from source with --with-libjson). 

Current netdata plugins is not suitable for bind monitoring in our case. I think it is very common situation!

The old way to monitor bind is to dump named.stats and parse it (the way we do it now using munin).

The only drawback - bind append new dump to log. It is only mean you need to create logrotate conf file for it and don't set update_every to a low value.

Plugin is lightweight because it reads only the last part of dump (~ 11 Kilobyte in our case). It does not matter what file size is.

The logic is very simple:
1. check size
2. run 'rndc stats' to force bind to dump stats
3. open 'named.stats', jump to prev size.
4. parse last dump

There is a lot of information in dump but current charts only are:
1. Stats file size (alarm to warn user if size is too big included)
2. Name Server Statistic ( requests, response, failures, recursion and etc).

It is very easy to add more charts to it since all information is collected. But we need only Name Server Statistic and that is why i didn't add others. Will do this later.