### PR TITLE
Replace OS conditional prctl.h include with file presence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,7 @@ AC_CHECK_SIZEOF([void *])
 AC_CANONICAL_HOST
 AC_HEADER_MAJOR
 AC_HEADER_RESOLV
+AC_CHECK_HEADERS_ONCE([sys/prctl.h])
 
 AC_CHECK_LIB([cap], [cap_get_proc, cap_set_proc],
 	[AC_CHECK_HEADER(

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -3109,7 +3109,9 @@ int main(int argc, char **argv) {
         struct rlimit rl = { RLIM_INFINITY, RLIM_INFINITY };
         if(setrlimit(RLIMIT_CORE, &rl) != 0)
             info("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
+#ifdef HAVE_SYS_PRCTL_H
         prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+#endif
     }
 #endif /* NETDATA_INTERNAL_CHECKS */
 

--- a/src/common.h
+++ b/src/common.h
@@ -67,9 +67,9 @@
 #include <syslog.h>
 #include <sys/mman.h>
 
-#if !(defined(__FreeBSD__) || defined(__APPLE__))
+#ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
-#endif /* __FreeBSD__ || __APPLE__*/
+#endif
 
 #include <sys/resource.h>
 #include <sys/socket.h>

--- a/src/main.c
+++ b/src/main.c
@@ -571,9 +571,9 @@ int main(int argc, char **argv)
             if(setrlimit(RLIMIT_CORE, &rl) != 0)
                 error("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
 
-#if !(defined(__FreeBSD__) || defined(__APPLE__))
+#ifdef HAVE_SYS_PRCTL_H
             prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
-#endif /* __FreeBSD__ || __APPLE__*/
+#endif
         }
 
         // --------------------------------------------------------------------
@@ -748,9 +748,9 @@ int main(int argc, char **argv)
         struct rlimit rl = { RLIM_INFINITY, RLIM_INFINITY };
         if(setrlimit(RLIMIT_CORE, &rl) != 0)
             error("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
-#if !(defined(__FreeBSD__) || defined(__APPLE__))
+#ifdef HAVE_SYS_PRCTL_H
         prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
-#endif /* __FreeBSD__ || __APPLE__*/
+#endif
     }
 #endif /* NETDATA_INTERNAL_CHECKS */
 


### PR DESCRIPTION
While checking the build logs for different architectures I noticed that debian/kFreeBSD and Hurd both failed because of the missing sys/prctl.h.
So I recommend changing the OS dependent include to a check based on file availability.