### PR TITLE
SPEC: Fix wrong capabilities definition.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -128,7 +128,7 @@ install -m755 system/netdata-init-d \
 
 %post
 %distro_post
-setcap cap_dac_read,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin || chmod 1755 /usr/libexec/netdata/plugins.d/apps.plugin
+setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin || chmod 1755 /usr/libexec/netdata/plugins.d/apps.plugin
 
 %preun
 %distro_preun


### PR DESCRIPTION
1. Install CentOS 7, yum update.
2. Build netdata 1.5 from spec.
3. Install netdata => apps.plugin permission denied.

```
[root@localhost x86_64]# yum install netdata-1.5.0-1.el7.centos.x86_64.rpm 
Loaded plugins: fastestmirror
Examining netdata-1.5.0-1.el7.centos.x86_64.rpm: netdata-1.5.0-1.el7.centos.x86_64
Marking netdata-1.5.0-1.el7.centos.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package netdata.x86_64 0:1.5.0-1.el7.centos will be installed
--> Finished Dependency Resolution

Dependencies Resolved

======================================================================================================================================================
 Package                   Arch                     Version                                Repository                                            Size
======================================================================================================================================================
Installing:
 netdata                   x86_64                   1.5.0-1.el7.centos                     /netdata-1.5.0-1.el7.centos.x86_64                   6.1 M

Transaction Summary
======================================================================================================================================================
Install  1 Package

Total size: 6.1 M
Installed size: 6.1 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : netdata-1.5.0-1.el7.centos.x86_64                                                                                                  1/1 
fatal error: Invalid argument
usage: setcap [-q] [-v] (-r|-|<caps>) <filename> [ ... (-r|-|<capsN>) <filenameN> ]

 Note <filename> must be a regular (non-symlink) file.
  Verifying  : netdata-1.5.0-1.el7.centos.x86_64                                                                                                  1/1 

Installed:
  netdata.x86_64 0:1.5.0-1.el7.centos                                                                                                                 

Complete!
```

Root cause - wrong capability **cap_dac_read**, I not found it on `man capabilities`.