### PR TITLE
TC plugin now works on qdiscs or classes

### DIFF
--- a/plugins.d/tc-qos-helper.sh
+++ b/plugins.d/tc-qos-helper.sh
@@ -63,6 +63,8 @@ fireqos_run_dir="/var/run/fireqos"
 qos_get_class_names_every=120
 qos_exit_every=3600
 
+tc_show="qdisc" # can also be "class"
+
 # check if we have a valid number for interval
 t=${1}
 update_every=$((t))
@@ -74,6 +76,16 @@ if [ -f "${config_dir}/tc-qos-helper.conf" ]
     then
     source "${config_dir}/tc-qos-helper.conf"
 fi
+
+case "${tc_show}" in
+    qdisc|class)
+        ;;
+
+    *)
+        error "tc_show variable can be either 'qdisc' or 'class' but is set to '${tc_show}'. Assuming it is 'qdisc'."
+        tc_show="qdisc"
+        ;;
+esac
 
 # default sleep function
 LOOPSLEEPMS_LASTWORK=0
@@ -94,10 +106,17 @@ tc_devices=
 fix_names=
 
 setclassname() {
-    echo "SETCLASSNAME $3 $2"
+    if [ "${tc_show}" = "qdisc" ]
+        then
+        echo "SETCLASSNAME $4 $2"
+    else
+        echo "SETCLASSNAME $3 $2"
+    fi
 }
 
 show_tc_cls() {
+    [ "${tc_show}" = "qdisc" ] && return 1
+
     local x="${1}"
 
     if [ -f /etc/iproute2/tc_cls ]
@@ -143,8 +162,7 @@ show_tc() {
     echo "BEGIN ${x}"
 
     # netdata can parse the output of tc
-    ${tc} -s class show dev ${x}
-    ${tc} -s qdisc show dev ${x}
+    ${tc} -s ${tc_show} show dev ${x}
 
     # check FireQOS names for classes
     if [ ! -z "${fix_names}" ]

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -485,7 +485,7 @@ RRDSET *rrdset_create(const char *type, const char *id, const char *name, const 
 
     RRDSET *st = rrdset_find(fullid);
     if(st) {
-        error("Cannot create rrd stats for '%s', it already exists.", fullid);
+        debug(D_RRD_CALLS, "RRDSET '%s', already exists.", fullid);
         return st;
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1094,7 +1094,7 @@
 
                     // find a name for this device from fireqos info
                     // we strip '_(in|out)' or '(in|out)_'
-                    if(typeof options.submenu_names[chart.family] === 'undefined' || options.submenu_names[chart.family] === chart.family) {
+                    if(chart.context === 'tc.qos' && (typeof options.submenu_names[chart.family] === 'undefined' || options.submenu_names[chart.family] === chart.family)) {
                         var n = chart.name.split('.')[1];
                         if(n.endsWith('_in'))
                             options.submenu_names[chart.family] = n.slice(0, n.lastIndexOf('_in'));
@@ -1104,6 +1104,8 @@
                             options.submenu_names[chart.family] = n.slice(3, n.length);
                         else if(n.startsWith('out_'))
                             options.submenu_names[chart.family] = n.slice(4, n.length);
+                        else
+                            options.submenu_names[chart.family] = n;
                     }
 
                     // increase the priority of IFB devices


### PR DESCRIPTION
Using `qdisc`s for monitoring TC QoS is a lot more efficient. The kernel internally creates random classes, which are exposed, so netdata had to parse them and eliminate them.

On the other had `qdisc`s do not have this side effect. So, netdata is a lot more efficient (faster, less CPU hungry) when `qdisc`s are parsed.

Thanks to @t-h-e for PR #1427, who brought to my attention that parsing `qdisc`s is very similar to `class`es and the code he submitted to show the fact.

This PR, extends @t-h-e PR #1427 to support:

1. hierarchical `qdisc`s
2. eliminate `ingress` `qdisc`s
3. adapt `tc-qos-helper.sh` to either send `qdisc`s or `class`es to netdata
4. adapt `tc-qos-helper.sh` to rename `qdisc`s too, based on FireQOS names
5. optimizes tc plugin a bit, by eliminating a lot of `strcmp()` and redundant checks

@t-h-e your commits are included in this PR, so we can close #1427 
fixes #1375