### PR TITLE
Add git describe info to version when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,8 @@ fi
 
 AC_DEFINE_UNQUOTED([NETDATA_USER], ["${with_user}"], [use this user to drop privileged])
 
+AC_DEFINE([GIT_DESC], ["]m4_esyscmd_s(git describe 2> /dev/null)["], [git describe, where available])
+
 AC_SUBST([varlibdir], ["\$(localstatedir)/lib/netdata"])
 AC_SUBST([registrydir], ["\$(localstatedir)/lib/netdata/registry"])
 AC_SUBST([cachedir], ["\$(localstatedir)/cache/netdata"])

--- a/src/main.c
+++ b/src/main.c
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
                     break;
                 case 'v':
                     // TODO: Outsource version to makefile which can compute version from git.
-                    printf("netdata %s\n", VERSION);
+                    printf("netdata %s%s\n", VERSION, *GIT_DESC?" (git " GIT_DESC ")":"");
                     return 0;
                 case 'W':
                     {


### PR DESCRIPTION
I would do something like this. Then it is unambiguous what we are getting. The `GIT_DESC` will be empty if and only if `autoreconf` is used in a tree without git.

Current output is:

~~~~
~/src/firehol/netdata$ ./src/netdata -v
netdata 1.5.1_master (git v1.5.0-194-g2bba43f)
~/src/firehol/netdata$ ../netdatax/src/netdata -v
netdata 1.5.1_master
~~~~

So you may want to tune the contents to avoid duplication. OTOH it may not be so bad as-is.