### PR TITLE
Initial implementation of Discord notifications

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -7,6 +7,7 @@
 # - e-mails (using the sendmail command),
 # - push notifications to your mobile phone (pushover.net),
 # - messages to your slack team (slack.com),
+# - messages to your discord guild (discordapp.com),
 # - messages to your telegram chat / group chat (telegram.org)
 # - sms messages to your cell phone or any sms enabled device (twilio.com)
 # - sms messages to your cell phone or any sms enabled device (messagebird.com)
@@ -22,7 +23,7 @@
 # proxy configuration
 #
 # If you need to send curl based notifications (pushover, pushbullet, slack,
-# telegram) via a proxy, set these to your proxy address:
+# discord, telegram) via a proxy, set these to your proxy address:
 #export http_proxy="http://10.0.0.1:3128/"
 #export https_proxy="http://10.0.0.1:3128/"
 
@@ -62,6 +63,7 @@ curl=""
 #  - pushover user tokens
 #  - telegram chat ids
 #  - slack channels
+#  - discord channels
 #  - hipchat rooms
 #  - sms phone numbers
 #  - pagerduty.com (pd) services
@@ -75,6 +77,7 @@ curl=""
 #  pushover   : "2987343...9437837 8756278...2362736|critical"
 #  telegram   : "111827421 112746832|critical"
 #  slack      : "alarms disasters|critical"
+#  discord    : "alarms disasters|critical"
 #  twilio     : "+15555555555 +17777777777|critical"
 #  messagebird: "+15555555555 +17777777777|critical"
 #  pd         : "<pd_service_key_1> <pd_service_key_2>|critical"
@@ -228,6 +231,25 @@ DEFAULT_RECIPIENT_SLACK=""
 
 
 #------------------------------------------------------------------------------
+# discord (discordapp.com) global notification options
+
+# multiple recipients can be given like this:
+#                  "CHANNEL1 CHANNEL2 ..."
+
+# enable/disable sending discord notifications
+SEND_DISCORD="YES"
+
+# Create a webhook by following the official documentation -
+# https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks
+DISCORD_WEBHOOK_URL=""
+
+# if a role's recipients are not configured, a notification will be send to
+# this discord channel (empty = do not send a notification for unconfigured
+# roles):
+DEFAULT_RECIPIENT_DISCORD=""
+
+
+#------------------------------------------------------------------------------
 # hipchat global notification options
 
 # multiple recipients can be given like this:
@@ -295,6 +317,8 @@ role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
 role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
+role_recipients_discord[sysadmin]="${DEFAULT_RECIPIENT_DISCORD}"
+
 role_recipients_hipchat[sysadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
 role_recipients_twilio[sysadmin]="${DEFAULT_RECIPIENT_TWILIO}"
@@ -315,6 +339,8 @@ role_recipients_pushbullet[domainadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 role_recipients_telegram[domainadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
 role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
+
+role_recipients_discord[domainadmin]="${DEFAULT_RECIPIENT_DISCORD}"
 
 role_recipients_hipchat[domainadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
@@ -338,6 +364,8 @@ role_recipients_telegram[dba]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
 role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
 
+role_recipients_discord[dba]="${DEFAULT_RECIPIENT_DISCORD}"
+
 role_recipients_hipchat[dba]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
 role_recipients_twilio[dba]="${DEFAULT_RECIPIENT_TWILIO}"
@@ -360,6 +388,8 @@ role_recipients_telegram[webmaster]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
 role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
 
+role_recipients_discord[webmaster]="${DEFAULT_RECIPIENT_DISCORD}"
+
 role_recipients_hipchat[webmaster]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
 role_recipients_twilio[webmaster]="${DEFAULT_RECIPIENT_TWILIO}"
@@ -381,6 +411,8 @@ role_recipients_pushbullet[proxyadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
 role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
+
+role_recipients_discord[proxyadmin]="${DEFAULT_RECIPIENT_DISCORD}"
 
 role_recipients_hipchat[proxyadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1056,7 +1056,7 @@ send_discord() {
             "channel": "#${channel}",
             "username": "netdata on ${host}",
             "text": "${host} ${status_message}, \`${chart}\` (_${family}_), *${alarm}*",
-            "icon_url": "https://discordapp.com/assets/f78426a064bc9dd24847519259bc42af.png",
+            "icon_url": "${images_base_url}/images/seo-performance-128.png",
             "attachments": [
                 {
                     "color": "${color}",


### PR DESCRIPTION
The following changes implement initial functionality of netdata alerts sent to a Discord guild channel. This ability has been useful within a gaming organization that also handles technical operations within Discord.

I'm including links to pictures showing the functionality of both the 'test' function of alarm-notify, and actual alerts.

According to the [Discord documentation](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook), Slack-compatible webhooks should mostly function when sent to a Discord webhook by appending `/slack` to the webhook URL. I did not find this to be the case, and would receive error code 400 upon sending. After reviewing the [Discord webhook documentation](https://discordapp.com/developers/docs/resources/webhook) and [Slack webhook documentation](https://api.slack.com/incoming-webhooks), I created the necessary changes to successfully send alarm notifications to Discord.

[Test Output](http://i.imgur.com/a4Awjx8.jpg)
[Alert Output](http://i.imgur.com/gOC2CsQ.jpg)