### PR TITLE
apps.plugin optimizations; enable docker containers by default

### DIFF
--- a/src/inlined.h
+++ b/src/inlined.h
@@ -3,6 +3,19 @@
 
 #include "common.h"
 
+#ifdef KERNEL_32BIT
+typedef uint32_t kernel_uint_t;
+#define str2kernel_unit_t(string) str2uint32_t(string)
+#define KERNEL_UINT_FORMAT "%u"
+#else
+typedef uint64_t kernel_uint_t;
+#define str2kernel_unit_t(string) str2uint64_t(string)
+#define KERNEL_UINT_FORMAT "%lu"
+#endif
+
+#define str2pid_t(string) str2uint32_t(string)
+
+
 // for faster execution, allow the compiler to inline
 // these functions that are called thousands of times per second
 
@@ -67,6 +80,26 @@ static inline long str2l(const char *s) {
     if(unlikely(negative))
         return -n;
 
+    return n;
+}
+
+static inline uint32_t str2uint32_t(const char *s) {
+    uint32_t n = 0;
+    char c;
+    for(c = *s; c >= '0' && c <= '9' ; c = *(++s)) {
+        n *= 10;
+        n += c - '0';
+    }
+    return n;
+}
+
+static inline uint64_t str2uint64_t(const char *s) {
+    uint64_t n = 0;
+    char c;
+    for(c = *s; c >= '0' && c <= '9' ; c = *(++s)) {
+        n *= 10;
+        n += c - '0';
+    }
     return n;
 }
 

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -19,6 +19,8 @@ size_t procfile_max_allocation = PROCFILE_INCREMENT_BUFFER;
 // ----------------------------------------------------------------------------
 
 char *procfile_filename(procfile *ff) {
+    if(ff->filename[0]) return ff->filename;
+
     char buffer[FILENAME_MAX + 1];
     snprintfz(buffer, FILENAME_MAX, "/proc/self/fd/%d", ff->fd);
 
@@ -398,6 +400,7 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
     procfile *ff = mallocz(sizeof(procfile) + size);
 
     //strncpyz(ff->filename, filename, FILENAME_MAX);
+    ff->filename[0] = '\0';
 
     ff->fd = fd;
     ff->size = size;
@@ -425,6 +428,7 @@ procfile *procfile_reopen(procfile *ff, const char *filename, const char *separa
     }
 
     //strncpyz(ff->filename, filename, FILENAME_MAX);
+    ff->filename[0] = '\0';
 
     ff->flags = flags;
 

--- a/src/procfile.h
+++ b/src/procfile.h
@@ -59,7 +59,8 @@ typedef struct {
 #define PROCFILE_FLAG_NO_ERROR_ON_FILE_IO 0x00000001
 
 typedef struct {
-    char filename[FILENAME_MAX + 1];
+    char filename[FILENAME_MAX + 1]; // not populated until profile_filename() is called
+
     uint32_t flags;
     int fd;               // the file desriptor
     size_t len;           // the bytes we have placed into data
@@ -88,6 +89,8 @@ extern void procfile_print(procfile *ff);
 
 extern void procfile_set_quotes(procfile *ff, const char *quotes);
 extern void procfile_set_open_close(procfile *ff, const char *open, const char *close);
+
+extern char *procfile_filename(procfile *ff);
 
 // ----------------------------------------------------------------------------
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -181,6 +181,7 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_renames = simple_pattern_create(
             config_get("plugin:cgroups", "run script to rename cgroups matching",
+                    " /system.slice/docker-*.scope "
                     " !/ "
                     " !*.mount "
                     " !*.partition "

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -181,7 +181,8 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_renames = simple_pattern_create(
             config_get("plugin:cgroups", "run script to rename cgroups matching",
-                    " /system.slice/docker-*.scope "
+                    " *docker* "
+                    " *lxc* "
                     " !/ "
                     " !*.mount "
                     " !*.partition "

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -145,6 +145,7 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_patterns = simple_pattern_create(
             config_get("plugin:cgroups", "enable by default cgroups matching",
+                    " /system.slice/docker-*.scope "
                     " !*.mount "
                     " !*.partition "
                     " !*.scope "


### PR DESCRIPTION
1. fixes #1636 (docker containers missing)
2. optimizes apps.plugin
3. allows apps.plugin to be compiled for 32 bit kernels (pass `-DKERNEL_32BIT=1` to CFLAGS during configure - i.e. expect 32bit metrics from the kernel - useful in IoT).
3. this is an attempt to cleanup and document the way apps.plugin works. apps.plugin is quite a complex piece of software, and because it needs to be so fast there is quite a complex internal structure. This PR cleans it up and attempts to provide some insights on how it works internally.

cc: @simonnagl 