### PR TITLE
nginx_log plugin: code optimization, bandwidth + unique visitors charts

### DIFF
--- a/conf.d/python.d/nginx_log.conf
+++ b/conf.d/python.d/nginx_log.conf
@@ -56,7 +56,8 @@
 #
 # Additionally to the above, nginx_log also supports the following:
 #
-#     path: 'PATH'     # the path to nginx's access.log
+#     path: 'PATH'                        # the path to nginx's access.log
+#     detailed_response_codes: yes/no     # additional chart where response codes are not grouped 
 #
 
 # ----------------------------------------------------------------------
@@ -66,7 +67,9 @@
 nginx_log:
   name: 'local'
   path: '/var/log/nginx/access.log'
+  detailed_response_codes: no
 
 nginx_log2:
   name: 'local'
   path: '/var/log/nginx/nginx-access.log'
+  detailed_response_codes: no

--- a/conf.d/python.d/nginx_log.conf
+++ b/conf.d/python.d/nginx_log.conf
@@ -58,7 +58,10 @@
 #
 #     path: 'PATH'                        # the path to nginx's access.log
 #     detailed_response_codes: yes/no     # additional chart where response codes are not grouped 
-#
+#     categories:                         # requests per url chart configuration
+#          cacti: 'cacti.*'               # name(dimension): REGEX to match
+#          observium: 'observium.*'       # name(dimension): REGEX to match
+#          stub_status: 'stub_status'    # name(dimension): REGEX to match
 
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
@@ -67,9 +70,11 @@
 nginx_log:
   name: 'local'
   path: '/var/log/nginx/access.log'
-  detailed_response_codes: no
+  detailed_response_codes: yes
+  categories:
+      stub_status: 'stub_status'
 
 nginx_log2:
   name: 'local'
   path: '/var/log/nginx/nginx-access.log'
-  detailed_response_codes: no
+  detailed_response_codes: yes

--- a/conf.d/python.d/nginx_log.conf
+++ b/conf.d/python.d/nginx_log.conf
@@ -57,11 +57,12 @@
 # Additionally to the above, nginx_log also supports the following:
 #
 #     path: 'PATH'                        # the path to nginx's access.log
-#     detailed_response_codes: yes/no     # additional chart where response codes are not grouped 
+#     detailed_response_codes: yes/no     # Default: yes. Additional chart where response codes are not grouped 
+#     all_time : yes/no                   # Default: yes. All time unique client IPs chart (50000 addresses ~ 400KB)
 #     categories:                         # requests per url chart configuration
 #          cacti: 'cacti.*'               # name(dimension): REGEX to match
 #          observium: 'observium.*'       # name(dimension): REGEX to match
-#          stub_status: 'stub_status'    # name(dimension): REGEX to match
+#          stub_status: 'stub_status'     # name(dimension): REGEX to match
 
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
@@ -71,6 +72,7 @@ nginx_log:
   name: 'local'
   path: '/var/log/nginx/access.log'
   detailed_response_codes: yes
+  all_time: yes
   categories:
       stub_status: 'stub_status'
 

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -115,7 +115,7 @@ class Service(LogService):
     def __init__(self, configuration=None, name=None):
         LogService.__init__(self, configuration=configuration, name=name)
         self.log_path = self.configuration.get('path', '/var/log/nginx/access.log')
-        self.detailed_response_codes = self.configuration.get('detailed_response_codes', True)
+        self.detailed_response_codes = self.configuration.get('detailed_response_codes', False)
         self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<= )[1-9]\d{2}) (\d+) (\d+)? ?([\d.]+)?')
         # sorted list of unique IPs
         self.unique_alltime = list()

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -9,27 +9,28 @@ import bisect
 priority = 60000
 retries = 60
 
-ORDER = ['codes', 'bandwidth', 'visitors']
+ORDER = ['codes', 'bandwidth', 'clients']
 CHARTS = {
     'codes': {
-        'options': [None, 'Status codes', 'requests/s', 'requests', 'nginx_log.codes', 'stacked'],
+        'options': [None, 'Response Codes', 'requests/s', 'Responses', 'nginx_log.codes', 'stacked'],
         'lines': [
             ['2', '2xx', 'incremental'],
             ['5', '5xx', 'incremental'],
             ['3', '3xx', 'incremental'],
             ['4', '4xx', 'incremental'],
-            ['1', '1xx', 'incremental']
+            ['1', '1xx', 'incremental'],
+            ['0', 'other', 'incremental']
         ]},
     'bandwidth': {
-        'options': [None, 'Bandwidth', 'KB/s', 'bandwidth', 'nginx_log.bw', 'area'],
+        'options': [None, 'Bandwidth', 'KB/s', 'Bandwidth', 'nginx_log.bw', 'area'],
         'lines': [
             ['bandwidth', 'sent', 'incremental', 1, 1024]
         ]},
-    'visitors': {
-        'options': [None, 'Unique visitors', 'number', 'visitors', 'nginx_log.visitors', 'stacked'],
+    'clients': {
+        'options': [None, 'Unique Client IPs', 'number', 'Client IPs', 'nginx_log.clients', 'stacked'],
         'lines': [
-            ['unique_cur', 'current', 'incremental', 1, 1],
-            ['unique_tot', 'total', 'absolute', 1, 1]
+            ['unique_cur', 'current_poll', 'incremental', 1, 1],
+            ['unique_tot', 'all_time', 'absolute', 1, 1]
         ]}
 }
 
@@ -40,7 +41,7 @@ class Service(LogService):
         self.order = ORDER
         self.definitions = CHARTS
         self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<=\s)[1-5])\d\d (\d+)?')
-        self.data = {str(k): 0 for k in range(1, 6)}
+        self.data = {str(k): 0 for k in range(6)}
         self.data.update({'bandwidth': 0, 'unique_cur': 0, 'unique_tot': 0})
         self.unique = list()
 
@@ -56,7 +57,10 @@ class Service(LogService):
             match = self.regex.findall(line)
             if match:
                 address, code, sent = match[0][0], match[0][1], match[0][2] or 0
-                self.data[code] += 1
+                try:
+                    self.data[code] += 1
+                except KeyError:
+                    self.data['0'] += 1
                 self.data['bandwidth'] += int(sent)
                 if self.contains(address):
                     self.data['unique_cur'] += 1

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -38,12 +38,12 @@ CHARTS = {
             ['resp_time_avg', 'avg', 'absolute', 1, 1]
         ]},
     'clients_cur': {
-        'options': [None, 'Current Poll Unique Client IPs', 'number', 'unique clients', 'nginx_log.clients', 'line'],
+        'options': [None, 'Current Poll Unique Client IPs', 'unique ips', 'unique clients', 'nginx_log.clients', 'line'],
         'lines': [
             ['unique_cur', 'clients', 'absolute', 1, 1]
         ]},
     'clients_all': {
-        'options': [None, 'All Time Unique Client IPs', 'number', 'unique clients', 'nginx_log.clients', 'line'],
+        'options': [None, 'All Time Unique Client IPs', 'unique ips', 'unique clients', 'nginx_log.clients', 'line'],
         'lines': [
             ['unique_tot', 'clients', 'absolute', 1, 1]
         ]}

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -5,14 +5,16 @@
 from base import LogService
 import re
 import bisect
+from os import access, R_OK
+from os.path import getsize
 
 priority = 60000
 retries = 60
 
-ORDER = ['codes', 'bandwidth', 'clients']
+ORDER = ['response_codes', 'request_time', 'bandwidth', 'clients']
 CHARTS = {
-    'codes': {
-        'options': [None, 'Response Codes', 'requests/s', 'Responses', 'nginx_log.codes', 'stacked'],
+    'response_codes': {
+        'options': [None, 'Response Codes', 'requests/s', 'Responses', 'nginx_log.response', 'stacked'],
         'lines': [
             ['2', '2xx', 'incremental'],
             ['5', '5xx', 'incremental'],
@@ -22,14 +24,23 @@ CHARTS = {
             ['0', 'other', 'incremental']
         ]},
     'bandwidth': {
-        'options': [None, 'Bandwidth', 'KB/s', 'Bandwidth', 'nginx_log.bw', 'area'],
+        'options': [None, 'Bandwidth', 'KB/s', 'Bandwidth', 'nginx_log.bw', 'stacked'],
         'lines': [
-            ['bandwidth', 'sent', 'incremental', 1, 1024]
+            ['bytes_sent', 'sent', 'incremental', 1, 1024],
+            ['resp_length', 'received', 'incremental', 1, 1024]
+        ]},
+    'request_time': {
+        'options': [None, 'Processing Time', 'seconds', 'Requests', 'nginx_log.request', 'stacked'],
+        'lines': [
+            ['resp_time_min', 'min', 'absolute', 1, 1000],
+            ['resp_time_avg', 'avg', 'absolute', 1, 1000],
+            ['resp_time_max', 'max', 'absolute', 1, 1000]
         ]},
     'clients': {
         'options': [None, 'Unique Client IPs', 'number', 'Client IPs', 'nginx_log.clients', 'stacked'],
         'lines': [
             ['unique_cur', 'current_poll', 'incremental', 1, 1],
+            ['foo', 'foo', 'absolute', 1, 1],
             ['unique_tot', 'all_time', 'absolute', 1, 1]
         ]}
 }
@@ -40,31 +51,78 @@ class Service(LogService):
         LogService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
-        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<=\s)[1-5])\d\d (\d+)?')
+        self.log_path = self.configuration.get('path', '/var/log/nginx/access.log')
+        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<= )[1-9])\d\d (\d+) (\d+)? ?([\d.]+)?')
         self.data = {str(k): 0 for k in range(6)}
-        self.data.update({'bandwidth': 0, 'unique_cur': 0, 'unique_tot': 0})
+        self.data.update({'bytes_sent': 0, 'unique_cur': 0,
+                          'unique_tot': 0, 'resp_length': 0,
+                          'resp_time_min': 0, 'resp_time_avg': 0,
+                          'resp_time_max': 0, 'foo': 0})
         self.unique = list()
 
+    def check(self):
+        if not access(self.log_path, R_OK):
+            self.error('%s not readable or not exist' % self.log_path)
+            return False
+
+        if not getsize(self.log_path):
+            self.error('%s is empty' % self.log_path)
+            return False
+        
+        with open(self.log_path, 'rb') as logs:
+            logs.seek(-2, 2)
+            while logs.read(1) != b'\n':
+                logs.seek(-2, 1)
+                if logs.tell() == 0:
+                    break
+            last_line = logs.readline().decode(encoding='utf-8')
+
+        parsed_line = self.regex.findall(last_line)
+        if not parsed_line:
+            self.error('Can\'t parse output')
+            return False
+        else:
+            if parsed_line[0][4] == '':
+                self.order.remove('request_time')
+        return True
+
     def _get_data(self):
-        '''
+        """
         Parse new log lines
         :return: dict
-        '''
+        """
         raw = self._get_raw_data()
-        if raw is None: return None
+        if raw is None:
+            return None
+
+        request_time = list()
+        request_counter = {'count': 0, 'sum': 0}
 
         for line in raw:
             match = self.regex.findall(line)
             if match:
-                address, code, sent = match[0][0], match[0][1], match[0][2] or 0
+                match_dict = dict(zip(['address', 'code', 'sent', 'resp_length', 'resp_time'], match[0]))
                 try:
-                    self.data[code] += 1
+                    self.data[match_dict['code']] += 1
                 except KeyError:
                     self.data['0'] += 1
-                self.data['bandwidth'] += int(sent)
-                if self.contains(address):
+                self.data['bytes_sent'] += int(match_dict['sent'])
+                if match_dict['resp_length'] != '' and match_dict['resp_time'] != '':
+                    self.data['resp_length'] += int(match_dict['resp_length'])
+                    resp_time = float(match_dict['resp_time']) * 1000
+                    bisect.insort_left(request_time, resp_time)
+                    request_counter['count'] += 1
+                    request_counter['sum'] += resp_time
+                    
+                if self.contains(match_dict['address']):
                     self.data['unique_cur'] += 1
                     self.data['unique_tot'] += 1
+
+        if request_time:
+            self.data['resp_time_min'] = request_time[0]
+            self.data['resp_time_avg'] = float(request_counter['sum']) / request_counter['count']
+            self.data['resp_time_max'] = request_time[-1]
+
         return self.data
 
     def contains(self, address):

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -12,10 +12,10 @@ from collections import defaultdict, namedtuple
 priority = 60000
 retries = 60
 
-ORDER = ['response_codes', 'request_time', 'requests_per_url', 'bandwidth', 'clients_cur', 'clients_all']
+ORDER = ['response_codes', 'request_time', 'requests_per_url', 'http_method', 'bandwidth', 'clients_cur', 'clients_all']
 CHARTS = {
     'response_codes': {
-        'options': [None, 'Response Codes', 'requests/s', 'responses', 'nginx_log.response', 'stacked'],
+        'options': [None, 'Response Codes', 'requests/s', 'responses', 'web_log.response', 'stacked'],
         'lines': [
             ['2xx', '2xx', 'absolute'],
             ['5xx', '5xx', 'absolute'],
@@ -25,27 +25,31 @@ CHARTS = {
             ['0xx', 'other', 'absolute']
         ]},
     'bandwidth': {
-        'options': [None, 'Bandwidth', 'KB/s', 'bandwidth', 'nginx_log.bw', 'area'],
+        'options': [None, 'Bandwidth', 'KB/s', 'bandwidth', 'web_log.bw', 'area'],
         'lines': [
             ['resp_length', 'received', 'absolute', 1, 1024],
             ['bytes_sent', 'sent', 'absolute', -1, 1024]
         ]},
     'request_time': {
-        'options': [None, 'Processing Time', 'milliseconds', 'timings', 'nginx_log.request', 'area'],
+        'options': [None, 'Processing Time', 'milliseconds', 'timings', 'web_log.request', 'area'],
         'lines': [
             ['resp_time_min', 'min', 'absolute', 1, 1],
             ['resp_time_max', 'max', 'absolute', 1, 1],
             ['resp_time_avg', 'avg', 'absolute', 1, 1]
         ]},
     'clients_cur': {
-        'options': [None, 'Current Poll Unique Client IPs', 'unique ips', 'unique clients', 'nginx_log.clients', 'line'],
+        'options': [None, 'Current Poll Unique Client IPs', 'unique ips', 'unique clients', 'web_log.clients', 'line'],
         'lines': [
             ['unique_cur', 'clients', 'absolute', 1, 1]
         ]},
     'clients_all': {
-        'options': [None, 'All Time Unique Client IPs', 'unique ips', 'unique clients', 'nginx_log.clients', 'line'],
+        'options': [None, 'All Time Unique Client IPs', 'unique ips', 'unique clients', 'web_log.clients', 'line'],
         'lines': [
             ['unique_tot', 'clients', 'absolute', 1, 1]
+        ]},
+    'http_method': {
+        'options': [None, 'Requests Per HTTP Method', 'requests/s', 'requests', 'web_log.http_method', 'stacked'],
+        'lines': [
         ]}
 }
 
@@ -55,32 +59,35 @@ NAMED_URL_PATTERN = namedtuple('URL_PATTERN', ['description', 'pattern'])
 class Service(LogService):
     def __init__(self, configuration=None, name=None):
         LogService.__init__(self, configuration=configuration, name=name)
+        # Vars from module configuration file
         self.log_path = self.configuration.get('path', '/var/log/nginx/access.log')
         self.detailed_response_codes = self.configuration.get('detailed_response_codes', True)
         self.all_time = self.configuration.get('all_time', True)
-        self.url_pattern = self.configuration.get('categories')
-        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?"[A-Z]+ (.*?)" ([1-9]\d{2}) (\d+) (\d+)? ?([\d.]+)?')
+        self.url_pattern = self.configuration.get('categories')  # dict
+        # REGEX: 1.IPv4 address 2.HTTP method 3. URL 4. Response code
+        # 5. Bytes sent 6. Response length 7. Response process time
+        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?"([A-Z]+) (.*?)" ([1-9]\d{2}) (\d+) (\d+)? ?([\d.]+)?')
         # sorted list of unique IPs
-        self.unique_alltime = list()
-        # all values that should not be zeroed every poll
+        self.unique_all_time = list()
+        # dict for values that should not be zeroed every poll
         self.storage = {'unique_tot': 0}
+        # if there is no new logs this dict + self.storage returned to netdata
         self.data = {'bytes_sent': 0, 'resp_length': 0, 'resp_time_min': 0,
                      'resp_time_max': 0, 'resp_time_avg': 0, 'unique_cur': 0,
-                     'unique_tot': 0, '2xx': 0, '5xx': 0, '3xx': 0, '4xx': 0,
-                     '1xx': 0, '0xx': 0}
+                     '2xx': 0, '5xx': 0, '3xx': 0, '4xx': 0, '1xx': 0, '0xx': 0}
 
     def check(self):
-        # Can't start if log path is not readable by netdata
+        # log_path must be readable
         if not access(self.log_path, R_OK):
             self.error('%s not readable or not exist' % self.log_path)
             return False
 
-        # Can't start if file is empty
+        # log_path file should not be empty
         if not getsize(self.log_path):
             self.error('%s is empty' % self.log_path)
             return False
 
-        # Read the last line from file
+        # Read last line (or first if there is only one line)
         with open(self.log_path, 'rb') as logs:
             logs.seek(-2, 2)
             while logs.read(1) != b'\n':
@@ -89,44 +96,56 @@ class Service(LogService):
                     break
             last_line = logs.readline().decode(encoding='utf-8')
 
-        # We need to make sure we can to parse the line
+        # Parse last line
         parsed_line = self.regex.findall(last_line)
         if not parsed_line:
             self.error('Can\'t parse output')
             return False
 
-        # Pass 5th element from parsed line result (response time)
-        self.create_charts(parsed_line[0][5])
+        # parsed_line[0][6] - response process time
+        self.create_charts(parsed_line[0][6])
         return True
 
     def create_charts(self, parsed_line):
         # This thing needed for adding dynamic dimensions
-        self.detailed_chart = 'CHART nginx_log_local.detailed_response_codes ""' \
-                              ' "Response Codes" requests responses nginx_log.detailed stacked 14 1\n'
+        def find_job_name(override_name, name):
+            add_to_name = override_name or name
+            if add_to_name:
+                return '_'.join(['nginx_log', add_to_name])
+            else:
+                return 'nginx_log'
+
+        job_name = find_job_name(self.override_name, self.name)
+        self.detailed_chart = 'CHART %s.detailed_response_codes ""' \
+                              ' "Response Codes" requests/s responses' \
+                              ' web_log.detailed_resp stacked 1 %s\n' % (job_name, self.update_every)
+        self.http_method_chart = 'CHART %s.http_method' \
+                                 ' "" "HTTP Methods" requests/s requests' \
+                                 ' web_log.http_method stacked 2 %s\n' % (job_name, self.update_every)
         self.order = ORDER[:]
         self.definitions = CHARTS
 
-        # Remove 'request_time' chart if there is not 'reponse_time' in logs
+        # Remove 'request_time' chart from ORDER if request_time not in logs
         if parsed_line == '':
             self.order.remove('request_time')
 
-        # Remove 'request_time' if specified in the configuration
+        # Remove 'clients_all' chart from ORDER if specified in the configuration
         if not self.all_time:
             self.order.remove('clients_all')
  
-        # Add detailed_response_codes chart if specified in the configuration
+        # Add 'detailed_response_codes' chart if specified in the configuration
         if self.detailed_response_codes:
             self.order.append('detailed_response_codes')
             self.definitions['detailed_response_codes'] = {'options': [None, 'Detailed Response Codes', 'requests/s',
-                                                                       'responses', 'nginx_log.detailed_resp', 'stacked'],
+                                                                       'responses', 'web_log.detailed_resp', 'stacked'],
                                                            'lines': []}
 
-        # Add response per url chart if specified in the configuration
+        # Add 'requests_per_url' chart if specified in the configuration
         if self.url_pattern:
             self.url_pattern = [NAMED_URL_PATTERN(description=k, pattern=re.compile(v)) for k, v in self.url_pattern.items()]
             self.definitions['requests_per_url'] = {'options': [None, 'Requests Per Url', 'requests/s',
-                                                                       'requests', 'nginx_log.url_pattern', 'stacked'],
-                                                           'lines': [['other_url', 'other', 'absolute']]}
+                                                                'requests', 'web_log.url_pattern', 'stacked'],
+                                                    'lines': [['other_url', 'other', 'absolute']]}
             for elem in self.url_pattern:
                 self.definitions['requests_per_url']['lines'].append([elem.description, elem.description, 'absolute'])
                 self.data.update({elem.description: 0})
@@ -134,14 +153,16 @@ class Service(LogService):
         else:
             self.order.remove('requests_per_url')
           
-    def add_new_dimension(self, code, line):
-        # add new dimension to STORAGE dict. If code appear once we it will always be as current value or zero
-        self.storage.update({code: 0})
-        # Pass new dimension to NETDATA
-        self._dimensions.append(code)
-        self.definitions['detailed_response_codes']['lines'].append(line)
-        self.detailed_chart += "%s %s\n" % ('DIMENSION', ' '.join(line))
-        print(self.detailed_chart)
+    def add_new_dimension(self, dimension, line_list, chart_string, key):
+        self.storage.update({dimension: 0})
+        # SET method check if dim in _dimensions
+        self._dimensions.append(dimension)
+        # UPDATE method do SET only if dim in definitions
+        self.definitions[key]['lines'].append(line_list)
+        chart = chart_string
+        chart += "%s %s\n" % ('DIMENSION', ' '.join(line_list))
+        print(chart)
+        return chart
 
     def _get_data(self):
         """
@@ -156,20 +177,25 @@ class Service(LogService):
         request_counter = {'count': 0, 'sum': 0}
         to_netdata = dict()
         to_netdata.update(self.data)
-        detailed_dict = defaultdict(lambda: 0)
+        default_dict = defaultdict(lambda: 0)
 
         for line in raw:
             match = self.regex.findall(line)
             if match:
-                match_dict = dict(zip(['address', 'url', 'code', 'sent', 'resp_length', 'resp_time'], match[0]))
+                match_dict = dict(zip('address method url code sent resp_length resp_time'.split(), match[0]))
                 try:
                     code = ''.join([match_dict['code'][0], 'xx'])
                     to_netdata[code] += 1
                 except KeyError:
                     to_netdata['0xx'] += 1
-
-                if self.detailed_response_codes: self._get_detailed_data(match_dict['code'], detailed_dict)
-                if self.url_pattern: self._get_url_pattern_data(match_dict['url'], detailed_dict)
+                # detailed response code
+                if self.detailed_response_codes:
+                    self._get_data_detailed_response_codes(match_dict['code'], default_dict)
+                # requests per url
+                if self.url_pattern:
+                    self._get_data_per_url(match_dict['url'], default_dict)
+                # requests per http method
+                self._get_data_http_method(match_dict['method'], default_dict)
                 
                 to_netdata['bytes_sent'] += int(match_dict['sent'])
                 
@@ -179,35 +205,45 @@ class Service(LogService):
                     bisect.insort_left(request_time, resp_time)
                     request_counter['count'] += 1
                     request_counter['sum'] += resp_time
-                    
-                if address_not_in_pool(self.unique_alltime, match_dict['address'], self.storage['unique_tot']):
+                # unique clients ips
+                if address_not_in_pool(self.unique_all_time, match_dict['address'], self.storage['unique_tot']):
                     self.storage['unique_tot'] += 1
                 if address_not_in_pool(unique_current, match_dict['address'], to_netdata['unique_cur']):
                     to_netdata['unique_cur'] += 1
-
+        # timings
         if request_time:
             to_netdata['resp_time_min'] = request_time[0]
             to_netdata['resp_time_avg'] = float(request_counter['sum']) / request_counter['count']
             to_netdata['resp_time_max'] = request_time[-1]
 
         to_netdata.update(self.storage)
-        to_netdata.update(detailed_dict)
+        to_netdata.update(default_dict)
 
         return to_netdata
 
-    def _get_detailed_data(self, code, detailed_dict):
+    def _get_data_detailed_response_codes(self, code, default_dict):
         if code not in self.storage:
-            self.add_new_dimension(code, [code, code, 'absolute'])
-        detailed_dict[code] += 1
+            chart_string_copy = self.detailed_chart
+            self.detailed_chart = self.add_new_dimension(code, [code, code, 'absolute'],
+                                                         chart_string_copy, 'detailed_response_codes')
+        default_dict[code] += 1
 
-    def _get_url_pattern_data(self, url, detailed_dict):
+    def _get_data_http_method(self, method, default_dict):
+        if method not in self.storage:
+            chart_string_copy = self.http_method_chart
+            self.http_method_chart = self.add_new_dimension(method, [method, method, 'absolute'],
+                                                            chart_string_copy, 'http_method')
+        default_dict[method] += 1
+
+    def _get_data_per_url(self, url, default_dict):
         match = None
         for elem in self.url_pattern:
             if elem.pattern.search(url):
-                detailed_dict[elem.description] += 1
+                default_dict[elem.description] += 1
                 match = True
                 break
-        if not match: detailed_dict['other_url'] += 1
+        if not match:
+            default_dict['other_url'] += 1
         
 
 def address_not_in_pool(pool, address, pool_size):

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # Description: nginx log netdata python.d module
-# Author: Pawel Krupa (paulfantom), l2isbad
+# Author: l2isbad
 
 from base import LogService
 import re
 import bisect
 from os import access, R_OK
 from os.path import getsize
+from collections import defaultdict
 
 priority = 60000
 retries = 60
@@ -16,18 +17,21 @@ CHARTS = {
     'response_codes': {
         'options': [None, 'Response Codes', 'requests/s', 'Responses', 'nginx_log.response', 'stacked'],
         'lines': [
-            ['2', '2xx', 'incremental'],
-            ['5', '5xx', 'incremental'],
-            ['3', '3xx', 'incremental'],
-            ['4', '4xx', 'incremental'],
-            ['1', '1xx', 'incremental'],
-            ['0', 'other', 'incremental']
+            ['2', '2xx', 'absolute'],
+            ['5', '5xx', 'absolute'],
+            ['3', '3xx', 'absolute'],
+            ['4', '4xx', 'absolute'],
+            ['1', '1xx', 'absolute'],
+            ['6', '6xx', 'absolute'],
+            ['7', '7xx', 'absolute'],
+            ['8', '8xx', 'absolute'],
+            ['9', '9xx', 'absolute']
         ]},
     'bandwidth': {
         'options': [None, 'Bandwidth', 'KB/s', 'Bandwidth', 'nginx_log.bw', 'stacked'],
         'lines': [
-            ['bytes_sent', 'sent', 'incremental', 1, 1024],
-            ['resp_length', 'received', 'incremental', 1, 1024]
+            ['bytes_sent', 'sent', 'absolute', 1, 1024],
+            ['resp_length', 'received', 'absolute', 1, 1024]
         ]},
     'request_time': {
         'options': [None, 'Processing Time', 'seconds', 'Requests', 'nginx_log.request', 'stacked'],
@@ -45,28 +49,95 @@ CHARTS = {
         ]}
 }
 
+ALL_CODES = {
+ '100': 'Continue',
+ '101': 'Switching Protocols',
+ '102': 'Processing',
+ '200': 'OK',
+ '201': 'Created',
+ '202': 'Accepted',
+ '204': 'No Content',
+ '205': 'Reset Content',
+ '206': 'Partial Content',
+ '208': 'Already Reported',
+ '226': 'IM Used',
+ '300': 'Multiple Choices',
+ '301': 'Moved Permanently',
+ '302': 'Found',
+ '303': 'See Other',
+ '304': 'Not Modified',
+ '305': 'Use Proxy',
+ '307': 'Temporary Redirect',
+ '308': 'Permanent Redirect',
+ '400': 'Bad Request',
+ '401': 'Unauthorized',
+ '402': 'Payment Required',
+ '403': 'Forbidden',
+ '404': 'Not Found',
+ '405': 'Method Not Allowed',
+ '406': 'Not Acceptable',
+ '407': 'Proxy Authentication Required',
+ '408': 'Request Timeout',
+ '409': 'Conflict',
+ '410': 'Gone',
+ '411': 'Length Required',
+ '412': 'Precondition Failed',
+ '413': 'Payload Too Large',
+ '415': 'Unsupported Media Type',
+ '416': 'Requested Range Not Satisfiable',
+ '417': 'Expectation Failed',
+ '421': 'Misdirected Request',
+ '422': 'Unprocessable Entity',
+ '423': 'Locked',
+ '424': 'Failed Dependency',
+ '426': 'Upgrade Required',
+ '428': 'Precondition Required',
+ '429': 'Too Many Requests',
+ '431': 'Request Header Fields Too Large',
+ '444': 'Connection Closed Without Response',
+ '451': 'Unavailable For Legal Reasons',
+ '499': 'Client Closed Request',
+ '500': 'Internal Server Error',
+ '501': 'Not Implemented',
+ '502': 'Bad Gateway',
+ '503': 'Service Unavailable',
+ '504': 'Gateway Timeout',
+ '505': 'HTTP Version Not Supported',
+ '506': 'Variant Also Negotiates',
+ '507': 'Insufficient Storage',
+ '508': 'Loop Detected',
+ '510': 'Not Extended',
+ '511': 'Network Authentication Required',
+ '599': 'Network Connect Timeout Error'}
+
 
 class Service(LogService):
     def __init__(self, configuration=None, name=None):
         LogService.__init__(self, configuration=configuration, name=name)
-        self.order = ORDER
-        self.definitions = CHARTS
         self.log_path = self.configuration.get('path', '/var/log/nginx/access.log')
-        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<= )[1-9])\d\d (\d+) (\d+)? ?([\d.]+)?')
-        self.data = {str(k): 0 for k in range(6)}
-        self.data.update({'bytes_sent': 0, 'unique_tot': 0,
-                          'resp_length': 0, 'foo': 0})
+        self.detailed_response_codes = self.configuration.get('detailed_response_codes', True)
+        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<= )[1-9]\d{2}) (\d+) (\d+)? ?([\d.]+)?')
+        # sorted list of unique IPs
         self.unique_alltime = list()
+        # all values that should not be zeroed every poll
+        self.storage = {'unique_tot': 0}
+        self.data = {str(k): 0 for k in range(1, 10)}
+        self.data.update({'bytes_sent': 0, 'resp_length': 0, 'resp_time_min': 0,
+                          'resp_time_avg': 0, 'resp_time_max': 0, 'unique_cur': 0,
+                          'foo': 0, 'unique_tot': 0})
 
     def check(self):
+        # Can't start if log path is not readable by netdata
         if not access(self.log_path, R_OK):
             self.error('%s not readable or not exist' % self.log_path)
             return False
 
+        # Can't start if file is empty
         if not getsize(self.log_path):
             self.error('%s is empty' % self.log_path)
             return False
-        
+
+        # Read the last line from file
         with open(self.log_path, 'rb') as logs:
             logs.seek(-2, 2)
             while logs.read(1) != b'\n':
@@ -75,14 +146,42 @@ class Service(LogService):
                     break
             last_line = logs.readline().decode(encoding='utf-8')
 
+        # We need to make sure we can to parse the line
         parsed_line = self.regex.findall(last_line)
         if not parsed_line:
             self.error('Can\'t parse output')
             return False
-        else:
-            if parsed_line[0][4] == '':
-                self.order.remove('request_time')
+
+        # Pass 5th element from parsed line result (response time)
+        self.create_charts(parsed_line[0][4])
         return True
+
+    def create_charts(self, parsed_line):
+        # This thing needed for adding dynamic dimensions
+        self.detailed_chart = 'CHART nginx_log_local.detailed_response_codes ""' \
+                              ' "Response Codes" requests Detailed nginx_log.detailed stacked 14 1\n'
+        self.order = ORDER
+        self.definitions = CHARTS
+
+        # Remove 'request_time' chart if there is not 'reponse_time' in logs
+        if parsed_line == '':
+            self.order.remove('request_time')
+ 
+        # Add detailed_response_codes chart if specified in the configuration
+        if self.detailed_response_codes:
+            self.order.append('detailed_response_codes')
+            self.definitions['detailed_response_codes'] = {'options': [None, 'Detailed Response Codes', 'requests/s',
+                                                                       'Detailed', 'nginx_log.detailed_resp', 'stacked'],
+                                                           'lines': []}
+
+    def add_new_dimension(self, code, line):
+        # add new dimension to STORAGE dict. If code appear once we it will always be as current value or zero
+        self.storage.update({code: 0})
+        # Pass new dimension to NETDATA
+        self._dimensions.append(code)
+        self.definitions['detailed_response_codes']['lines'].append(line)
+        self.detailed_chart += "%s %s\n" % ('DIMENSION', ' '.join(line))
+        print(self.detailed_chart)
 
     def _get_data(self):
         """
@@ -92,41 +191,52 @@ class Service(LogService):
         raw = self._get_raw_data()
         if raw is None:
             return None
-
+        
         request_time, unique_current = list(), list()
         request_counter = {'count': 0, 'sum': 0}
-        self.data.update({'resp_time_min' : 0, 'resp_time_avg': 0, 'resp_time_max': 0, 'unique_cur': 0})
+        to_netdata = dict()
+        to_netdata.update(self.data)
+        detailed_dict = defaultdict(lambda: 0)
 
         for line in raw:
             match = self.regex.findall(line)
             if match:
                 match_dict = dict(zip(['address', 'code', 'sent', 'resp_length', 'resp_time'], match[0]))
-                try:
-                    self.data[match_dict['code']] += 1
-                except KeyError:
-                    self.data['0'] += 1
-                self.data['bytes_sent'] += int(match_dict['sent'])
+                to_netdata[match_dict['code'][0]] += 1
+
+                if self.detailed_response_codes: self._get_detailed_data(match_dict['code'], detailed_dict)
+                
+                to_netdata['bytes_sent'] += int(match_dict['sent'])
+                
                 if match_dict['resp_length'] != '' and match_dict['resp_time'] != '':
-                    self.data['resp_length'] += int(match_dict['resp_length'])
+                    to_netdata['resp_length'] += int(match_dict['resp_length'])
                     resp_time = float(match_dict['resp_time']) * 1000
                     bisect.insort_left(request_time, resp_time)
                     request_counter['count'] += 1
                     request_counter['sum'] += resp_time
                     
-                if addr_not_in_pool(self.unique_alltime, match_dict['address'], self.data['unique_tot']):
-                    self.data['unique_tot'] += 1
-                if addr_not_in_pool(unique_current, match_dict['address'], self.data['unique_cur']):
-                    self.data['unique_cur'] += 1
+                if address_not_in_pool(self.unique_alltime, match_dict['address'], self.storage['unique_tot']):
+                    self.storage['unique_tot'] += 1
+                if address_not_in_pool(unique_current, match_dict['address'], to_netdata['unique_cur']):
+                    to_netdata['unique_cur'] += 1
 
         if request_time:
-            self.data['resp_time_min'] = request_time[0]
-            self.data['resp_time_avg'] = float(request_counter['sum']) / request_counter['count']
-            self.data['resp_time_max'] = request_time[-1]
+            to_netdata['resp_time_min'] = request_time[0]
+            to_netdata['resp_time_avg'] = float(request_counter['sum']) / request_counter['count']
+            to_netdata['resp_time_max'] = request_time[-1]
 
-        return self.data
+        to_netdata.update(self.storage)
+        to_netdata.update(detailed_dict)
 
+        return to_netdata
 
-def addr_not_in_pool(pool, address, pool_size):
+    def _get_detailed_data(self, code, detailed_dict):
+        if code not in self.storage:
+            self.add_new_dimension(code, [code, code, 'absolute'])
+        detailed_dict[code] += 1
+        
+
+def address_not_in_pool(pool, address, pool_size):
     index = bisect.bisect_left(pool, address)
     if index < pool_size:
         if pool[index] == address:

--- a/python.d/nginx_log.chart.py
+++ b/python.d/nginx_log.chart.py
@@ -1,25 +1,34 @@
 # -*- coding: utf-8 -*-
 # Description: nginx log netdata python.d module
-# Author: Pawel Krupa (paulfantom)
+# Author: Pawel Krupa (paulfantom), l2isbad
 
 from base import LogService
 import re
+import bisect
 
 priority = 60000
 retries = 60
-# update_every = 3
 
-ORDER = ['codes']
+ORDER = ['codes', 'bandwidth', 'unique']
 CHARTS = {
     'codes': {
-        'options': [None, 'nginx status codes', 'requests/s', 'requests', 'nginx_log.codes', 'stacked'],
+        'options': [None, 'Status codes', 'requests/s', 'requests', 'nginx_log.codes', 'stacked'],
         'lines': [
-            ["2xx", None, "incremental"],
-            ["5xx", None, "incremental"],
-            ["3xx", None, "incremental"],
-            ["4xx", None, "incremental"],
-            ["1xx", None, "incremental"],
-            ["other", None, "incremental"]
+            ['2', '2xx', 'incremental'],
+            ['5', '5xx', 'incremental'],
+            ['3', '3xx', 'incremental'],
+            ['4', '4xx', 'incremental'],
+            ['1', '1xx', 'incremental']
+        ]},
+    'bandwidth': {
+        'options': [None, 'Bandwidth', 'KB/s', 'bandwidth', 'nginx_log.bw', 'area'],
+        'lines': [
+            ['bandwidth', 'sent', 'incremental', 1, 1024]
+        ]},
+    'unique': {
+        'options': [None, 'Unique visitors', 'number', 'unique visitors', 'nginx_log.uv', 'line'],
+        'lines': [
+            ['unique', 'visitors', 'absolute', 1, 1]
         ]}
 }
 
@@ -27,56 +36,39 @@ CHARTS = {
 class Service(LogService):
     def __init__(self, configuration=None, name=None):
         LogService.__init__(self, configuration=configuration, name=name)
-        if len(self.log_path) == 0:
-            self.log_path = "/var/log/nginx/access.log"
         self.order = ORDER
         self.definitions = CHARTS
-        pattern = r'" ([0-9]{3}) ?'
-        #pattern = r'(?:" )([0-9][0-9][0-9]) ?'
-        self.regex = re.compile(pattern)
-
-        self.data = {
-            '1xx': 0,
-            '2xx': 0,
-            '3xx': 0,
-            '4xx': 0,
-            '5xx': 0,
-            'other': 0
-        }
+        self.regex = re.compile(r'(\d{1,3}(?:\.\d{1,3}){3}).*?((?<=\s)[1-5])\d\d (\d+)?')
+        self.data = {str(k): 0 for k in range(1, 6)}
+        self.data.update({'bandwidth': 0, 'unique': 0})
+        self.unique = list()
 
     def _get_data(self):
-        """
+        '''
         Parse new log lines
         :return: dict
-        """
-        try:
-            raw = self._get_raw_data()
-            if raw is None:
-                return None
-            elif not raw:
-                return self.data
-        except (ValueError, AttributeError):
-            return None
+        '''
+        raw = self._get_raw_data()
+        if raw is None: return None
 
-        regex = self.regex
         for line in raw:
-            code = regex.search(line)
-            try:
-                beginning = code.group(1)[0]
-            except AttributeError:
-                continue
-
-            if beginning == '2':
-                self.data["2xx"] += 1
-            elif beginning == '3':
-                self.data["3xx"] += 1
-            elif beginning == '4':
-                self.data["4xx"] += 1
-            elif beginning == '5':
-                self.data["5xx"] += 1
-            elif beginning == '1':
-                self.data["1xx"] += 1
-            else:
-                self.data["other"] += 1
-
+            match = self.regex.findall(line)
+            if match:
+                address, code, sent = match[0][0], match[0][1], match[0][2] or 0
+                self.data[code] += 1
+                self.data['bandwidth'] += int(sent)
+                if self.contains(address):
+                    self.data['unique'] += 1
         return self.data
+
+    def contains(self, address):
+        index = bisect.bisect_left(self.unique, address)
+        if index < len(self.unique):
+            if self.unique[index] == address:
+                return False
+            else:
+                bisect.insort_left(self.unique, address)
+                return True
+        else:
+            bisect.insort_left(self.unique, address)
+            return True


### PR DESCRIPTION
Optimization i made yesterday while talking in https://github.com/firehol/netdata/pull/1337

Do the same job but plus two more charts.
For unique users count script uses bisect algorithm so it's fast.

![screenshot_20170204_185139](https://cloud.githubusercontent.com/assets/22274335/22617550/777c67ca-eb0b-11e6-80fb-a315215b2a4c.png)

Works for me, but pls test it @ktsaou 
@shadycuz looks like you are using plugin. Can you test this version?

And what is ['other'](https://github.com/firehol/netdata/blob/master/python.d/nginx_log.chart.py#L22)
Status codes always are (i google it!) 1x|2x|3x|4x|5x
'other' was removed..