### PR TITLE
detect slow browsers and lower charts detail and update frequency; fixes #212

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3312,4 +3312,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170205-1"></script>
+<script type="text/javascript" src="dashboard.js?v20170205-4"></script>


### PR DESCRIPTION
This PR detects that the client is an iOS or android device and sets:

1. `pixels_per_point = 5`, to lower the detail of charts (fewer points to draw)
2. `parallel_refresher = false`, to render the charts one by one, instead of concurrently
3. `destroy_on_hide = true`, to destroy the not visible charts and lower the memory used by the dashboard.
4. `smooth_plot = false`, to disable the Bézier algorithm on line charts

All settings, except the first, are editable via the dashboard settings.

fixes #212 