### PR TITLE
python.d.plugin: YAML output is ordered now

### DIFF
--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -67,6 +67,26 @@ try:
 except ImportError:
     msg.fatal('Cannot find yaml library')
 
+try:
+    from collections import OrderedDict
+    ORDERED = True
+    DICT = OrderedDict
+    msg.info('YAML output is ordered')
+except ImportError:
+    ORDERED = False
+    DICT = dict
+    msg.info('YAML output is unordered')
+else:
+    def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+        class OrderedLoader(Loader):
+            pass
+        def construct_mapping(loader, node):
+           loader.flatten_mapping(node)
+           return object_pairs_hook(loader.construct_pairs(node))
+        OrderedLoader.add_constructor(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            construct_mapping)
+        return yaml.load(stream, OrderedLoader)
 
 class PythonCharts(object):
     """
@@ -235,7 +255,7 @@ class PythonCharts(object):
         # check if there are dict in config dict
         many_jobs = False
         for name in config:
-            if type(config[name]) is dict:
+            if isinstance(config[name], DICT):
                 many_jobs = True
                 break
 
@@ -420,7 +440,10 @@ def read_config(path):
     """
     try:
         with open(path, 'r') as stream:
-            config = yaml.load(stream)
+            if ORDERED:
+                config = ordered_load(stream, yaml.SafeLoader)
+            else:
+                config = yaml.load(stream)
     except (OSError, IOError):
         msg.error(str(path), "is not a valid configuration file")
         return None


### PR DESCRIPTION
Example conf file:

```yaml
nginx_log:
  name: 'local'
  path: '/var/log/nginx/access.log'
  detailed_response_codes: yes
  all_time: yes
  categories:
      cacti_graph: 'cacti/graph.*'
      cacti: 'cacti.*'
      observium: 'observium.*'
      stub_status: 'stub_status'
```

Before PR (categories - unordered):
```bash
python.d ERROR: nginx_log_nginx_log {'stub_status': 'stub_status', 'cacti': 'cacti.*', 'cacti_graph': 'cacti/graph.*', 'observium': 'observium.*'}
```

After (same order as in conf file):
```bash
python.d ERROR: nginx_log_nginx_log OrderedDict([('cacti_graph', 'cacti/graph.*'), ('cacti', 'cacti.*'), ('observium', 'observium.*'), ('stub_status', 'stub_status')])
```

We need this for https://github.com/firehol/netdata/pull/1716 (per url requests)

It should be well tested (works for me).

@ktsaou you can install this PR on your http://registry.my-netdata.io to test regex order
