### PR TITLE
Add version to /api/v1/charts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,15 +7,15 @@ define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [5])
 define([VERSION_FIX], [1])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-define([VERSION_SUFFIX], [_prerelease])
+define([VERSION_SUFFIX], [_rolling])
 
 dnl Set to "1" for a first RPM release of a new version
 PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)"
 
 define([VERSION_STRING], m4_esyscmd_s(git describe 2>/dev/null | sed 's/^v//'))
-m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER[]VERSION_SUFFIX)])
+m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER)])
 
-AC_INIT([netdata], VERSION_STRING)
+AC_INIT([netdata], VERSION_STRING[]VERSION_SUFFIX)
 
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -7,12 +7,12 @@ define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [5])
 define([VERSION_FIX], [1])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-define([VERSION_SUFFIX], [_master])
+define([VERSION_SUFFIX], [_prerelease])
 
 dnl Set to "1" for a first RPM release of a new version
 PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)"
 
-define([VERSION_STRING], m4_esyscmd_s(git describe 2> /dev/null))
+define([VERSION_STRING], m4_esyscmd_s(git describe 2>/dev/null | sed 's/^v//'))
 m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER[]VERSION_SUFFIX)])
 
 AC_INIT([netdata], VERSION_STRING)

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,10 @@ define([VERSION_SUFFIX], [_master])
 dnl Set to "1" for a first RPM release of a new version
 PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)"
 
-AC_INIT([netdata], VERSION_NUMBER[]VERSION_SUFFIX)
+define([VERSION_STRING], m4_esyscmd_s(git describe 2> /dev/null))
+m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER[]VERSION_SUFFIX)])
+
+AC_INIT([netdata], VERSION_STRING)
 
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then

--- a/packaging/update-tags
+++ b/packaging/update-tags
@@ -135,7 +135,7 @@ then
   fi
 
   echo "Resetting suffix in configure.ac:"
-  sed -i -e 's/define(\[VERSION_SUFFIX\], \[.*])/define([VERSION_SUFFIX], [_master])/' configure.ac
+  sed -i -e 's/define(\[VERSION_SUFFIX\], \[.*])/define([VERSION_SUFFIX], [_prerelease])/' configure.ac
   sed -i -e 's:^PACKAGE_RPM_RELEASE=.*:PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)":' configure.ac
 
   echo "Committing new configure.ac:"

--- a/packaging/update-tags
+++ b/packaging/update-tags
@@ -135,7 +135,7 @@ then
   fi
 
   echo "Resetting suffix in configure.ac:"
-  sed -i -e 's/define(\[VERSION_SUFFIX\], \[.*])/define([VERSION_SUFFIX], [_prerelease])/' configure.ac
+  sed -i -e 's/define(\[VERSION_SUFFIX\], \[.*])/define([VERSION_SUFFIX], [_rolling])/' configure.ac
   sed -i -e 's:^PACKAGE_RPM_RELEASE=.*:PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)":' configure.ac
 
   echo "Committing new configure.ac:"

--- a/src/common.c
+++ b/src/common.c
@@ -13,6 +13,7 @@ int enable_ksm = 1;
 
 volatile sig_atomic_t netdata_exit = 0;
 const char *os_type = NETDATA_OS_TYPE;
+const char *program_version = VERSION;
 
 // ----------------------------------------------------------------------------
 // memory allocation functions that handle failures

--- a/src/common.h
+++ b/src/common.h
@@ -277,6 +277,8 @@ extern void get_system_HZ(void);
 extern volatile sig_atomic_t netdata_exit;
 extern const char *os_type;
 
+extern const char *program_version;
+
 /* fix for alpine linux */
 #ifndef RUSAGE_THREAD
 #ifdef RUSAGE_CHILDREN

--- a/src/main.c
+++ b/src/main.c
@@ -434,8 +434,7 @@ int main(int argc, char **argv)
                     config_set("global", "run as user", optarg);
                     break;
                 case 'v':
-                    // TODO: Outsource version to makefile which can compute version from git.
-                    printf("netdata %s\n", VERSION);
+                    printf("%s %s\n", program_name, program_version);
                     return 0;
                 case 'W':
                     {

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -85,11 +85,13 @@ void rrd_stats_api_v1_charts(BUFFER *wb)
 
     buffer_sprintf(wb, "{\n"
            "\t\"hostname\": \"%s\""
+        ",\n\t\"version\": \"%s\""
         ",\n\t\"os\": \"%s\""
         ",\n\t\"update_every\": %d"
         ",\n\t\"history\": %d"
         ",\n\t\"charts\": {"
         , localhost.hostname
+        , program_version
         , os_type
         , rrd_update_every
         , rrd_default_history_entries


### PR DESCRIPTION
This fixes #1222

Version is computed with git describe. Now we are able to extend version checking afterwards.
This should not influence the packaging process. Please re-check if I am right.

For this we might use:
https://developer.github.com/v3/repos/releases/
and compare from https://developer.github.com/v3/repos/commits/