### PR TITLE
prometheus supports

### DIFF
--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -32,6 +32,12 @@ extern char *hostname;
 #define DATASOURCE_FORMAT_SSV_COMMA "ssvcomma"
 #define DATASOURCE_FORMAT_CSV_JSON_ARRAY "csvjsonarray"
 
+#define RAWMETRICS_FORMAT_BASH "bash"
+#define RAWMETRICS_FORMAT_PROMETHEUS "prometheus"
+
+#define RAWMETRICS_BASH 1
+#define RAWMETRICS_PROMETHEUS 2
+
 #define GROUP_UNDEFINED         0
 #define GROUP_AVERAGE           1
 #define GROUP_MIN               2
@@ -55,6 +61,9 @@ extern char *hostname;
 
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrd_stats_api_v1_charts(BUFFER *wb);
+
+// extern void rrd_stats_api_v1_charts_allmetrics_bash(BUFFER *wb);
+extern void rrd_stats_api_v1_charts_allmetrics_prometheus(BUFFER *wb);
 
 extern unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb);
 

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -2,7 +2,6 @@
 #define NETDATA_RRD2JSON_H 1
 
 #define HOSTNAME_MAX 1024
-extern char *hostname;
 
 #define API_RELATIVE_TIME_MAX (3 * 365 * 86400)
 

--- a/src/web_buffer.h
+++ b/src/web_buffer.h
@@ -39,6 +39,7 @@ typedef struct web_buffer {
 #define CT_IMAGE_XICON                  19
 #define CT_IMAGE_ICNS                   20
 #define CT_IMAGE_BMP                    21
+#define CT_PROMETHEUS                   22
 
 #define buffer_cacheable(wb)    do { (wb)->options |= WB_CONTENT_CACHEABLE;    if((wb)->options & WB_CONTENT_NO_CACHEABLE) (wb)->options &= ~WB_CONTENT_NO_CACHEABLE; } while(0)
 #define buffer_no_cacheable(wb) do { (wb)->options |= WB_CONTENT_NO_CACHEABLE; if((wb)->options & WB_CONTENT_CACHEABLE)    (wb)->options &= ~WB_CONTENT_CACHEABLE;  (wb)->expires = 0; } while(0)

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -796,7 +796,6 @@ int web_client_api_request_v1_allmetrics(struct web_client *w, char *url)
 
     buffer_flush(w->response.data);
     buffer_no_cacheable(w->response.data);
-    w->response.data->contenttype = CT_TEXT_PLAIN;
 
     switch(format) {
         //case RAWMETRICS_BASH:
@@ -804,10 +803,12 @@ int web_client_api_request_v1_allmetrics(struct web_client *w, char *url)
         //    return 200;
 
         case RAWMETRICS_PROMETHEUS:
+            w->response.data->contenttype = CT_PROMETHEUS;
             rrd_stats_api_v1_charts_allmetrics_prometheus(w->response.data);
             return 200;
 
         default:
+            w->response.data->contenttype = CT_TEXT_PLAIN;
             buffer_strcat(w->response.data, "Which format? Only '" RAWMETRICS_FORMAT_PROMETHEUS "' is currently supported.");
             return 400;
     }
@@ -1733,6 +1734,9 @@ const char *web_content_type_to_string(uint8_t contenttype) {
 
         case CT_IMAGE_ICNS:
             return "image/icns";
+
+        case CT_PROMETHEUS:
+            return "text/plain; version=0.0.4";
 
         default:
         case CT_TEXT_PLAIN:


### PR DESCRIPTION
fixes #1497 

Prometheus is polling for data. This PR adds a new API method to netdata `/api/v1/allmetrics?format=prometheus`.

This call returns the latest collected values for all metrics collected by netdata.