### PR TITLE
apps_groups: add routing group.

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -106,11 +106,12 @@ nosql: mongod redis* memcached
 email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr
 
 # -----------------------------------------------------------------------------
-# networking and VPN servers
+# network, routing, VPN
 
 ppp: ppp*
 vpn: openvpn pptp* cjdroute
 wifi: hostapd wpa_supplicant
+routing: ospfd* ospf6d* bgpd isisd ripd ripngd pimd ldpd zebra vtysh bird*
 
 # -----------------------------------------------------------------------------
 # high availability and balancers


### PR DESCRIPTION
Add daemons of two open source routing packages [quagga](http://www.nongnu.org/quagga/) and [bird](http://bird.network.cz/).
`ospfd*` under asterisk because ospf multi instance patch shipped with [CumulusLinux](http://oss.cumulusnetworks.com/) and one ospf rounting process is one ospfd. ldpd is not on quagga upstream, but on [frr](https://github.com/freerangerouting/frr) on master (frr is fresh fork of quagga).
In total supported: [quagga](http://www.nongnu.org/quagga/), [bird](http://bird.network.cz/), [frr](https://github.com/freerangerouting/frr), [Cumulus](https://docs.cumulusnetworks.com/display/DOCS/Quagga+Overview).