### PR TITLE
Patch to add support for messagebird.com SMS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Netdata is featured at <b><a href="https://octoverse.github.com/" target="_blank
  - **Sophisticated alarming**<br/>
    supports dynamic thresholds, hysteresis, alarm templates,
    multiple role-based notification methods (such as email, slack.com,
-   pushover.net, pushbullet.com telegram.org, twilio.com)
+   pushover.net, pushbullet.com telegram.org, twilio.com, messagebird.com)
    
  - **Extensible**<br/>
    you can monitor anything you can get a metric for,

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -9,6 +9,7 @@
 # - messages to your slack team (slack.com),
 # - messages to your telegram chat / group chat (telegram.org)
 # - sms messages to your cell phone or any sms enabled device (twilio.com)
+# - sms messages to your cell phone or any sms enabled device (messagebird.com)
 # - notifications to users on pagerduty.com
 #
 # The 'to' line given at netdata alarms defines a *role*, so that many
@@ -70,12 +71,13 @@ curl=""
 # In these examples, the first recipient receives all the alarms
 # while the second one receives only the critical ones:
 #
-#  email   : "user1@example.com user2@example.com|critical"
-#  pushover: "2987343...9437837 8756278...2362736|critical"
-#  telegram: "111827421 112746832|critical"
-#  slack   : "alarms disasters|critical"
-#  twilio  : "+15555555555 +17777777777|critical"
-#  pd      : "<pd_service_key_1> <pd_service_key_2>|critical"
+#  email      : "user1@example.com user2@example.com|critical"
+#  pushover   : "2987343...9437837 8756278...2362736|critical"
+#  telegram   : "111827421 112746832|critical"
+#  slack      : "alarms disasters|critical"
+#  twilio     : "+15555555555 +17777777777|critical"
+#  messagebird: "+15555555555 +17777777777|critical"
+#  pd         : "<pd_service_key_1> <pd_service_key_2>|critical"
 #
 # If a recipient is set to empty string, the default recipient of the given
 # notification method (email, pushover, telegram, slack, pd) will be used.
@@ -159,6 +161,20 @@ TWILIO_ACCOUNT_SID=""
 TWILIO_ACCOUNT_TOKEN=""
 TWILIO_NUMBER=""
 DEFAULT_RECIPIENT_TWILIO=""
+
+#------------------------------------------------------------------------------
+# Messagebird (messagebird.com) SMS options
+
+# multiple recipients can be given like this:
+#                  "+15555555555 +17777777777"
+
+# enable/disable sending messagebird SMS
+SEND_MESSAGEBIRD="YES"
+
+# Without an access key, netdata cannot send Messagebird text messages.
+MESSAGEBIRD_ACCESS_KEY=""
+MESSAGEBIRD_NUMBER=""
+DEFAULT_RECIPIENT_MESSAGEBIRD=""
 
 #------------------------------------------------------------------------------
 # telegram (telegram.org) global notification options
@@ -253,6 +269,8 @@ role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[sysadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_messagebird[sysadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+
 role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
 
 # -----------------------------------------------------------------------------
@@ -269,6 +287,8 @@ role_recipients_telegram[domainadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[domainadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+
+role_recipients_messagebird[domainadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
 
@@ -288,6 +308,8 @@ role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[dba]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_messagebird[dba]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+
 role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
 
 # -----------------------------------------------------------------------------
@@ -306,6 +328,8 @@ role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[webmaster]="${DEFAULT_RECIPIENT_TWILIO}"
 
+role_recipients_messagebird[webmaster]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+
 role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
 
 # -----------------------------------------------------------------------------
@@ -323,5 +347,7 @@ role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
 role_recipients_twilio[proxyadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+
+role_recipients_messagebird[proxyadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -171,6 +171,12 @@ DEFAULT_RECIPIENT_TWILIO=""
 # enable/disable sending messagebird SMS
 SEND_MESSAGEBIRD="YES"
 
+# to get an access key, create a free account at https://www.messagebird.com
+# verify and activate the account (no CC info needed)
+# login to your account and enter your phonenumber to get some free credits
+# to get the API key, click on 'API' in the sidebar, then 'API Access (REST)' 
+# click 'Add access key' and fill in data (you want a live key to send SMS)
+
 # Without an access key, netdata cannot send Messagebird text messages.
 MESSAGEBIRD_ACCESS_KEY=""
 MESSAGEBIRD_NUMBER=""


### PR DESCRIPTION
I've added support for messagebird.com SMS alarms because we already have an account there and it looked easy to implement. I've copied all twilio code and modified the config variables and send_messagebird() code to match their API.

also, my first PR, no idea if I'm doing this right :)