### PR TITLE
multi-os support (final touch)

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -848,7 +848,7 @@ static inline int read_proc_pid_stat(struct pid_stat *p) {
             if(p->comm[0])
                 fprintf(stderr, "apps.plugin: \tpid %d (%s) changed name to '%s'\n", p->pid, p->comm, comm);
             else
-                fprintf(stderr, "apps.plugin: \tJust added %d (%s)\n", p->pid, p->comm);
+                fprintf(stderr, "apps.plugin: \tJust added %d (%s)\n", p->pid, comm);
         }
 
         strncpyz(p->comm, comm, MAX_COMPARE_NAME);

--- a/src/common.c
+++ b/src/common.c
@@ -12,6 +12,7 @@ char *global_host_prefix = "";
 int enable_ksm = 1;
 
 volatile sig_atomic_t netdata_exit = 0;
+const char *os_type = NETDATA_OS_TYPE;
 
 // ----------------------------------------------------------------------------
 // memory allocation functions that handle failures

--- a/src/common.h
+++ b/src/common.h
@@ -188,10 +188,13 @@
 #include "plugin_nfacct.h"
 
 #if defined(__FreeBSD__)
+#define NETDATA_OS_TYPE "freebsd"
 #include "plugin_freebsd.h"
 #elif defined(__APPLE__)
+#define NETDATA_OS_TYPE "macos"
 #include "plugin_macos.h"
 #else
+#define NETDATA_OS_TYPE "linux"
 #include "plugin_proc.h"
 #include "plugin_proc_diskspace.h"
 #endif /* __FreeBSD__, __APPLE__*/
@@ -270,6 +273,9 @@ extern pid_t get_system_pid_max(void);
 /* Number of ticks per second */
 extern unsigned int hz;
 extern void get_system_HZ(void);
+
+extern volatile sig_atomic_t netdata_exit;
+extern const char *os_type;
 
 
 /* fix for alpine linux */

--- a/src/main.h
+++ b/src/main.h
@@ -1,8 +1,6 @@
 #ifndef NETDATA_MAIN_H
 #define NETDATA_MAIN_H 1
 
-extern volatile sig_atomic_t netdata_exit;
-
 /**
  * This struct contains information about command line options.
  */

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -283,29 +283,31 @@ static inline void tc_device_commit(struct tc_device *d) {
     //
     // so, here we remove the isleaf flag from nodes in the middle
     // and we add the hasparent flag to leaf nodes we found their parent
-    for(c = d->classes; c; c = c->next) {
-        if(unlikely(!c->updated)) continue;
+    if(likely(!d->enabled_all_classes_qdiscs)) {
+        for(c = d->classes; c; c = c->next) {
+            if(unlikely(!c->updated)) continue;
 
-        //debug(D_TC_LOOP, "TC: In device '%s', %s '%s'  has leafid: '%s' and parentid '%s'.",
-        //    d->id,
-        //    c->isqdisc?"qdisc":"class",
-        //    c->id,
-        //    c->leafid?c->leafid:"NULL",
-        //    c->parentid?c->parentid:"NULL");
+            //debug(D_TC_LOOP, "TC: In device '%s', %s '%s'  has leafid: '%s' and parentid '%s'.",
+            //    d->id,
+            //    c->isqdisc?"qdisc":"class",
+            //    c->id,
+            //    c->leafid?c->leafid:"NULL",
+            //    c->parentid?c->parentid:"NULL");
 
-        // find if c is leaf or not
-        for(x = d->classes; x; x = x->next) {
-            if(unlikely(!x->updated || c == x || !x->parentid)) continue;
+            // find if c is leaf or not
+            for(x = d->classes; x; x = x->next) {
+                if(unlikely(!x->updated || c == x || !x->parentid)) continue;
 
-            // classes have both parentid and leafid
-            // qdiscs have only parentid
-            // the following works for both (it is an OR)
+                // classes have both parentid and leafid
+                // qdiscs have only parentid
+                // the following works for both (it is an OR)
 
-            if( (c->hash == x->parent_hash && strcmp(c->id, x->parentid) == 0) ||
-                (c->leafid && c->leaf_hash == x->parent_hash && strcmp(c->leafid, x->parentid) == 0)) {
-                // debug(D_TC_LOOP, "TC: In device '%s', %s '%s' (leafid: '%s') has as leaf %s '%s' (parentid: '%s').", d->name?d->name:d->id, c->isqdisc?"qdisc":"class", c->name?c->name:c->id, c->leafid?c->leafid:c->id, x->isqdisc?"qdisc":"class", x->name?x->name:x->id, x->parentid?x->parentid:x->id);
-                c->isleaf = 0;
-                x->hasparent = 1;
+                if((c->hash == x->parent_hash && strcmp(c->id, x->parentid) == 0) ||
+                   (c->leafid && c->leaf_hash == x->parent_hash && strcmp(c->leafid, x->parentid) == 0)) {
+                    // debug(D_TC_LOOP, "TC: In device '%s', %s '%s' (leafid: '%s') has as leaf %s '%s' (parentid: '%s').", d->name?d->name:d->id, c->isqdisc?"qdisc":"class", c->name?c->name:c->id, c->leafid?c->leafid:c->id, x->isqdisc?"qdisc":"class", x->name?x->name:x->id, x->parentid?x->parentid:x->id);
+                    c->isleaf = 0;
+                    x->hasparent = 1;
+                }
             }
         }
     }

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -85,10 +85,12 @@ void rrd_stats_api_v1_charts(BUFFER *wb)
 
     buffer_sprintf(wb, "{\n"
            "\t\"hostname\": \"%s\""
+        ",\n\t\"os_type\": \"%s\""
         ",\n\t\"update_every\": %d"
         ",\n\t\"history\": %d"
         ",\n\t\"charts\": {"
         , localhost.hostname
+        , os_type
         , rrd_update_every
         , rrd_default_history_entries
         );
@@ -122,6 +124,22 @@ void rrd_stats_api_v1_charts(BUFFER *wb)
                    , dimensions
                    , alarms
                    , memory
+    );
+}
+
+void rrd_stats_api_v1_info(BUFFER *wb)
+{
+    buffer_sprintf(wb, "{\n"
+                    "\t\"hostname\": \"%s\""
+                    ",\n\t\"os_type\": \"%s\""
+                    ",\n\t\"version\": \"" VERSION "\""
+                    ",\n\t\"update_every\": %d"
+                    ",\n\t\"history\": %d"
+                    "\n}"
+                   , localhost.hostname
+                   , os_type
+                   , rrd_update_every
+                   , rrd_default_history_entries
     );
 }
 

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -60,6 +60,7 @@
 
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrd_stats_api_v1_charts(BUFFER *wb);
+extern void rrd_stats_api_v1_info(BUFFER *wb);
 
 extern void rrd_stats_api_v1_charts_allmetrics_shell(BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_prometheus(BUFFER *wb);

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -10,7 +10,6 @@ dist_web_DATA = \
 	demosites2.html \
 	dashboard.html \
 	dashboard.js \
-	dashboard_info.js \
 	dashboard.css \
 	dashboard.slate.css \
 	favicon.ico \
@@ -23,6 +22,13 @@ dist_web_DATA = \
 	sitemap.xml \
 	tv.html \
 	version.txt \
+	$(NULL)
+
+dashboardinfodir=$(webdir)/dashboard_info
+dist_dashboardinfo_DATA = \
+	dashboard_info/linux.js \
+	dashboard_info/freebsd.js \
+	dashboard_info/macos.js \
 	$(NULL)
 
 webolddir=$(webdir)/old

--- a/web/dashboard_info/freebsd.js
+++ b/web/dashboard_info/freebsd.js
@@ -1,0 +1,4 @@
+// Javascript file for providing dashboard information on FreeBSD
+
+var netdataDashboard = window.netdataDashboard || {};
+

--- a/web/dashboard_info/linux.js
+++ b/web/dashboard_info/linux.js
@@ -1,3 +1,4 @@
+// Javascript file for providing dashboard information on Linux
 
 var netdataDashboard = window.netdataDashboard || {};
 

--- a/web/dashboard_info/linux.js
+++ b/web/dashboard_info/linux.js
@@ -418,8 +418,8 @@ netdataDashboard.context = {
     },
 
     'mem.committed': {
+        colors: NETDATA.colors[3],
         info: 'Committed Memory, read from <code>/proc/meminfo</code>, is the sum of all memory which has been allocated by processes.'
-        colors: NETDATA.colors[3]
     },
 
     'mem.writeback': {

--- a/web/dashboard_info/linux.js
+++ b/web/dashboard_info/linux.js
@@ -413,16 +413,13 @@ netdataDashboard.context = {
         ]
     },
 
-    'mem.committed': {
-        colors: NETDATA.colors[3]
-    },
-    
     'mem.pgfaults': {
     	info: 'A <a href="https://en.wikipedia.org/wiki/Page_fault" target="_blank">page fault</a> is a type of interrupt, called trap, raised by computer hardware when a running program accesses a memory page that is mapped into the virtual address space, but not actually loaded into main memory. If the page is loaded in memory at the time the fault is generated, but is not marked in the memory management unit as being loaded in memory, then it is called a <b>minor</b> or soft page fault. A <b>major</b> page fault is generated when the system needs to load the memory page from disk or swap memory. These values are read from <code>/proc/vmstat</code>.'
     },
 
     'mem.committed': {
         info: 'Committed Memory, read from <code>/proc/meminfo</code>, is the sum of all memory which has been allocated by processes.'
+        colors: NETDATA.colors[3]
     },
 
     'mem.writeback': {

--- a/web/dashboard_info/macos.js
+++ b/web/dashboard_info/macos.js
@@ -1,0 +1,4 @@
+// Javascript file for providing dashboard information on MacOS
+
+var netdataDashboard = window.netdataDashboard || {};
+

--- a/web/index.html
+++ b/web/index.html
@@ -403,8 +403,21 @@
 
     </style>
 
+    <script type="text/javascript">
+        // default, in case it fails to be loaded
+        NETDATA_INFO = {
+            version: 'unknown',
+            os_type: 'linux'
+        }
+    </script>
+
+    <script type="text/javascript" src="api/v1/info.js"></script>
+
     <!-- check which theme to use -->
     <script type="text/javascript">
+        // --------------------------------------------------------------------
+        // these are used by dashboard.js
+
         // enable alarms checking and notifications
         var netdataShowAlarms = true;
 
@@ -2663,9 +2676,9 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20170115-1',
+                url: NETDATA.serverDefault + 'dashboard_info/' + NETDATA_INFO.os_type.toString() + '.js?v20170201-1',
                 async: false,
-                isAlreadyLoaded: function() { return false; }
+                isAlreadyLoaded: function () { return false; }
             });
 
             if(isdemo()) {


### PR DESCRIPTION
This PR adds:

- [x] different dashboard information files per operating system supported by netdata; fixes #1480
- [ ] ability to have different alarms for the different operating systems supported by netdata; fixes #1598

I have added a new API call to netdata: `/api/v1/info` and `/api/v1/info.js`. The first returns a JSON, the second returns a javascript file. Both give the same information.

Based on this, `index.html` decides which `dashboard_info.js` file to load. Now there is a directory called `dashboard_info` containing files `linux.js`, `freebsd.js` and `macos.js`.

For alarms, I plan to add a configuration line called `os`, which will use a simple pattern to activate the alarm for the given OSes only. This means we will be able to add `ram_linux.conf`, `ram_freebsd.conf`, etc and netdata will activate only the alarms matching the current operating system.

Tomorrow I hope will be ready.
