### PR TITLE
uniform but dynamic number of fraction digits at the legends

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,8 +15,6 @@ engines:
         enabled: false
       Identical code:
         enabled: false
-      no-undef-init:
-        enabled: false
   eslint:
     enabled: true
     checks:
@@ -31,6 +29,8 @@ engines:
       no-void:
         enabled: false
       no-alert:
+        enabled: false
+      no-undef-init:
         enabled: false
   fixme:
     enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,6 +13,8 @@ engines:
     checks:
       Similar code:
         enabled: false
+      Identical code:
+        enabled: false
   eslint:
     enabled: true
     checks:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,8 @@ engines:
         enabled: false
       Identical code:
         enabled: false
+      no-undef-init:
+        enabled: false
   eslint:
     enabled: true
     checks:

--- a/src/web_buffer_svg.c
+++ b/src/web_buffer_svg.c
@@ -389,7 +389,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
             len = snprintfz(value_string, value_string_len, "%0.0Lf", (long double) value);
             trim_zeros = 0;
         }
-        else if(isgreaterequal(abs, 100)) len = snprintfz(value_string, value_string_len, "%0.1Lf", (long double) value);
+        else if(isgreaterequal(abs, 10))  len = snprintfz(value_string, value_string_len, "%0.1Lf", (long double) value);
         else if(isgreaterequal(abs, 1))   len = snprintfz(value_string, value_string_len, "%0.2Lf", (long double) value);
         else if(isgreaterequal(abs, 0.1)) len = snprintfz(value_string, value_string_len, "%0.3Lf", (long double) value);
         else                              len = snprintfz(value_string, value_string_len, "%0.4Lf", (long double) value);

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -2329,33 +2329,44 @@ var NETDATA = window.NETDATA || {};
             }
         };
 
+        this.legendSetDateLast = {
+            ms: 0,
+            date: undefined,
+            time: undefined
+        };
+
         this.legendSetDate = function(ms) {
             if(typeof ms !== 'number') {
                 this.legendShowUndefined();
                 return;
             }
 
-            var d = new Date(ms);
+            if(this.legendSetDateLast.ms !== ms) {
+                var d = new Date(ms);
+                this.legendSetDateLast.ms = ms;
+                this.legendSetDateLast.date = d.toLocaleDateString();
+                this.legendSetDateLast.time = d.toLocaleTimeString();
+            }
 
-            if(this.element_legend_childs.title_date)
-                this.__legendSetDateString(d.toLocaleDateString());
+            if(this.element_legend_childs.title_date !== null)
+                this.__legendSetDateString(this.legendSetDateLast.date);
 
-            if(this.element_legend_childs.title_time)
-                this.__legendSetTimeString(d.toLocaleTimeString());
+            if(this.element_legend_childs.title_time !== null)
+                this.__legendSetTimeString(this.legendSetDateLast.time);
 
-            if(this.element_legend_childs.title_units)
+            if(this.element_legend_childs.title_units !== null)
                 this.__legendSetUnitsString(this.units)
         };
 
         this.legendShowUndefined = function() {
-            if(this.element_legend_childs.title_date)
-                this.__legendSetDateString(' ');
+            if(this.element_legend_childs.title_date !== null)
+                this.__legendSetDateString(' haha ');
 
-            if(this.element_legend_childs.title_time)
+            if(this.element_legend_childs.title_time !== null)
                 this.__legendSetTimeString(this.chart.name);
 
-            if(this.element_legend_childs.title_units)
-                this.__legendSetUnitsString(' ');
+            if(this.element_legend_childs.title_units !== null)
+                this.__legendSetUnitsString(' haha2 ');
 
             if(this.data && this.element_legend_childs.series !== null) {
                 var labels = this.data.dimension_names;
@@ -2363,8 +2374,7 @@ var NETDATA = window.NETDATA || {};
                 while(i--) {
                     var label = labels[i];
 
-                    if(typeof label === 'undefined') continue;
-                    if(typeof this.element_legend_childs.series[label] === 'undefined') continue;
+                    if(typeof label === 'undefined' || typeof this.element_legend_childs.series[label] === 'undefined') continue;
                     this.legendSetLabelValue(label, null);
                 }
             }
@@ -2776,16 +2786,19 @@ var NETDATA = window.NETDATA || {};
 
                 this.element_legend_childs.title_date.className += " netdata-legend-title-date";
                 this.element_legend.appendChild(this.element_legend_childs.title_date);
+                this.__last_shown_legend_date = undefined;
 
                 this.element_legend.appendChild(document.createElement('br'));
 
                 this.element_legend_childs.title_time.className += " netdata-legend-title-time";
                 this.element_legend.appendChild(this.element_legend_childs.title_time);
+                this.__last_shown_legend_time = undefined;
 
                 this.element_legend.appendChild(document.createElement('br'));
 
                 this.element_legend_childs.title_units.className += " netdata-legend-title-units";
                 this.element_legend.appendChild(this.element_legend_childs.title_units);
+                this.__last_shown_legend_units = undefined;
 
                 this.element_legend.appendChild(document.createElement('br'));
 

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -2360,13 +2360,13 @@ var NETDATA = window.NETDATA || {};
 
         this.legendShowUndefined = function() {
             if(this.element_legend_childs.title_date !== null)
-                this.__legendSetDateString(' haha ');
+                this.__legendSetDateString(' ');
 
             if(this.element_legend_childs.title_time !== null)
                 this.__legendSetTimeString(this.chart.name);
 
             if(this.element_legend_childs.title_units !== null)
-                this.__legendSetUnitsString(' haha2 ');
+                this.__legendSetUnitsString(' ');
 
             if(this.data && this.element_legend_childs.series !== null) {
                 var labels = this.data.dimension_names;

--- a/web/index.html
+++ b/web/index.html
@@ -3312,4 +3312,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170205-4"></script>
+<script type="text/javascript" src="dashboard.js?v20170205-10"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3312,4 +3312,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170205-10"></script>
+<script type="text/javascript" src="dashboard.js?v20170205-28"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3312,4 +3312,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170205-28"></script>
+<script type="text/javascript" src="dashboard.js?v20170205-37"></script>


### PR DESCRIPTION
## the problem

Find in this picture the process that used most of the CPU:

![image](https://cloud.githubusercontent.com/assets/2662304/22629698/dd27e91c-ebf3-11e6-9d27-e4bef9518a98.png)

Yes, I know it is `torrents`, but the legend does not help. When there are many dimensions, the legend requires quite some focus to find the most important one.

## the solution

Well, before this PR the dashboard decides for the number of fraction digits, based on each number alone. It used no fraction digits for values above 1000, 1 fraction digit for values above 100, 2 fraction digits for values above 10, etc up to 4 fraction digits.

This PR tries something different. It decides the number of fraction digits for all dimensions of a chart, based on the visible y-range of the chart! The algorithm for deciding the number of fraction digits is the same, but all the dimensions get the same, so the numbers are easily distinguishable.

Let's see:

![image](https://cloud.githubusercontent.com/assets/2662304/22629731/c0146b92-ebf4-11e6-87b7-5e4751669ab6.png)

A lot better.

What is nice, is that when you click on a dimension to select it, the y-range of the chart changes, so the detail on the numbers changes too immediately:

So, `netdata` has a small range and 2 fraction digits:

![image](https://cloud.githubusercontent.com/assets/2662304/22629769/340c704e-ebf5-11e6-950d-566a0a4a17eb.png)

But `X`, has a bigger range and 1 fraction digits: 

![image](https://cloud.githubusercontent.com/assets/2662304/22629772/5088d848-ebf5-11e6-9897-6f3882eeb394.png)

If the range is too small, you still get up to 4 digits (this chart ranges from 0.9995 to 1.0048):

![image](https://cloud.githubusercontent.com/assets/2662304/22629787/7f635706-ebf5-11e6-9545-851b05d48687.png)

## side effects

There are always side effects:

![image](https://cloud.githubusercontent.com/assets/2662304/22629795/a2880d12-ebf5-11e6-97aa-e9cb107ea82d.png)

Before this PR, this chart did not have any fraction digits.

It is annoying I know, but I made a little change to make it easier to accept it: before this PR values from 1 to 100 would get 2 fraction digits. After this PR, values 1 to 10 get 2, but 10 to 100 get 1. This makes it a little bit less annoying.

---

this PR also fixes an issue where charts were randomly loosing some legend information (date and units).

---

also, chart y-axis labels are now using the same formatting as the legends:

![image](https://cloud.githubusercontent.com/assets/2662304/22630177/88a7c786-ebfd-11e6-9a55-98b89937b5da.png)
