### PR TITLE
isolated statvfs(); improved netdata cleanup/exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ set(NETDATA_SOURCE_FILES
         src/registry_person.c
         src/registry_person.h
         src/registry_machine.c
-        src/registry_machine.h src/registry_internals.c src/registry_init.c src/registry_db.c src/registry_log.c src/proc_uptime.c src/sys_devices_system_edac_mc.c)
+        src/registry_machine.h src/registry_internals.c src/registry_init.c src/registry_db.c src/registry_log.c src/proc_uptime.c src/sys_devices_system_edac_mc.c src/plugin_proc_diskspace.c src/plugin_proc_diskspace.h)
 
 set(APPS_PLUGIN_SOURCE_FILES
         src/appconfig.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,6 +86,7 @@ else
 netdata_SOURCES += \
 	ipc.c ipc.h \
 	plugin_proc.c plugin_proc.h \
+	plugin_proc_diskspace.c plugin_proc_diskspace.h \
 	proc_diskstats.c \
 	proc_interrupts.c \
 	proc_softirqs.c \

--- a/src/backends.c
+++ b/src/backends.c
@@ -129,7 +129,7 @@ static inline int process_opentsdb_response(BUFFER *b) {
 }
 
 void *backends_main(void *ptr) {
-    (void)ptr;
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     BUFFER *b = buffer_create(1), *response = buffer_create(1);
     int (*backend_request_formatter)(BUFFER *b, const char *prefix, RRDHOST *host, const char *hostname, RRDSET *st, RRDDIM *rd, time_t after, time_t before, uint32_t options) = NULL;
@@ -543,6 +543,8 @@ cleanup:
 
     info("BACKEND thread exiting");
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -188,6 +188,7 @@
 #include "plugin_macos.h"
 #else
 #include "plugin_proc.h"
+#include "plugin_proc_diskspace.h"
 #endif /* __FreeBSD__, __APPLE__*/
 
 #include "plugin_tc.h"

--- a/src/global_statistics.c
+++ b/src/global_statistics.c
@@ -131,7 +131,7 @@ void global_statistics_charts(void) {
 
     if (!stcpu_thread) stcpu_thread = rrdset_find("netdata.plugin_proc_cpu");
     if (!stcpu_thread) {
-        stcpu_thread = rrdset_create("netdata", "plugin_proc_cpu", NULL, "proc.internal", NULL,
+        stcpu_thread = rrdset_create("netdata", "plugin_proc_cpu", NULL, "proc", NULL,
                                      "NetData Proc Plugin CPU usage", "milliseconds/s", 132000, rrd_update_every,
                                      RRDSET_TYPE_STACKED);
 

--- a/src/health.c
+++ b/src/health.c
@@ -2806,7 +2806,7 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
 }
 
 void *health_main(void *ptr) {
-    (void)ptr;
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("HEALTH thread created with task id %d", gettid());
 
@@ -3113,6 +3113,9 @@ void *health_main(void *ptr) {
     buffer_free(wb);
 
     info("HEALTH thread exiting");
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -178,12 +178,13 @@ void kill_childs()
 
     struct plugind *cd;
     for(cd = pluginsd_root ; cd ; cd = cd->next) {
-        if(!cd->obsolete) {
-            if(cd->thread) {
+        if(cd->enabled && !cd->obsolete) {
+            if(cd->thread != (pthread_t)NULL) {
                 info("Stopping %s plugin thread", cd->id);
                 pthread_cancel(cd->thread);
                 // they are detached
                 // pthread_join(cd->thread, NULL);
+                cd->thread = (pthread_t)NULL;
             }
 
             if(cd->pid) {

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ struct netdata_static_thread static_threads[] = {
     {"macos",              "plugins",   "macos",      1, NULL, NULL, macos_main},
 #else
     {"proc",               "plugins",   "proc",       1, NULL, NULL, proc_main},
+    {"diskspace",          "plugins",   "diskspace",  1, NULL, NULL, proc_diskspace_main},
 #endif /* __FreeBSD__, __APPLE__*/
     {"cgroups",            "plugins",   "cgroups",    1, NULL, NULL, cgroups_main},
     {"check",              "plugins",   "checks",     0, NULL, NULL, checks_main},

--- a/src/main.h
+++ b/src/main.h
@@ -24,6 +24,21 @@ struct option_def {
  */
 extern struct option_def options[];
 
+
+struct netdata_static_thread {
+    char *name;
+
+    char *config_section;
+    char *config_name;
+
+    volatile int enabled;
+
+    pthread_t *thread;
+
+    void (*init_routine) (void);
+    void *(*start_routine) (void *);
+};
+
 extern void kill_childs(void);
 extern int killpid(pid_t pid, int signal);
 extern void netdata_cleanup_and_exit(int ret) NORETURN;

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -1,8 +1,7 @@
 #include "common.h"
 
-void *checks_main(void *ptr)
-{
-    if(ptr) { ; }
+void *checks_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("CHECKS thread created with task id %d", gettid());
 
@@ -78,6 +77,10 @@ void *checks_main(void *ptr)
         rrdset_done(check3);
     }
 
+    info("CHECKS thread exiting");
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -1,8 +1,7 @@
 #include "common.h"
 
-void *freebsd_main(void *ptr)
-{
-    (void)ptr;
+void *freebsd_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("FREEBSD Plugin thread created with task id %d", gettid());
 
@@ -59,6 +58,8 @@ void *freebsd_main(void *ptr)
 
     info("FREEBSD thread exiting");
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -2,11 +2,10 @@
 
 #define CPU_IDLEJITTER_SLEEP_TIME_MS 20
 
-void *cpuidlejitter_main(void *ptr)
-{
-    if(ptr) { ; }
+void *cpuidlejitter_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
-    info("CPU Idle Jitter thread created with task id %d", gettid());
+    info("IDLEJITTER thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
         error("Cannot set pthread cancel type to DEFERRED.");
@@ -48,6 +47,10 @@ void *cpuidlejitter_main(void *ptr)
         rrdset_done(st);
     }
 
+    info("IDLEJITTER thread exiting");
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -1,8 +1,7 @@
 #include "common.h"
 
-void *macos_main(void *ptr)
-{
-    (void)ptr;
+void *macos_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("MACOS Plugin thread created with task id %d", gettid());
 
@@ -79,6 +78,8 @@ void *macos_main(void *ptr)
 
     info("MACOS thread exiting");
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -55,7 +55,7 @@ static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {
 }
 
 void *nfacct_main(void *ptr) {
-    if(ptr) { ; }
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("NFACCT thread created with task id %d", gettid());
 
@@ -75,15 +75,12 @@ void *nfacct_main(void *ptr) {
     nl  = mnl_socket_open(NETLINK_NETFILTER);
     if(!nl) {
         error("nfacct.plugin: mnl_socket_open() failed");
-        pthread_exit(NULL);
-        return NULL;
+        goto cleanup;
     }
 
     if(mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        mnl_socket_close(nl);
         error("nfacct.plugin: mnl_socket_bind() failed");
-        pthread_exit(NULL);
-        return NULL;
+        goto cleanup;
     }
     portid = mnl_socket_get_portid(nl);
 
@@ -104,16 +101,13 @@ void *nfacct_main(void *ptr) {
 
         nlh = nfacct_nlmsg_build_hdr(buf, NFNL_MSG_ACCT_GET, NLM_F_DUMP, seq);
         if(!nlh) {
-            mnl_socket_close(nl);
             error("nfacct.plugin: nfacct_nlmsg_build_hdr() failed");
-            pthread_exit(NULL);
-            return NULL;
+            goto cleanup;
         }
 
         if(mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
             error("nfacct.plugin: mnl_socket_send");
-            pthread_exit(NULL);
-            return NULL;
+            goto cleanup;
         }
 
         if(nfacct_list) nfacct_list->len = 0;
@@ -125,8 +119,7 @@ void *nfacct_main(void *ptr) {
 
         if (ret == -1) {
             error("nfacct.plugin: error communicating with kernel.");
-            pthread_exit(NULL);
-            return NULL;
+            goto cleanup;
         }
 
         // --------------------------------------------------------------------
@@ -191,7 +184,13 @@ void *nfacct_main(void *ptr) {
         memmove(&last, &now, sizeof(struct timeval));
     }
 
-    mnl_socket_close(nl);
+cleanup:
+    info("NFACCT thread exiting");
+
+    if(nl) mnl_socket_close(nl);
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -116,7 +116,7 @@ void *proc_main(void *ptr) {
                 st = rrdset_find_bytype("netdata", "plugin_proc_modules");
 
                 if(!st) {
-                    st = rrdset_create("netdata", "plugin_proc_modules", NULL, "proc.internal", NULL, "NetData Proc Plugin Modules Durations", "milliseconds/run", 132001, rrd_update_every, RRDSET_TYPE_STACKED);
+                    st = rrdset_create("netdata", "plugin_proc_modules", NULL, "proc", NULL, "NetData Proc Plugin Modules Durations", "milliseconds/run", 132001, rrd_update_every, RRDSET_TYPE_STACKED);
 
                     for(i = 0 ; proc_modules[i].name ;i++) {
                         if(unlikely(!proc_modules[i].enabled)) continue;

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -56,9 +56,8 @@ static struct proc_module {
         { .name = NULL, .dim = NULL, .func = NULL }
 };
 
-void *proc_main(void *ptr)
-{
-    (void)ptr;
+void *proc_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("PROC Plugin thread created with task id %d", gettid());
 
@@ -140,6 +139,8 @@ void *proc_main(void *ptr)
 
     info("PROC thread exiting");
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -14,7 +14,7 @@ static inline void mountinfo_reload(int force) {
         mountinfo_free(disk_mountinfo_root);
 
         // re-read mountinfo in case something changed
-        disk_mountinfo_root = mountinfo_read();
+        disk_mountinfo_root = mountinfo_read(1);
 
         last_loaded = now;
     }

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -1,0 +1,227 @@
+#include "common.h"
+
+#ifndef NETDATA_RELOAD_MOUNTINFO_EVERY
+#define NETDATA_RELOAD_MOUNTINFO_EVERY 60
+#endif
+
+#define DELAULT_EXLUDED_PATHS "/proc/ /sys/ /var/run/user/ /run/user/"
+
+static struct mountinfo *disk_mountinfo_root = NULL;
+
+static inline void mountinfo_reload(int force) {
+    static time_t last_loaded = 0;
+    time_t now = now_realtime_sec();
+
+    if(force || now - last_loaded >= NETDATA_RELOAD_MOUNTINFO_EVERY) {
+        // mountinfo_free() can be called with NULL disk_mountinfo_root
+        mountinfo_free(disk_mountinfo_root);
+
+        // re-read mountinfo in case something changed
+        disk_mountinfo_root = mountinfo_read();
+
+        last_loaded = now;
+    }
+}
+
+// Data to be stored in DICTIONARY mount_points used by do_disk_space_stats().
+// This DICTIONARY is used to lookup the settings of the mount point on each iteration.
+struct mount_point_metadata {
+    int do_space;
+    int do_inodes;
+    int update_every;
+};
+
+static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
+    const char *family = mi->mount_point;
+    const char *disk = mi->persistent_id;
+
+    static DICTIONARY *mount_points = NULL;
+    static NETDATA_SIMPLE_PATTERN *excluded_mountpoints = NULL;
+    int do_space, do_inodes;
+
+    if(unlikely(!mount_points)) {
+        const char *s;
+
+        if(config_exists("plugin:proc:/proc/diskstats", "exclude space metrics on paths") && !config_exists("plugin:proc:diskspace", "exclude space metrics on paths")) {
+            // the config exists in the old section
+            s = config_get("plugin:proc:/proc/diskstats", "exclude space metrics on paths", DELAULT_EXLUDED_PATHS);
+
+            // set it to the new section
+            config_set("plugin:proc:diskspace", "exclude space metrics on paths", s);
+        }
+        else
+            s = config_get("plugin:proc:diskspace", "exclude space metrics on paths", DELAULT_EXLUDED_PATHS);
+
+        mount_points = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
+        excluded_mountpoints = netdata_simple_pattern_list_create(s, NETDATA_SIMPLE_PATTERN_MODE_PREFIX);
+    }
+
+    struct mount_point_metadata *m = dictionary_get(mount_points, mi->mount_point);
+    if(unlikely(!m)) {
+        char var_name[4096 + 1];
+        snprintfz(var_name, 4096, "plugin:proc:diskspace:%s", mi->mount_point);
+
+        int def_space = config_get_boolean_ondemand("plugin:proc:diskspace", "space usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
+        int def_inodes = config_get_boolean_ondemand("plugin:proc:diskspace", "inodes usage for all disks", CONFIG_ONDEMAND_ONDEMAND);
+
+        if(unlikely(netdata_simple_pattern_list_matches(excluded_mountpoints, mi->mount_point))) {
+            def_space = CONFIG_ONDEMAND_NO;
+            def_inodes = CONFIG_ONDEMAND_NO;
+        }
+
+        do_space = config_get_boolean_ondemand(var_name, "space usage", def_space);
+        do_inodes = config_get_boolean_ondemand(var_name, "inodes usage", def_inodes);
+
+        struct mount_point_metadata mp = {
+                .do_space = do_space,
+                .do_inodes = do_inodes,
+                .update_every = rrd_update_every
+        };
+
+        dictionary_set(mount_points, mi->mount_point, &mp, sizeof(struct mount_point_metadata));
+    }
+    else {
+        do_space = m->do_space;
+        do_inodes = m->do_inodes;
+        update_every = m->update_every;
+    }
+
+    if(unlikely(do_space == CONFIG_ONDEMAND_NO && do_inodes == CONFIG_ONDEMAND_NO))
+        return;
+
+    struct statvfs buff_statvfs;
+    if (statvfs(mi->mount_point, &buff_statvfs) < 0) {
+        error("Failed statvfs() for '%s' (disk '%s')", mi->mount_point, disk);
+        return;
+    }
+
+    // taken from get_fs_usage() found in coreutils
+    unsigned long bsize = (buff_statvfs.f_frsize) ? buff_statvfs.f_frsize : buff_statvfs.f_bsize;
+
+    fsblkcnt_t bavail         = buff_statvfs.f_bavail;
+    fsblkcnt_t btotal         = buff_statvfs.f_blocks;
+    fsblkcnt_t bavail_root    = buff_statvfs.f_bfree;
+    fsblkcnt_t breserved_root = bavail_root - bavail;
+    fsblkcnt_t bused;
+    if(likely(btotal >= bavail_root))
+        bused = btotal - bavail_root;
+    else
+        bused = bavail_root - btotal;
+
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(btotal != bavail + breserved_root + bused))
+        error("Disk block statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)btotal, (unsigned long long)bavail, (unsigned long long)breserved_root, (unsigned long long)bused);
+#endif
+
+    // --------------------------------------------------------------------------
+
+    fsfilcnt_t favail         = buff_statvfs.f_favail;
+    fsfilcnt_t ftotal         = buff_statvfs.f_files;
+    fsfilcnt_t favail_root    = buff_statvfs.f_ffree;
+    fsfilcnt_t freserved_root = favail_root - favail;
+    fsfilcnt_t fused          = ftotal - favail_root;
+
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(btotal != bavail + breserved_root + bused))
+        error("Disk inode statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)ftotal, (unsigned long long)favail, (unsigned long long)freserved_root, (unsigned long long)fused);
+#endif
+
+    // --------------------------------------------------------------------------
+
+    RRDSET *st;
+
+    if(do_space == CONFIG_ONDEMAND_YES || (do_space == CONFIG_ONDEMAND_ONDEMAND && (bavail || breserved_root || bused))) {
+        st = rrdset_find_bytype("disk_space", disk);
+        if(unlikely(!st)) {
+            char title[4096 + 1];
+            snprintfz(title, 4096, "Disk Space Usage for %s [%s]", family, mi->mount_source);
+            st = rrdset_create("disk_space", disk, NULL, family, "disk.space", title, "GB", 2023, update_every, RRDSET_TYPE_STACKED);
+
+            rrddim_add(st, "avail", NULL, bsize, 1024*1024*1024, RRDDIM_ABSOLUTE);
+            rrddim_add(st, "used" , NULL, bsize, 1024*1024*1024, RRDDIM_ABSOLUTE);
+            rrddim_add(st, "reserved_for_root", "reserved for root", bsize, 1024*1024*1024, RRDDIM_ABSOLUTE);
+        }
+        else rrdset_next(st);
+
+        rrddim_set(st, "avail", (collected_number)bavail);
+        rrddim_set(st, "used", (collected_number)bused);
+        rrddim_set(st, "reserved_for_root", (collected_number)breserved_root);
+        rrdset_done(st);
+    }
+
+    // --------------------------------------------------------------------------
+
+    if(do_inodes == CONFIG_ONDEMAND_YES || (do_inodes == CONFIG_ONDEMAND_ONDEMAND && (favail || freserved_root || fused))) {
+        st = rrdset_find_bytype("disk_inodes", disk);
+        if(unlikely(!st)) {
+            char title[4096 + 1];
+            snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]", family, mi->mount_source);
+            st = rrdset_create("disk_inodes", disk, NULL, family, "disk.inodes", title, "Inodes", 2024, update_every, RRDSET_TYPE_STACKED);
+
+            rrddim_add(st, "avail", NULL, 1, 1, RRDDIM_ABSOLUTE);
+            rrddim_add(st, "used" , NULL, 1, 1, RRDDIM_ABSOLUTE);
+            rrddim_add(st, "reserved_for_root", "reserved for root", 1, 1, RRDDIM_ABSOLUTE);
+        }
+        else rrdset_next(st);
+
+        rrddim_set(st, "avail", (collected_number)favail);
+        rrddim_set(st, "used", (collected_number)fused);
+        rrddim_set(st, "reserved_for_root", (collected_number)freserved_root);
+        rrdset_done(st);
+    }
+}
+
+void *proc_diskspace_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+
+    info("DISKSPACE thread created with task id %d", gettid());
+
+    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+        error("Cannot set pthread cancel type to DEFERRED.");
+
+    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+        error("Cannot set pthread cancel state to ENABLE.");
+
+    int update_every = (int)config_get_number("plugin:proc:diskspace", "update every", rrd_update_every);
+    if(update_every < rrd_update_every)
+        update_every = rrd_update_every;
+
+    usec_t step = update_every * USEC_PER_SEC;
+    for(;;) {
+        usec_t now = now_monotonic_usec();
+        usec_t next = now - (now % step) + step;
+
+        while(now < next) {
+            sleep_usec(next - now);
+            now = now_monotonic_usec();
+        }
+
+        if(unlikely(netdata_exit)) break;
+
+        // --------------------------------------------------------------------------
+        // this is smart enough not to reload it every time
+
+        mountinfo_reload(0);
+
+        // --------------------------------------------------------------------------
+        // disk space metrics
+
+        struct mountinfo *mi;
+        for(mi = disk_mountinfo_root; mi; mi = mi->next) {
+
+            if(unlikely(mi->flags &
+                        (MOUNTINFO_IS_DUMMY | MOUNTINFO_IS_BIND | MOUNTINFO_IS_SAME_DEV | MOUNTINFO_NO_STAT |
+                         MOUNTINFO_NO_SIZE | MOUNTINFO_READONLY)))
+                continue;
+
+            do_disk_space_stats(mi, update_every);
+        }
+    }
+
+    info("DISKSPACE thread exiting");
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
+    pthread_exit(NULL);
+    return NULL;
+}

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -25,7 +25,6 @@ static inline void mountinfo_reload(int force) {
 struct mount_point_metadata {
     int do_space;
     int do_inodes;
-    int update_every;
 };
 
 static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
@@ -71,8 +70,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
         struct mount_point_metadata mp = {
                 .do_space = do_space,
-                .do_inodes = do_inodes,
-                .update_every = rrd_update_every
+                .do_inodes = do_inodes
         };
 
         dictionary_set(mount_points, mi->mount_point, &mp, sizeof(struct mount_point_metadata));
@@ -80,7 +78,6 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     else {
         do_space = m->do_space;
         do_inodes = m->do_inodes;
-        update_every = m->update_every;
     }
 
     if(unlikely(do_space == CONFIG_ONDEMAND_NO && do_inodes == CONFIG_ONDEMAND_NO))

--- a/src/plugin_proc_diskspace.h
+++ b/src/plugin_proc_diskspace.h
@@ -1,0 +1,6 @@
+#ifndef NETDATA_PLUGIN_PROC_DISKSPACE_H
+#define NETDATA_PLUGIN_PROC_DISKSPACE_H
+
+extern void *proc_diskspace_main(void *ptr);
+
+#endif //NETDATA_PLUGIN_PROC_DISKSPACE_H

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -747,7 +747,7 @@ static inline void tc_split_words(char *str, char **words, int max_words) {
     while(i < max_words) words[i++] = NULL;
 }
 
-pid_t tc_child_pid = 0;
+volatile pid_t tc_child_pid = 0;
 void *tc_main(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
@@ -793,7 +793,7 @@ void *tc_main(void *ptr) {
         snprintfz(buffer, TC_LINE_MAX, "exec %s %d", tc_script, rrd_update_every);
         debug(D_TC_LOOP, "executing '%s'", buffer);
 
-        fp = mypopen(buffer, &tc_child_pid);
+        fp = mypopen(buffer, (pid_t *)&tc_child_pid);
         if(unlikely(!fp)) {
             error("TC: Cannot popen(\"%s\", \"r\").", buffer);
             goto cleanup;
@@ -986,7 +986,7 @@ void *tc_main(void *ptr) {
         }
 
         // fgets() failed or loop broke
-        int code = mypclose(fp, tc_child_pid);
+        int code = mypclose(fp, (pid_t)tc_child_pid);
         tc_child_pid = 0;
 
         if(unlikely(device)) {

--- a/src/plugin_tc.h
+++ b/src/plugin_tc.h
@@ -1,7 +1,7 @@
 #ifndef NETDATA_PLUGIN_TC_H
 #define NETDATA_PLUGIN_TC_H 1
 
-extern pid_t tc_child_pid;
+extern volatile pid_t tc_child_pid;
 extern void *tc_main(void *ptr);
 
 #endif /* NETDATA_PLUGIN_TC_H */

--- a/src/plugins_d.h
+++ b/src/plugins_d.h
@@ -24,7 +24,7 @@ struct plugind {
 
     int update_every;                   // the plugin default data collection frequency
     volatile int obsolete;              // do not touch this structure after setting this to 1
-    int enabled;                        // if this is enabled or not
+    volatile int enabled;               // if this is enabled or not
 
     time_t started_t;
 

--- a/src/plugins_d.h
+++ b/src/plugins_d.h
@@ -23,7 +23,7 @@ struct plugind {
                                         // without collecting values
 
     int update_every;                   // the plugin default data collection frequency
-    int obsolete;                       // do not touch this structure after setting this to 1
+    volatile int obsolete;              // do not touch this structure after setting this to 1
     int enabled;                        // if this is enabled or not
 
     time_t started_t;

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -41,7 +41,7 @@ static inline void mountinfo_reload(int force) {
         mountinfo_free(disk_mountinfo_root);
 
         // re-read mountinfo in case something changed
-        disk_mountinfo_root = mountinfo_read();
+        disk_mountinfo_root = mountinfo_read(0);
 
         last_loaded = now;
     }

--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -282,7 +282,7 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
                 mi->flags |= MOUNTINFO_IS_REMOTE;
 
             // mark as BIND the duplicates (i.e. same filesystem + same source)
-            {
+            if(do_statvfs) {
                 struct stat buf;
                 if(unlikely(stat(mi->mount_point, &buf) == -1)) {
                     mi->st_dev = 0;
@@ -301,6 +301,9 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
                         }
                     }
                 }
+            }
+            else {
+                mi->st_dev = 0;
             }
         }
         else {

--- a/src/proc_self_mountinfo.c
+++ b/src/proc_self_mountinfo.c
@@ -173,7 +173,7 @@ static inline int is_read_only(const char *s) {
 }
 
 // read the whole mountinfo into a linked list
-struct mountinfo *mountinfo_read() {
+struct mountinfo *mountinfo_read(int do_statvfs) {
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/proc/self/mountinfo", global_host_prefix);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
@@ -316,7 +316,7 @@ struct mountinfo *mountinfo_read() {
         }
 
         // check if it has size
-        {
+        if(do_statvfs) {
             struct statvfs buff_statvfs;
             if(unlikely(statvfs(mi->mount_point, &buff_statvfs) < 0)) {
                 mi->flags |= MOUNTINFO_NO_STAT;

--- a/src/proc_self_mountinfo.h
+++ b/src/proc_self_mountinfo.h
@@ -50,6 +50,6 @@ extern struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mounti
 extern struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options);
 
 extern void mountinfo_free(struct mountinfo *mi);
-extern struct mountinfo *mountinfo_read();
+extern struct mountinfo *mountinfo_read(int do_statvfs);
 
 #endif /* NETDATA_PROC_SELF_MOUNTINFO_H */

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -902,7 +902,10 @@ void rrdset_save_all(void) {
     RRDSET *st;
     RRDDIM *rd;
 
-    rrdhost_rdlock(&localhost);
+    // we get an write lock
+    // to ensure only one thread is saving the database
+    rrdhost_rwlock(&localhost);
+
     for(st = localhost.rrdset_root; st ; st = st->next) {
         pthread_rwlock_rdlock(&st->rwlock);
 
@@ -920,6 +923,7 @@ void rrdset_save_all(void) {
 
         pthread_rwlock_unlock(&st->rwlock);
     }
+
     rrdhost_unlock(&localhost);
 }
 

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -880,14 +880,7 @@ void rrdset_free_all(void)
 
         pthread_rwlock_unlock(&st->rwlock);
 
-        if(st->mapped == RRD_MEMORY_MODE_SAVE) {
-            debug(D_RRD_CALLS, "Saving stats '%s' to '%s'.", st->name, st->cache_filename);
-            savememory(st->cache_filename, st, st->memsize);
-
-            debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
-            munmap(st, st->memsize);
-        }
-        else if(st->mapped == RRD_MEMORY_MODE_MAP) {
+        if(st->mapped == RRD_MEMORY_MODE_SAVE || st->mapped == RRD_MEMORY_MODE_MAP) {
             debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
             munmap(st, st->memsize);
         }

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1485,7 +1485,7 @@ void *cgroups_main(void *ptr) {
 
             if(!stcpu_thread) stcpu_thread = rrdset_find("netdata.plugin_cgroups_cpu");
             if(!stcpu_thread) {
-                stcpu_thread = rrdset_create("netdata", "plugin_cgroups_cpu", NULL, "proc.internal", NULL, "NetData CGroups Plugin CPU usage", "milliseconds/s", 132000, rrd_update_every, RRDSET_TYPE_STACKED);
+                stcpu_thread = rrdset_create("netdata", "plugin_cgroups_cpu", NULL, "cgroups", NULL, "NetData CGroups Plugin CPU usage", "milliseconds/s", 132000, rrd_update_every, RRDSET_TYPE_STACKED);
 
                 rrddim_add(stcpu_thread, "user",  NULL,  1, 1000, RRDDIM_INCREMENTAL);
                 rrddim_add(stcpu_thread, "system", NULL, 1, 1000, RRDDIM_INCREMENTAL);

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -28,7 +28,7 @@ void read_cgroup_plugin_configuration() {
     cgroup_enable_blkio = config_get_boolean_ondemand("plugin:cgroups", "enable blkio", cgroup_enable_blkio);
 
     char filename[FILENAME_MAX + 1], *s;
-    struct mountinfo *mi, *root = mountinfo_read();
+    struct mountinfo *mi, *root = mountinfo_read(0);
 
     mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
     if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -1427,9 +1427,8 @@ int do_sys_fs_cgroup(int update_every, usec_t dt) {
     return 0;
 }
 
-void *cgroups_main(void *ptr)
-{
-    (void)ptr;
+void *cgroups_main(void *ptr) {
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     info("CGROUP Plugin thread created with task id %d", gettid());
 
@@ -1501,6 +1500,8 @@ void *cgroups_main(void *ptr)
 
     info("CGROUP thread exiting");
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -2097,7 +2097,6 @@ void web_client_process(struct web_client *w) {
 
                     error("web request to exit received.");
                     netdata_cleanup_and_exit(0);
-                    netdata_exit = 1;
                 }
                 else if(hash == hash_debug && strcmp(tok, "debug") == 0) {
                     buffer_flush(w->response.data);

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -390,7 +390,7 @@ static inline void cleanup_web_clients(void) {
 #define CLEANUP_EVERY_EVENTS 100
 
 void *socket_listen_main_multi_threaded(void *ptr) {
-    (void)ptr;
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     web_server_mode = WEB_SERVER_MODE_MULTI_THREADED;
     info("Multi-threaded WEB SERVER thread created with task id %d", gettid());
@@ -470,6 +470,9 @@ void *socket_listen_main_multi_threaded(void *ptr) {
     debug(D_WEB_CLIENT, "LISTENER: exit!");
     close_listen_sockets();
 
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
+    pthread_exit(NULL);
     return NULL;
 }
 
@@ -518,7 +521,7 @@ static inline int single_threaded_unlink_client(struct web_client *w, fd_set *if
 }
 
 void *socket_listen_main_single_threaded(void *ptr) {
-    (void)ptr;
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     web_server_mode = WEB_SERVER_MODE_SINGLE_THREADED;
 
@@ -637,5 +640,9 @@ void *socket_listen_main_single_threaded(void *ptr) {
 
     debug(D_WEB_CLIENT, "LISTENER: exit!");
     close_listen_sockets();
+
+    static_thread->enabled = 0;
+    static_thread->thread = NULL;
+    pthread_exit(NULL);
     return NULL;
 }


### PR DESCRIPTION
## the problem

`statvfs()`, the call that is used for disk space monitoring, is veeeeeery slow, causing the whole `proc` and `sys` plugins to be delayed.

The result is that under heavy system load, most internal plugins show gaps on the charts.

## the solution

disk space monitoring is now moved to its own thread, totally independent of the other `proc` and `sys` plugins.

---

additionally, this PR includes several improvements that allow netdata to exit in a more manageable way.