### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ cmake_install.cmake
 
 .jetbrains*
 
+.DS_Store
+
 contrib/debian/changelog
 profile/benchmark-dictionary
 profile/benchmark-registry


### PR DESCRIPTION
As we now support macOS we may ignore this.

In the Apple macOS operating system, .DS_Store is a file that stores custom attributes of its containing folder (https://en.wikipedia.org/wiki/.DS_Store)