### PR TITLE
elasticsearch plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -28,6 +28,7 @@ dist_pythonconfig_DATA = \
     python.d/bind_rndc.conf \
     python.d/cpufreq.conf \
     python.d/dovecot.conf \
+    python.d/elasticsearch.conf \
     python.d/example.conf \
     python.d/exim.conf \
     python.d/fail2ban.conf \
@@ -60,6 +61,7 @@ dist_healthconfig_DATA = \
     health.d/bind_rndc.conf \
     health.d/cpu.conf \
     health.d/disks.conf \
+    health.d/elasticsearch.conf \
     health.d/entropy.conf \
     health.d/haproxy.conf \
     health.d/ipc.conf \

--- a/conf.d/health.d/elasticsearch.conf
+++ b/conf.d/health.d/elasticsearch.conf
@@ -1,0 +1,9 @@
+   alarm: elasticsearch_last_collected
+      on: elasticsearch_local.cluster_health_status
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+    info: number of seconds since the last successful data collection
+      to: sysadmin

--- a/conf.d/python.d/elasticsearch.conf
+++ b/conf.d/python.d/elasticsearch.conf
@@ -1,0 +1,72 @@
+# netdata python.d.plugin configuration for elasticsearch stats
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, elasticsearch plugin also supports the following:
+#
+#     host: 'ipaddress'                # Server ip address or hostname.
+#     port: 'port'                     # Port on which elasticsearch  listen.
+#     cluster_health: False/True       # Calls to cluster health elasticsearch API. Enabled by default.
+#     cluster_stats: False/True        # Calls to cluster stats elasticsearch API. Enabled by default.
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+#
+#local:
+# host: '127.0.0.1'
+# port: '9200'
+# cluster_health: True
+# cluster_stats: True

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -14,6 +14,7 @@ dist_python_SCRIPTS = \
     cpufreq.chart.py \
     cpuidle.chart.py \
     dovecot.chart.py \
+    elasticsearch.chart.py \
     example.chart.py \
     exim.chart.py \
     fail2ban.chart.py \

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -162,7 +162,7 @@ CHARTS = {
             ['store_size_in_bytes', 'size', 'absolute', 1, 1048567]
         ]},
     'cluster_stats_indices_shards': {
-        'options': [None, 'Inidecs and shards statistics', 'count', 'Cluster stats API',
+        'options': [None, 'Indices and shards statistics', 'count', 'Cluster stats API',
                     'es.cluster_stats_ind_sha', 'stacked'],
         'lines': [
             ['indices_count', 'indices', 'absolute'],
@@ -256,10 +256,7 @@ class Service(UrlService):
             thread.join()
             result.update(queue.get())
 
-        if result:
-            return result
-        else:
-            return None
+        return result or None
 
     def _get_cluster_health(self, queue, url):
         """

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+# Description: elastic search node stats netdata python.d module
+# Author: l2isbad
+
+from base import UrlService
+from requests import get
+from socket import gethostbyname
+try:
+        from queue import Queue
+except ImportError:
+        from Queue import Queue
+from threading import Thread
+
+# default module values (can be overridden per job in `config`)
+# update_every = 2
+update_every = 5
+priority = 60000
+retries = 60
+
+# charts order (can be overridden if you want less charts, or different order)
+ORDER = ['search_perf_total', 'search_perf_time', 'search_latency', 'index_perf_total', 'index_perf_time',
+         'index_latency', 'jvm_mem_heap', 'jvm_gc_count', 'jvm_gc_time', 'thread_pool_qr', 'fdata_cache',
+         'fdata_ev_tr', 'cluster_health_nodes', 'cluster_health_shards', 'cluster_stats_nodes',
+         'cluster_stats_query_cache', 'cluster_stats_docs', 'cluster_stats_store', 'cluster_stats_indices_shards']
+
+CHARTS = {
+    'search_perf_total': {
+        'options': [None, 'Number of queries, fetches', 'queries', 'Search performance', 'es.search_query', 'stacked'],
+        'lines': [
+            ['query_total', 'search_total', 'incremental'],
+            ["fetch_total", 'fetch_total', 'incremental'],
+            ["query_current", 'search_current', 'absolute'],
+            ["fetch_current", 'fetch_current', 'absolute']
+        ]},
+    'search_perf_time': {
+        'options': [None, 'Time spent on queries, fetches', 'seconds', 'Search performance', 'es.search_time', 'stacked'],
+        'lines': [
+            ["query_time_in_millis", 'query', 'incremental', 1, 1000],
+            ["fetch_time_in_millis", 'fetch', 'incremental', 1, 1000]
+        ]},
+    'search_latency': {
+        'options': [None, 'Query and fetch latency', 'ms', 'Search performance', 'es.search_latency', 'stacked'],
+        'lines': [
+            ["query_latency", 'query', 'absolute', 1, 1000],
+            ["fetch_latency", 'fetch', 'absolute', 1, 1000]
+        ]},
+    'index_perf_total': {
+        'options': [None, 'Number of documents indexed, index refreshes, flushes', 'documents/indexes',
+                    'Indexing performance', 'es.index_doc', 'stacked'],
+        'lines': [
+            ['indexing_index_total', 'indexed', 'incremental'],
+            ["refresh_total", 'refreshes', 'incremental'],
+            ["flush_total", 'flushes', 'incremental'],
+            ["indexing_index_current", 'indexed_current', 'absolute'],
+        ]},
+    'index_perf_time': {
+        'options': [None, 'Time spent on indexing, refreshing, flushing', 'seconds', 'Indexing performance',
+                    'es.search_time', 'stacked'],
+        'lines': [
+            ['indexing_index_time_in_millis', 'indexing', 'incremental', 1, 1000],
+            ['refresh_total_time_in_millis', 'refreshing', 'incremental', 1, 1000],
+            ['flush_total_time_in_millis', 'flushing', 'incremental', 1, 1000]
+        ]},
+    'index_latency': {
+        'options': [None, 'Indexing and flushing latency', 'ms', 'Indexing performance',
+                    'es.index_latency', 'stacked'],
+        'lines': [
+            ['indexing_latency', 'indexing', 'absolute', 1, 1000],
+            ['flushing_latency', 'flushing', 'absolute', 1, 1000]
+        ]},
+    'jvm_mem_heap': {
+        'options': [None, 'JVM heap currently in use/committed', 'percent/MB', 'Memory usage and gc',
+                    'es.jvm_heap', 'area'],
+        'lines': [
+            ["jvm_heap_percent", 'inuse', 'absolute'],
+            ["jvm_heap_commit", 'commit', 'absolute', -1, 1048576]
+        ]},
+    'jvm_gc_count': {
+        'options': [None, 'Count of garbage collections', 'counts', 'Memory usage and gc', 'es.gc_count', 'stacked'],
+        'lines': [
+            ["young_collection_count", 'young', 'incremental'],
+            ["old_collection_count", 'old', 'incremental']
+        ]},
+    'jvm_gc_time': {
+        'options': [None, 'Time spent on garbage collections', 'ms', 'Memory usage and gc', 'es.gc_time', 'stacked'],
+        'lines': [
+            ["young_collection_time_in_millis", 'young', 'incremental'],
+            ["old_collection_time_in_millis", 'old', 'incremental']
+        ]},
+    'thread_pool_qr': {
+        'options': [None, 'Number of queued/rejected threads in thread pool', 'threads', 'Queues and rejections',
+                    'es.qr', 'stacked'],
+        'lines': [
+            ["bulk_queue", 'bulk_queue', 'absolute'],
+            ["index_queue", 'index_queue', 'absolute'],
+            ["search_queue", 'search_queue', 'absolute'],
+            ["merge_queue", 'merge_queue', 'absolute'],
+            ["bulk_rejected", 'bulk_rej', 'absolute'],
+            ["index_rejected", 'index_rej', 'absolute'],
+            ["search_rejected", 'search_rej', 'absolute'],
+            ["merge_rejected", 'merge_rej', 'absolute']
+        ]},
+    'fdata_cache': {
+        'options': [None, 'Fielddata cache size', 'MB', 'Fielddata cache', 'es.fdata_cache', 'line'],
+        'lines': [
+            ["index_fdata_mem", 'mem_size', 'absolute', 1, 1048576]
+        ]},
+    'fdata_ev_tr': {
+        'options': [None, 'Fielddata evictions and circuit breaker tripped count', 'number of events',
+                    'Fielddata cache', 'es.fdata_ev_tr', 'line'],
+        'lines': [
+            ["index_fdata_evic", 'evictions', 'incremental'],
+            ["breakers_fdata_trip", 'tripped', 'incremental']
+        ]},
+    'cluster_health_nodes': {
+        'options': [None, 'Nodes and tasks statistics', 'units', 'Cluster health API',
+                    'es.cluster_health', 'stacked'],
+        'lines': [
+            ["health_number_of_nodes", 'nodes', 'absolute'],
+            ["health_number_of_data_nodes", 'data_nodes', 'absolute'],
+            ["health_number_of_pending_tasks", 'pending_tasks', 'absolute'],
+            ["health_number_of_in_flight_fetch", 'inflight_fetch', 'absolute']
+        ]},
+    'cluster_health_shards': {
+        'options': [None, 'Shards statistics', 'shards', 'Cluster health API',
+                    'es.cluster_health_sharts', 'stacked'],
+        'lines': [
+            ["health_active_shards", 'active_shards', 'absolute'],
+            ["health_relocating_shards", 'relocating_shards', 'absolute'],
+            ["health_unassigned_shards", 'unassigned', 'absolute'],
+            ["health_delayed_unassigned_shards", 'delayed_unassigned', 'absolute'],
+            ["health_initializing_shards", 'initializing', 'absolute'],
+            ["health_active_shards_percent_as_number", 'active_percent', 'absolute']
+        ]},
+    'cluster_stats_nodes': {
+        'options': [None, 'Nodes statistics', 'nodes', 'Cluster stats API',
+                    'es.cluster_stats_nodes', 'stacked'],
+        'lines': [
+            ['count_data_only', 'data_only', 'absolute'],
+            ['count_master_data', 'master_data', 'absolute'],
+            ['count_total', 'total', 'absolute'],
+            ['count_master_only', 'master_only', 'absolute'],
+            ['count_client', 'client', 'absolute']
+        ]},
+    'cluster_stats_query_cache': {
+        'options': [None, 'Query cache statistics', 'queries', 'Cluster stats API',
+                    'es.cluster_stats_query_cache', 'stacked'],
+        'lines': [
+            ['query_cache_hit_count', 'hit', 'incremental'],
+            ['query_cache_miss_count', 'miss', 'incremental']
+        ]},
+    'cluster_stats_docs': {
+        'options': [None, 'Docs statistics', 'count', 'Cluster stats API',
+                    'es.cluster_stats_docs', 'line'],
+        'lines': [
+            ['docs_count', 'docs', 'absolute']
+        ]},
+    'cluster_stats_store': {
+        'options': [None, 'Store statistics', 'MB', 'Cluster stats API',
+                    'es.cluster_stats_store', 'line'],
+        'lines': [
+            ['store_size_in_bytes', 'size', 'absolute', 1, 1048567]
+        ]},
+    'cluster_stats_indices_shards': {
+        'options': [None, 'Inidecs and shards statistics', 'count', 'Cluster stats API',
+                    'es.cluster_stats_ind_sha', 'stacked'],
+        'lines': [
+            ['indices_count', 'indices', 'absolute'],
+            ['shards_total', 'shards', 'absolute']
+        ]}
+}
+
+
+class Service(UrlService):
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.host = self.configuration.get('host')
+        self.port = self.configuration.get('port')
+        self.user = self.configuration.get('user')
+        self.password = self.configuration.get('pass')
+        self.latency = dict()
+
+    def check(self):
+        # We can't start if <host> AND <port> not specified
+        if not all([self.host, self.port]):
+            return False
+
+        # It as a bad idea to use hostname.
+        # Hostname -> ipaddress
+        try:
+            self.host = gethostbyname(self.host)
+        except Exception as e:
+            self.error(str(e))
+            return False
+
+        # HTTP Auth? NOT TESTED
+        self.auth = self.user and self.password
+
+        # Create URL for every Elasticsearch API
+        url_node_stats = 'http://%s:%s/_nodes/_local/stats' % (self.host, self.port)
+        url_cluster_health = 'http://%s:%s/_cluster/health' % (self.host, self.port)
+        url_cluster_stats = 'http://%s:%s/_cluster/stats' % (self.host, self.port)
+
+        # Create list of enabled API calls
+        user_choice = [bool(self.configuration.get('node_stats', True)),
+                       bool(self.configuration.get('cluster_health', True)),
+                       bool(self.configuration.get('cluster_stats', True))]
+        
+        avail_methods = [(self._get_node_stats, url_node_stats), 
+                        (self._get_cluster_health, url_cluster_health),
+                        (self._get_cluster_stats, url_cluster_stats)]
+
+        # Remove disabled API calls from 'avail methods'
+        self.methods = [choice[0] for choice in list(zip(avail_methods, user_choice)) if choice[1]]
+
+        # Run _get_data for ALL active API calls. 
+        api_result = {}
+        for method in self.methods:
+            api_result[method[1]] = (bool(self._get_raw_data(method[1])))
+
+        # We can start ONLY if all active API calls returned NOT None
+        if not all(api_result.values()):
+            self.error('Plugin could not get data from all APIs')
+            self.error('%s' % api_result)
+            return False
+        else:
+            self.info('%s' % api_result)
+            self.info('Plugin was started successfully')
+
+            return True
+
+    def _get_raw_data(self, url):
+        try:
+            if not self.auth:
+                raw_data = get(url)
+            else:
+                raw_data = get(url, auth=(self.user, self.password))
+        except Exception:
+            return None
+
+        return raw_data
+
+    def _get_data(self):
+        threads = list()
+        queue = Queue()
+        result = dict()
+
+        for method in self.methods:
+            th = Thread(target=method[0], args=(queue, method[1]))
+            th.start()
+            threads.append(th)
+
+        for thread in threads:
+            thread.join()
+            result.update(queue.get())
+
+        if result:
+            return result
+        else:
+            return None
+
+    def _get_cluster_health(self, queue, url):
+        """
+        Format data received from http request
+        :return: dict
+        """
+
+        data = self._get_raw_data(url)
+
+        if not data:
+            queue.put({})
+        else:
+            data = data.json()
+
+            to_netdata = dict()
+            to_netdata.update(update_key('health', data))
+
+            queue.put(to_netdata)
+
+    def _get_cluster_stats(self, queue, url):
+        """
+        Format data received from http request
+        :return: dict
+        """
+
+        data = self._get_raw_data(url)
+
+        if not data:
+            queue.put({})
+        else:
+            data = data.json()
+
+            to_netdata = dict()
+            to_netdata.update(update_key('count', data['nodes']['count']))
+            to_netdata.update(update_key('query_cache', data['indices']['query_cache']))
+            to_netdata.update(update_key('docs', data['indices']['docs']))
+            to_netdata.update(update_key('store', data['indices']['store']))
+            to_netdata['indices_count'] = data['indices']['count']
+            to_netdata['shards_total'] = data['indices']['shards']['total']
+
+            queue.put(to_netdata)
+
+    def _get_node_stats(self, queue, url):
+        """
+        Format data received from http request
+        :return: dict
+        """
+
+        data = self._get_raw_data(url)
+
+        if not data:
+            queue.put({})
+        else:
+            data = data.json()
+            node = list(data['nodes'].keys())[0]
+            to_netdata = dict()
+            # Search performance metrics
+            to_netdata.update(data['nodes'][node]['indices']['search'])
+            to_netdata['query_latency'] = self.find_avg(to_netdata['query_total'],
+                                               to_netdata['query_time_in_millis'], 'query_latency')
+            to_netdata['fetch_latency'] = self.find_avg(to_netdata['fetch_total'],
+                                               to_netdata['fetch_time_in_millis'], 'fetch_latency')
+
+            # Indexing performance metrics
+            for key in ['indexing', 'refresh', 'flush']:
+                to_netdata.update(update_key(key, data['nodes'][node]['indices'].get(key, {})))
+            to_netdata['indexing_latency'] = self.find_avg(to_netdata['indexing_index_total'],
+                                               to_netdata['indexing_index_time_in_millis'], 'index_latency')
+            to_netdata['flushing_latency'] = self.find_avg(to_netdata['flush_total'],
+                                               to_netdata['flush_total_time_in_millis'], 'flush_latency')
+            # Memory usage and garbage collection
+            to_netdata.update(update_key('young', data['nodes'][node]['jvm']['gc']['collectors']['young']))
+            to_netdata.update(update_key('old', data['nodes'][node]['jvm']['gc']['collectors']['old']))
+            to_netdata['jvm_heap_percent'] = data['nodes'][node]['jvm']['mem']['heap_used_percent']
+            to_netdata['jvm_heap_commit'] = data['nodes'][node]['jvm']['mem']['heap_committed_in_bytes']
+
+            # Thread pool queues and rejections
+            for key in ['bulk', 'index', 'search', 'merge']:
+                to_netdata.update(update_key(key, data['nodes'][node]['thread_pool'].get(key, {})))
+
+            # Fielddata cache
+            to_netdata['index_fdata_mem'] = data['nodes'][node]['indices']['fielddata']['memory_size_in_bytes']
+            to_netdata['index_fdata_evic'] = data['nodes'][node]['indices']['fielddata']['evictions']
+            to_netdata['breakers_fdata_trip'] = data['nodes'][node]['breakers']['fielddata']['tripped']
+
+            queue.put(to_netdata)
+
+    def find_avg(self, value1, value2, key):
+        if key not in self.latency.keys():
+            self.latency.update({key: [value1, value2]})
+            return 0
+        else:
+            if not self.latency[key][0] == value1:
+                latency = round(float(value2 - self.latency[key][1]) / float(value1 - self.latency[key][0]) * 1000)
+                self.latency.update({key: [value1, value2]})
+                return latency
+            else:
+                self.latency.update({key: [value1, value2]})
+                return 0
+
+
+def update_key(string, dictionary):
+    return {'_'.join([string, k]): v for k, v in dictionary.items()}

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -224,7 +224,7 @@ class Service(UrlService):
                         (self._get_cluster_stats, url_cluster_stats)]
 
         # Remove disabled API calls from 'avail methods'
-        self.methods = [choice[0] for choice in list(zip(avail_methods, user_choice)) if choice[1]]
+        self.methods = [avail_methods[_] for _ in range(len(avail_methods)) if user_choice[_]]
 
         # Run _get_data for ALL active API calls. 
         api_result = {}
@@ -284,10 +284,9 @@ class Service(UrlService):
 
             to_netdata = dict()
             to_netdata.update(update_key('health', data))
-            to_netdata['status_green'] = 1 if to_netdata.get('health_status') == 'green' else 0
-            to_netdata['status_red'] = 1 if to_netdata.get('health_status') == 'red' else 0
-            to_netdata['status_yellow'] = 1 if to_netdata.get('health_status') == 'yellow' else 0
-            to_netdata['status_foo1'], to_netdata['status_foo2'], to_netdata['status_foo3'] = 0, 0, 0
+            to_netdata.update({'status_green': 0, 'status_red': 0, 'status_yellow': 0,
+                               'status_foo1': 0, 'status_foo2': 0, 'status_foo3': 0})
+            to_netdata[''.join(['status_', to_netdata.get('health_status', '')])] = 1
 
             queue.put(to_netdata)
 
@@ -360,7 +359,7 @@ class Service(UrlService):
             queue.put(to_netdata)
 
     def find_avg(self, value1, value2, key):
-        if key not in self.latency.keys():
+        if key not in self.latency:
             self.latency.update({key: [value1, value2]})
             return 0
         else:

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -20,7 +20,7 @@ retries = 60
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_perf_total', 'search_perf_time', 'search_latency', 'index_perf_total', 'index_perf_time',
          'index_latency', 'jvm_mem_heap', 'jvm_gc_count', 'jvm_gc_time', 'thread_pool_qr', 'fdata_cache',
-         'fdata_ev_tr', 'cluster_health_nodes', 'cluster_health_shards', 'cluster_stats_nodes',
+         'fdata_ev_tr', 'cluster_health_status', 'cluster_health_nodes', 'cluster_health_shards', 'cluster_stats_nodes',
          'cluster_stats_query_cache', 'cluster_stats_docs', 'cluster_stats_store', 'cluster_stats_indices_shards']
 
 CHARTS = {
@@ -120,6 +120,17 @@ CHARTS = {
             ["health_number_of_data_nodes", 'data_nodes', 'absolute'],
             ["health_number_of_pending_tasks", 'pending_tasks', 'absolute'],
             ["health_number_of_in_flight_fetch", 'inflight_fetch', 'absolute']
+        ]},
+    'cluster_health_status': {
+        'options': [None, 'Cluster status', 'status', 'Cluster health API',
+                    'es.cluster_health_status', 'area'],
+        'lines': [
+            ["status_green", 'green', 'absolute'],
+            ["status_red", 'red', 'absolute'],
+            ["status_foo1", None, 'absolute'],
+            ["status_foo2", None, 'absolute'],
+            ["status_foo3", None, 'absolute'],
+            ["status_yellow", 'yellow', 'absolute']
         ]},
     'cluster_health_shards': {
         'options': [None, 'Shards statistics', 'shards', 'Cluster health API',
@@ -273,6 +284,10 @@ class Service(UrlService):
 
             to_netdata = dict()
             to_netdata.update(update_key('health', data))
+            to_netdata['status_green'] = 1 if to_netdata.get('health_status') == 'green' else 0
+            to_netdata['status_red'] = 1 if to_netdata.get('health_status') == 'red' else 0
+            to_netdata['status_yellow'] = 1 if to_netdata.get('health_status') == 'yellow' else 0
+            to_netdata['status_foo1'], to_netdata['status_foo2'], to_netdata['status_foo3'] = 0, 0, 0
 
             queue.put(to_netdata)
 

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -19,8 +19,9 @@ retries = 60
 
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_perf_total', 'search_perf_time', 'search_latency', 'index_perf_total', 'index_perf_time',
-         'index_latency', 'jvm_mem_heap', 'jvm_gc_count', 'jvm_gc_time', 'thread_pool_qr', 'fdata_cache',
-         'fdata_ev_tr', 'cluster_health_status', 'cluster_health_nodes', 'cluster_health_shards', 'cluster_stats_nodes',
+         'index_latency', 'jvm_mem_heap', 'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
+         'host_metrics_http', 'host_metrics_transport', 'thread_pool_qr', 'fdata_cache', 'fdata_ev_tr',
+         'cluster_health_status', 'cluster_health_nodes', 'cluster_health_shards', 'cluster_stats_nodes',
          'cluster_stats_query_cache', 'cluster_stats_docs', 'cluster_stats_store', 'cluster_stats_indices_shards']
 
 CHARTS = {
@@ -28,30 +29,30 @@ CHARTS = {
         'options': [None, 'Number of queries, fetches', 'queries', 'Search performance', 'es.search_query', 'stacked'],
         'lines': [
             ['query_total', 'search_total', 'incremental'],
-            ["fetch_total", 'fetch_total', 'incremental'],
-            ["query_current", 'search_current', 'absolute'],
-            ["fetch_current", 'fetch_current', 'absolute']
+            ['fetch_total', 'fetch_total', 'incremental'],
+            ['query_current', 'search_current', 'absolute'],
+            ['fetch_current', 'fetch_current', 'absolute']
         ]},
     'search_perf_time': {
         'options': [None, 'Time spent on queries, fetches', 'seconds', 'Search performance', 'es.search_time', 'stacked'],
         'lines': [
-            ["query_time_in_millis", 'query', 'incremental', 1, 1000],
-            ["fetch_time_in_millis", 'fetch', 'incremental', 1, 1000]
+            ['query_time_in_millis', 'query', 'incremental', 1, 1000],
+            ['fetch_time_in_millis', 'fetch', 'incremental', 1, 1000]
         ]},
     'search_latency': {
         'options': [None, 'Query and fetch latency', 'ms', 'Search performance', 'es.search_latency', 'stacked'],
         'lines': [
-            ["query_latency", 'query', 'absolute', 1, 1000],
-            ["fetch_latency", 'fetch', 'absolute', 1, 1000]
+            ['query_latency', 'query', 'absolute', 1, 1000],
+            ['fetch_latency', 'fetch', 'absolute', 1, 1000]
         ]},
     'index_perf_total': {
         'options': [None, 'Number of documents indexed, index refreshes, flushes', 'documents/indexes',
                     'Indexing performance', 'es.index_doc', 'stacked'],
         'lines': [
             ['indexing_index_total', 'indexed', 'incremental'],
-            ["refresh_total", 'refreshes', 'incremental'],
-            ["flush_total", 'flushes', 'incremental'],
-            ["indexing_index_current", 'indexed_current', 'absolute'],
+            ['refresh_total', 'refreshes', 'incremental'],
+            ['flush_total', 'flushes', 'incremental'],
+            ['indexing_index_current', 'indexed_current', 'absolute'],
         ]},
     'index_perf_time': {
         'options': [None, 'Time spent on indexing, refreshing, flushing', 'seconds', 'Indexing performance',
@@ -72,76 +73,76 @@ CHARTS = {
         'options': [None, 'JVM heap currently in use/committed', 'percent/MB', 'Memory usage and gc',
                     'es.jvm_heap', 'area'],
         'lines': [
-            ["jvm_heap_percent", 'inuse', 'absolute'],
-            ["jvm_heap_commit", 'commit', 'absolute', -1, 1048576]
+            ['jvm_heap_percent', 'inuse', 'absolute'],
+            ['jvm_heap_commit', 'commit', 'absolute', -1, 1048576]
         ]},
     'jvm_gc_count': {
         'options': [None, 'Count of garbage collections', 'counts', 'Memory usage and gc', 'es.gc_count', 'stacked'],
         'lines': [
-            ["young_collection_count", 'young', 'incremental'],
-            ["old_collection_count", 'old', 'incremental']
+            ['young_collection_count', 'young', 'incremental'],
+            ['old_collection_count', 'old', 'incremental']
         ]},
     'jvm_gc_time': {
         'options': [None, 'Time spent on garbage collections', 'ms', 'Memory usage and gc', 'es.gc_time', 'stacked'],
         'lines': [
-            ["young_collection_time_in_millis", 'young', 'incremental'],
-            ["old_collection_time_in_millis", 'old', 'incremental']
+            ['young_collection_time_in_millis', 'young', 'incremental'],
+            ['old_collection_time_in_millis', 'old', 'incremental']
         ]},
     'thread_pool_qr': {
         'options': [None, 'Number of queued/rejected threads in thread pool', 'threads', 'Queues and rejections',
                     'es.qr', 'stacked'],
         'lines': [
-            ["bulk_queue", 'bulk_queue', 'absolute'],
-            ["index_queue", 'index_queue', 'absolute'],
-            ["search_queue", 'search_queue', 'absolute'],
-            ["merge_queue", 'merge_queue', 'absolute'],
-            ["bulk_rejected", 'bulk_rej', 'absolute'],
-            ["index_rejected", 'index_rej', 'absolute'],
-            ["search_rejected", 'search_rej', 'absolute'],
-            ["merge_rejected", 'merge_rej', 'absolute']
+            ['bulk_queue', 'bulk_queue', 'absolute'],
+            ['index_queue', 'index_queue', 'absolute'],
+            ['search_queue', 'search_queue', 'absolute'],
+            ['merge_queue', 'merge_queue', 'absolute'],
+            ['bulk_rejected', 'bulk_rej', 'absolute'],
+            ['index_rejected', 'index_rej', 'absolute'],
+            ['search_rejected', 'search_rej', 'absolute'],
+            ['merge_rejected', 'merge_rej', 'absolute']
         ]},
     'fdata_cache': {
         'options': [None, 'Fielddata cache size', 'MB', 'Fielddata cache', 'es.fdata_cache', 'line'],
         'lines': [
-            ["index_fdata_mem", 'mem_size', 'absolute', 1, 1048576]
+            ['index_fdata_mem', 'mem_size', 'absolute', 1, 1048576]
         ]},
     'fdata_ev_tr': {
         'options': [None, 'Fielddata evictions and circuit breaker tripped count', 'number of events',
                     'Fielddata cache', 'es.fdata_ev_tr', 'line'],
         'lines': [
-            ["index_fdata_evic", 'evictions', 'incremental'],
-            ["breakers_fdata_trip", 'tripped', 'incremental']
+            ['index_fdata_evic', 'evictions', 'incremental'],
+            ['breakers_fdata_trip', 'tripped', 'incremental']
         ]},
     'cluster_health_nodes': {
         'options': [None, 'Nodes and tasks statistics', 'units', 'Cluster health API',
                     'es.cluster_health', 'stacked'],
         'lines': [
-            ["health_number_of_nodes", 'nodes', 'absolute'],
-            ["health_number_of_data_nodes", 'data_nodes', 'absolute'],
-            ["health_number_of_pending_tasks", 'pending_tasks', 'absolute'],
-            ["health_number_of_in_flight_fetch", 'inflight_fetch', 'absolute']
+            ['health_number_of_nodes', 'nodes', 'absolute'],
+            ['health_number_of_data_nodes', 'data_nodes', 'absolute'],
+            ['health_number_of_pending_tasks', 'pending_tasks', 'absolute'],
+            ['health_number_of_in_flight_fetch', 'inflight_fetch', 'absolute']
         ]},
     'cluster_health_status': {
         'options': [None, 'Cluster status', 'status', 'Cluster health API',
                     'es.cluster_health_status', 'area'],
         'lines': [
-            ["status_green", 'green', 'absolute'],
-            ["status_red", 'red', 'absolute'],
-            ["status_foo1", None, 'absolute'],
-            ["status_foo2", None, 'absolute'],
-            ["status_foo3", None, 'absolute'],
-            ["status_yellow", 'yellow', 'absolute']
+            ['status_green', 'green', 'absolute'],
+            ['status_red', 'red', 'absolute'],
+            ['status_foo1', None, 'absolute'],
+            ['status_foo2', None, 'absolute'],
+            ['status_foo3', None, 'absolute'],
+            ['status_yellow', 'yellow', 'absolute']
         ]},
     'cluster_health_shards': {
         'options': [None, 'Shards statistics', 'shards', 'Cluster health API',
                     'es.cluster_health_sharts', 'stacked'],
         'lines': [
-            ["health_active_shards", 'active_shards', 'absolute'],
-            ["health_relocating_shards", 'relocating_shards', 'absolute'],
-            ["health_unassigned_shards", 'unassigned', 'absolute'],
-            ["health_delayed_unassigned_shards", 'delayed_unassigned', 'absolute'],
-            ["health_initializing_shards", 'initializing', 'absolute'],
-            ["health_active_shards_percent_as_number", 'active_percent', 'absolute']
+            ['health_active_shards', 'active_shards', 'absolute'],
+            ['health_relocating_shards', 'relocating_shards', 'absolute'],
+            ['health_unassigned_shards', 'unassigned', 'absolute'],
+            ['health_delayed_unassigned_shards', 'delayed_unassigned', 'absolute'],
+            ['health_initializing_shards', 'initializing', 'absolute'],
+            ['health_active_shards_percent_as_number', 'active_percent', 'absolute']
         ]},
     'cluster_stats_nodes': {
         'options': [None, 'Nodes statistics', 'nodes', 'Cluster stats API',
@@ -178,6 +179,25 @@ CHARTS = {
         'lines': [
             ['indices_count', 'indices', 'absolute'],
             ['shards_total', 'shards', 'absolute']
+        ]},
+    'host_metrics_transport': {
+        'options': [None, 'Cluster communication transport metrics', 'kbit/s', 'Host metrics',
+                    'es.host_metrics_transport', 'area'],
+        'lines': [
+            ['transport_rx_size_in_bytes', 'in', 'incremental', 8, 1000],
+            ['transport_tx_size_in_bytes', 'out', 'incremental', -8, 1000]
+        ]},
+    'host_metrics_file_descriptors': {
+        'options': [None, 'Available file descriptors in percent', 'percent', 'Host metrics',
+                    'es.host_metrics_descriptors', 'area'],
+        'lines': [
+            ['file_descriptors_used', 'used', 'absolute', 1, 10]
+        ]},
+    'host_metrics_http': {
+        'options': [None, 'Opened HTTP connections', 'connections', 'Host metrics',
+                    'es.host_metrics_http', 'line'],
+        'lines': [
+            ['http_current_open', 'opened', 'absolute', 1, 1]
         ]}
 }
 
@@ -356,6 +376,12 @@ class Service(UrlService):
             to_netdata['index_fdata_evic'] = data['nodes'][node]['indices']['fielddata']['evictions']
             to_netdata['breakers_fdata_trip'] = data['nodes'][node]['breakers']['fielddata']['tripped']
 
+            # Host metrics
+            to_netdata.update(update_key('http', data['nodes'][node]['http']))
+            to_netdata.update(update_key('transport', data['nodes'][node]['transport']))
+            to_netdata['file_descriptors_used'] = round(float(data['nodes'][node]['process']['open_file_descriptors'])
+                                                        / data['nodes'][node]['process']['max_file_descriptors'] * 1000)
+            
             queue.put(to_netdata)
 
     def find_avg(self, value1, value2, key):


### PR DESCRIPTION
This one is heavy. (update_interval every 5 sec by default)

**It uses 3 different api calls to get data.**

1. Node Stats API
2. Cluster Stats API
3. Cluster Health API

All of them enabled by default. Any of them can be disabled in conf file.
All requests executed simultaneously.

23 charts
I am not a ES expert (not even close). But I tried to follow [datadog](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/) way choosing which metrics should be collected.
Must be tested.
