### PR TITLE
postgres plugin: connect/reconnect to unix socket fixed

### DIFF
--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -203,7 +203,7 @@ class Service(SimpleService):
         params = dict(user='postgres',
                       database=None,
                       password=None,
-                      host='localhost',
+                      host=None,
                       port=5432)
         params.update(self.configuration)
 
@@ -301,8 +301,7 @@ class Service(SimpleService):
             try:
                 self.add_stats(cursor)
             except OperationalError:
-                if self.connection.closed == 2:
-                    self.connection = False
+                self.connection = False
                 cursor.close()
                 return None
             else:

--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -218,7 +218,9 @@ class Service(SimpleService):
 
     def check(self):
         try:
-            self._connect()
+            if not self._connect():
+                self.error('Can\'t connect to %s' % str(self.configuration))
+                return False
             cursor = self.connection.cursor()
             self._discover_databases(cursor)
             self._check_if_superuser(cursor)


### PR DESCRIPTION
https://github.com/firehol/netdata/issues/1701
@Yamakaky 
@harpo

This is the fix. Works for me.
Can you test it please (connect to unix socket/tcp socket/ reconnect after restart/stop start postgres)?