### PR TITLE
Add health tracking for ipfs

### DIFF
--- a/conf.d/health.d/ipfs.conf
+++ b/conf.d/health.d/ipfs.conf
@@ -1,6 +1,6 @@
 
-   alarm: ipfs_datastore_in_use
-      on: ipfs_local.repo_size
+template: ipfs_datastore_usage
+      on: ipfs.repo_size
     calc: $size * 100 / $avail
    units: %
    every: 10s

--- a/conf.d/health.d/ipfs.conf
+++ b/conf.d/health.d/ipfs.conf
@@ -1,0 +1,11 @@
+
+   alarm: ipfs_datastore_in_use
+      on: ipfs_local.repo_size
+    calc: $size * 100 / $avail
+   units: %
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? (80) : (90))
+    crit: $this > (($status == $CRITICAL) ? (90) : (98))
+   delay: down 15m multiplier 1.5 max 1h
+    info: ipfs Datastore close to running out of space
+      to: sysadmin

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -34,9 +34,10 @@ CHARTS = {
             ["peers", None, 'absolute']
         ]},
     'repo_size': {
-        'options': [None, 'IPFS Repo Size', 'MB', 'Size', 'ipfs.repo_size', 'line'],
+        'options': [None, 'IPFS Repo Size', 'GB', 'Size', 'ipfs.repo_size', 'area'],
         'lines': [
-            ["size", None, "absolute", 1, 1000000]
+            ["avail", None, "absolute", 1, 1e9],
+            ["size", None, "absolute", 1, 1e9],
         ]},
     'repo_objects': {
         'options': [None, 'IPFS Repo Objects', 'objects', 'Objects', 'ipfs.repo_objects', 'line'],
@@ -47,6 +48,10 @@ CHARTS = {
         ]},
 }
 
+SI_zeroes = {'k': 3, 'm': 6, 'g': 9, 't': 12,
+             'p': 15, 'e': 18, 'z': 21, 'y': 24 }
+
+
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
@@ -56,35 +61,55 @@ class Service(UrlService):
             self.baseurl = "http://localhost:5001"
         self.order = ORDER
         self.definitions = CHARTS
+        self.__storagemax = None
 
     def _get_json(self, suburl):
         """
         :return: json decoding of the specified url
-        """ 
+        """
         self.url = self.baseurl + suburl
         try:
-            return json.loads(self._get_raw_data()) 
+            return json.loads(self._get_raw_data())
         except:
             return {}
 
     def _recursive_pins(self, keys):
         return len([k for k in keys if keys[k]["Type"] == b"recursive"])
 
+    def _dehumanize(self, storemax):
+        # convert from '10Gb' to 10000000000
+        if type(storemax) != int:
+            storemax = storemax.lower()
+            if storemax.endswith('b'):
+                val, units = storemax[:-2], storemax[-2]
+                if units in SI_zeroes:
+                    val += '0'*SI_zeroes[units]
+                storemax = val
+            try:
+                storemax = int(storemax)
+            except:
+                storemax = None
+        return storemax
+
+    def _storagemax(self, storecfg):
+        if self.__storagemax is None:
+            self.__storagemax = self._dehumanize(storecfg['StorageMax'])
+        return self.__storagemax
 
     def _get_data(self):
         """
         Get data from API
         :return: dict
         """
-        cfg = {# suburl : List of (result-key, original-key, transform-func)
+        cfg = { # suburl : List of (result-key, original-key, transform-func)
                '/api/v0/stats/bw'   :[('in', 'RateIn', int ),
                                       ('out', 'RateOut', int )],
                '/api/v0/swarm/peers':[('peers', 'Strings', len )],
                '/api/v0/stats/repo' :[('size', 'RepoSize', int),
                                       ('objects', 'NumObjects', int)],
                '/api/v0/pin/ls': [('pinned', 'Keys', len),
-                                  ('recursive_pins', 'Keys', self._recursive_pins)
-                                 ]
+                                  ('recursive_pins', 'Keys', self._recursive_pins)],
+               '/api/v0/config/show': [('avail', 'Datastore', self._storagemax)]
         }
         r = {}
         for suburl in cfg:
@@ -95,6 +120,4 @@ class Service(UrlService):
                 except: pass
         return r or None
 
-
- 
 


### PR DESCRIPTION
This adds one variable 'avail' that's the available space in the datastore.  It then uses that and the previously built 'size' variable to add an alert when the datastore gets over 90% full.

My only question is this: parsing the config isn't something that should be done every call, so I just parse it the first time and then cache it, so that costly work is only done once.  Server config isn't likely to change very often, so I thought it'd be acceptable to require a netdata restart if it did.  Should I instead figure out how to parse the config at some interval  (once every 5 or 10 mins maybe)?

Oh, and I also switched the size graph to `area` instead of `line` because that's what other disk-space-related graphs use.