### PR TITLE
Adapt processors and pid_max to macOS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,9 @@ dist_cache_DATA = .keep
 dist_varlib_DATA = .keep
 dist_registry_DATA = .keep
 dist_log_DATA = .keep
+if !MACOS
 plugins_PROGRAMS = apps.plugin
+endif
 
 netdata_SOURCES = \
 	appconfig.c appconfig.h \

--- a/src/macos_sysctl.c
+++ b/src/macos_sysctl.c
@@ -20,12 +20,8 @@
 // NEEDED BY do_uptime
 #include <time.h>
 
-#define GETSYSCTL(name, var) getsysctl(name, &(var), sizeof(var))
-
 // MacOS calculates load averages once every 5 seconds
 #define MIN_LOADAVG_UPDATE_EVERY 5
-
-int getsysctl(const char *name, void *ptr, size_t len);
 
 int do_macos_sysctl(int update_every, usec_t dt) {
     (void)dt;

--- a/src/plugin_macos.h
+++ b/src/plugin_macos.h
@@ -3,6 +3,10 @@
 
 void *macos_main(void *ptr);
 
+#define GETSYSCTL(name, var) getsysctl(name, &(var), sizeof(var))
+
+extern int getsysctl(const char *name, void *ptr, size_t len);
+
 extern int do_macos_sysctl(int update_every, usec_t dt);
 extern int do_macos_mach_smi(int update_every, usec_t dt);
 extern int do_macos_iokit(int update_every, usec_t dt);


### PR DESCRIPTION
@vlvkobal could you please review that? Thank you for starting porting netdata to macOS. This is fantastic!

I moved `getsysctl()` to commons.c because otherwise I get this error:

```
clang: warning: argument unused during compilation: '-pthread'
Undefined symbols for architecture x86_64:
  "_getsysctl", referenced from:
      _get_system_cpus in common.o
      _get_system_pid_max in common.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [apps.plugin] Error 1
make[1]: *** [all-recursive] Error 1
```

Can somebody help me with that?