### PR TITLE
User proper JSON for /api/v1/data

### DIFF
--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -918,13 +918,13 @@ static void rrdr2json(RRDR *r, BUFFER *wb, uint32_t options, int datatable)
     else {
         kq[0] = '"';
         sq[0] = '"';
-        if((options & RRDR_OPTION_SECONDS) || (options & RRDR_OPTION_MILLISECONDS)) {
-            dates = JSON_DATES_TIMESTAMP;
-            dates_with_new = 0;
-        }
-        else {
+        if(options & RRDR_OPTION_GOOGLE_JSON) {
             dates = JSON_DATES_JS;
             dates_with_new = 1;
+        }
+        else {
+            dates = JSON_DATES_TIMESTAMP;
+            dates_with_new = 0;
         }
         if( options & RRDR_OPTION_OBJECTSROWS )
             strcpy(pre_date, "      { ");


### PR DESCRIPTION
This fixes issue #83
The output with options=google_json does not change.

@ktsaou Sorry for delaying documentation but documentation needs a special type of mood ;) Please be patient... 

I am pretty sure this is correct because printing new Date(... is very Google specific and we should not use that in any other output.

Of course as mentioned in #83 we might need tests to ensure our JSON API does not change. I want to start a discussion here what might be the best solution implementing such tests... Any ideas?