### PR TITLE
cpufreq.chart.py: add more accurate cpufreq_stats-based calculations

### DIFF
--- a/python.d/README.md
+++ b/python.d/README.md
@@ -186,13 +186,21 @@ If no configuration is given, module will attempt to read named.stats file  at `
 
 ---
 
-
 # cpufreq
 
-Module shows current cpu frequency by looking at appropriate files in /sys/devices
+This module shows the current CPU frequency as set by the cpufreq kernel
+module.
 
 **Requirement:**
-Processor which presents data scaling frequency data
+You need to have `CONFIG_CPU_FREQ` and (optionally) `CONFIG_CPU_FREQ_STAT`
+enabled in your kernel.
+
+This module tries to read from one of two possible locations. On
+initialization, it tries to read the `time_in_state` files provided by
+cpufreq\_stats. If this file does not exist, or doesn't contain valid data, it
+falls back to using the more inaccurate `scaling_cur_freq` file (which only
+represents the **current** CPU frequency, and doesn't account for any state
+changes which happen between updates).
 
 It produces one chart with multiple lines (one line per core).
 
@@ -204,7 +212,7 @@ Sample:
 sys_dir: "/sys/devices"
 ```
 
-If no configuration is given, module will search for `scaling_cur_freq` files in `/sys/devices` directory.
+If no configuration is given, module will search for cpufreq files in `/sys/devices` directory.
 Directory is also prefixed with `NETDATA_HOST_PREFIX` if specified.
 
 ---


### PR DESCRIPTION
There were two major problems with this module:

- The 'cpuN' names weren't accurate. The 'self.paths.sort()' was trying
  to compensate for os.walk() enumerating the CPUs out of order (as any
  directory enumeration will do). Unfortunately the sort() function is
  alphabetical, so it would result in a list of paths like this:

    [
        '/sys/.../cpu0/...'
        '/sys/.../cpu1/...'
        '/sys/.../cpu11/...'
        '/sys/.../cpu12/...'
        ...
    ]

  So the chart for cpu2 would actually map to cpu11's stats.

  This can be corrected by extracting the 'cpuN' value that's already
  inside the path anyway.

- The scaling_cur_freq value is an instantaneous value. It only
  represents the current processor P-state at the time it was read, and
  doesn't account for the other 999ms that netdata wasn't looking at the
  value.

  This can be corrected by using data from cpufreq_stats, which includes
  P-state residency statistics. Note that the values in cpufreq_stats
  aren't always valid (e.g. if the cpufreq governor is set to
  'schedutil', the statistic files exist but are are empty), so we can
  just fall back to the inaccurate scaling_cur_freq method if necessary.
