### PR TITLE
fix spelling of "systemd"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,7 +27,7 @@ netdata (1.5.0) - 2016-01-22
    Ilya Mashchenko (@l2isbad) has created most of the python
    data collection plugins in this release !
 
-    - Systemd Services (using cgroups!)
+    - systemd Services (using cgroups!)
     - FPing (yes, network latency in netdata!)
     - postgres databases            @facetoe, @moumoul
     - Vanish disk cache (v3 and v4) @l2isbad

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Netdata is featured at <b><a href="https://octoverse.github.com/" target="_blank
 
  - netdata now runs on **FreeBSD** and **MacOS**
  - netdata now supports **Graphite**, **OpenTSDB**, **Prometheus** and compatible backends
- - netdata now monitors **SystemD Services**
+ - netdata now monitors **systemd Services**
  - new plugins: fping, postgres, varnish, elasticsearch, haproxy, freeradius, mdstat, ISC dhcpd, fail2ban, openvpn, NUMA memory, CPU Idle States, gunicorn, ECC memory errors, IPC semaphores, uptime
  - improved plugins: netfilter conntrack, mysql/mariadb, ipfs, cpufreq, hddtemp, sensors, nginx, nginx_log, phpfpm, redis, dovecot, containers and cgroups, disk space, apps.plugin, tc (QoS) and almost all internal plugins (memory, IPv4 and IPv6, network interfaces, QoS, etc)
  - dozens of new and improved alarms (including performance monitoring alarms for mysql)

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -12,7 +12,7 @@ netdataDashboard.menu = {
     },
 
     'services': {
-        title: 'Systemd Services',
+        title: 'systemd Services',
         icon: '<i class="fa fa-cogs" aria-hidden="true"></i>',
         info: 'Resources utilization of systemd services.'
     },


### PR DESCRIPTION
Per the "spelling" section on the systemd main page:

https://www.freedesktop.org/wiki/Software/systemd/