### PR TITLE
Update to remove overfiring/misfiring alarm

### DIFF
--- a/conf.d/health.d/softnet.conf
+++ b/conf.d/health.d/softnet.conf
@@ -15,7 +15,7 @@
   lookup: sum -1h unaligned absolute of squeezed
    units: events
    every: 1m
-    warn: $this > (($status >= $WARNING)  ? (0) : (10))
+    warn: $this > (($status >= $WARNING)  ? (1) : (10))
    delay: down 30m multiplier 1.5 max 1h
     info: number of times ksoftirq ran out of sysctl net.core.netdev_budget or time slice, with work remaining (this can be a cause for dropped packets)
       to: silent


### PR DESCRIPTION
Currently using 0 as the lower threshold for this alarm is causing the alarm to come on even when I have a SoftIRQ (squeezed) of 0.2 every half an hour. Suggest raising this to 1 so that the alarm fires when there is something a little more backlogging occurring :)