### PR TITLE
web_log improvements

### DIFF
--- a/conf.d/health.d/web_log.conf
+++ b/conf.d/health.d/web_log.conf
@@ -13,8 +13,16 @@ families: *
     info: number of seconds since the last successful data collection
       to: webmaster
 
+
 # -----------------------------------------------------------------------------
 # high level response code alarms
+
+# the following alarms trigger only when there are enough data.
+# we assume there are enough data when:
+#
+#  $1m_requests > 120
+#
+# i.e. when there are at least 120 requests during the last minute
 
 template: 1m_requests
       on: web_log.response_codes
@@ -40,57 +48,61 @@ families: *
     calc: $1m_2xx * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 30) ? ($this < (($status >= $WARNING ) ? ( 98 ) : ( 95 )) ) : ( 0 )
-    crit: ($1m_requests > 30) ? ($this < (($status == $CRITICAL) ? ( 95 ) : ( 90 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this < (($status >= $WARNING ) ? ( 98 ) : ( 95 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this < (($status == $CRITICAL) ? ( 95 ) : ( 90 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of HTTP redirects (3xx) vs the successful requests, \
-          over the last minute
+    info: the ratio of successful HTTP responses (2xx) over the last minute
       to: webmaster
 
 template: 1m_redirects
       on: web_log.detailed_response_codes
 families: *
   lookup: sum -1m unaligned of 301,303,307,308
-    calc: $this * 100 / ( $1m_2xx + $this )
+    calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 30) ? ($this > (($status >= $WARNING ) ? ( 1 ) : ( 2 )) ) : ( 0 )
-    crit: ($1m_requests > 30) ? ($this > (($status == $CRITICAL) ? ( 2 ) : ( 5 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING ) ? ( 1 ) : ( 2 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 2 ) : ( 5 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of HTTP redirects (301, 303, 307, 308) vs the successful requests, \
-          over the last minute
+    info: the ratio of HTTP redirects (301, 303, 307, 308) over the last minute
       to: webmaster
 
 template: 1m_bad_requests
       on: web_log.response_codes
 families: *
   lookup: sum -1m unaligned of 4xx
-    calc: $this * 100 / ( $1m_2xx + $this )
+    calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 30) ? ($this > (($status >= $WARNING)  ? ( 1 ) : (  5 )) ) : ( 0 )
-    crit: ($1m_requests > 30) ? ($this > (($status == $CRITICAL) ? ( 5 ) : ( 10 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 1 ) : (  5 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 5 ) : ( 10 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of HTTP bad requests (4xx) vs the successful requests, \
-          over the last minute
+    info: the ratio of HTTP bad requests (4xx) over the last minute
       to: webmaster
 
 template: 1m_internal_errors
       on: web_log.response_codes
 families: *
   lookup: sum -1m unaligned of 5xx
-    calc: $this * 100 / ( $1m_2xx + $this )
+    calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 30) ? ($this > (($status >= $WARNING)  ? ( 1 ) : ( 2 )) ) : ( 0 )
-    crit: ($1m_requests > 30) ? ($this > (($status == $CRITICAL) ? ( 2 ) : ( 5 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 1 ) : ( 2 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 2 ) : ( 5 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of HTTP internal server errors (5xx) vs the successful \
-          requests, over the last minute
+    info: the ratio of HTTP internal server errors (5xx), over the last minute
       to: webmaster
+
 
 # -----------------------------------------------------------------------------
 # web slow
+
+# the following alarms trigger only when there are enough data.
+# we assume there are enough data when:
+#
+#  $1m_requests > 120
+#
+# i.e. when there are at least 120 requests during the last minute
 
 template: 10m_response_time
       on: web_log.response_time
@@ -108,14 +120,22 @@ families: *
    every: 10s
    green: 500
      red: 1000
-    warn: ($1m_requests > 30) ? ($this > $green && $this > ($10m_response_time * 2) ) : ( 0 )
-    crit: ($1m_requests > 30) ? ($this > $red   && $this > ($10m_response_time * 4) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > $green && $this > ($10m_response_time * 2) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > $red   && $this > ($10m_response_time * 4) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
     info: the average time to respond to HTTP requests, over the last 1 minute
       to: webmaster
 
 # -----------------------------------------------------------------------------
 # web too many or too few requests
+
+# the following alarms trigger only when there are enough data.
+# we assume there are enough data when:
+#
+#  $5m_2xx_last > 120
+#
+# i.e. when there were at least 120 requests during the 5 minutes starting
+#      at -10m and ending at -5m
 
 template: 5m_2xx_last
       on: web_log.response_codes
@@ -139,11 +159,11 @@ families: *
     calc: ($5m_2xx_last > 0)?($5m_2xx_now * 100 / $5m_2xx_last):(100)
    units: %
    every: 30s
-    warn: ($1m_requests > 30) ? (($5m_2xx_last > 30) ? ($this > 200 OR $this < 50) : (0) ) : ( 0 )
-    crit: ($1m_requests > 30) ? (($5m_2xx_last > 30) ? ($this > 400 OR $this < 25) : (0) ) : ( 0 )
+    warn: ($5m_2xx_last > 120) ? ($this > 200 OR $this < 50) : (0)
+    crit: ($5m_2xx_last > 120) ? ($this > 400 OR $this < 25) : (0)
    delay: down 15m multiplier 1.5 max 1h
 options: no-clear-notification
     info: the percentage of web requests over the last 5 minutes, \
-          compared with the previous 15 minutes
+          compared with the previous 5 minutes
       to: webmaster
 

--- a/configs.signatures
+++ b/configs.signatures
@@ -383,6 +383,7 @@ declare -A configs_signatures=(
   ['f5736e0b2945182cb659cb0713eff923']='apps_groups.conf'
   ['f66e5236ba1245bb2e5fd99191f114c6']='charts.d/hddtemp.conf'
   ['f6c6656f900ff52d159dca12d624016a']='python.d/postgres.conf'
+  ['f7401a6e7c7d4fe2e0e2be7f7f523275']='health.d/web_log.conf'
   ['f7a99e94231beda85c6254912d8d31c1']='python.d/tomcat.conf'
   ['f82924563e41d99cdae5431f0af69155']='python.d.conf'
   ['f8c30f22df92765e2c0fab3c8174e2fc']='health.d/memcached.conf'

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -857,7 +857,7 @@ netdataDashboard.context = {
                     + ' data-dimensions="2xx"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="Successful"'
-                    + ' data-units="requests"'
+                    + ' data-units="requests/s"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
                     + ' data-before="0"'
@@ -865,6 +865,7 @@ netdataDashboard.context = {
                     + ' data-points="CHART_DURATION"'
                     + ' data-common-max="' + id + '"'
                     + ' data-colors="' + NETDATA.colors[0] + '"'
+                    + ' data-decimal-digits="0"'
                     + ' role="application"></div>';
             },
 
@@ -874,7 +875,7 @@ netdataDashboard.context = {
                     + ' data-dimensions="3xx"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="Redirects"'
-                    + ' data-units="requests"'
+                    + ' data-units="requests/s"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
                     + ' data-before="0"'
@@ -882,6 +883,7 @@ netdataDashboard.context = {
                     + ' data-points="CHART_DURATION"'
                     + ' data-common-max="' + id + '"'
                     + ' data-colors="' + NETDATA.colors[2] + '"'
+                    + ' data-decimal-digits="0"'
                     + ' role="application"></div>';
             },
 
@@ -891,7 +893,7 @@ netdataDashboard.context = {
                     + ' data-dimensions="4xx"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="Bad Requests"'
-                    + ' data-units="requests"'
+                    + ' data-units="requests/s"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
                     + ' data-before="0"'
@@ -899,6 +901,7 @@ netdataDashboard.context = {
                     + ' data-points="CHART_DURATION"'
                     + ' data-common-max="' + id + '"'
                     + ' data-colors="' + NETDATA.colors[3] + '"'
+                    + ' data-decimal-digits="0"'
                     + ' role="application"></div>';
             },
 
@@ -908,7 +911,7 @@ netdataDashboard.context = {
                     + ' data-dimensions="5xx"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="Server Errors"'
-                    + ' data-units="requests"'
+                    + ' data-units="requests/s"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
                     + ' data-before="0"'
@@ -916,6 +919,7 @@ netdataDashboard.context = {
                     + ' data-points="CHART_DURATION"'
                     + ' data-common-max="' + id + '"'
                     + ' data-colors="' + NETDATA.colors[1] + '"'
+                    + ' data-decimal-digits="0"'
                     + ' role="application"></div>';
             }
         ]
@@ -928,7 +932,7 @@ netdataDashboard.context = {
                 return  '<div data-netdata="' + id + '"'
                     + ' data-dimensions="avg"'
                     + ' data-chart-library="gauge"'
-                    + ' data-title="Average Response"'
+                    + ' data-title="Average Response Time"'
                     + ' data-units="milliseconds"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
@@ -936,6 +940,7 @@ netdataDashboard.context = {
                     + ' data-after="-CHART_DURATION"'
                     + ' data-points="CHART_DURATION"'
                     + ' data-colors="' + NETDATA.colors[4] + '"'
+                    + ' data-decimal-digits="2"'
                     + ' role="application"></div>';
             }
         ]

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -28,7 +28,7 @@ netdataDashboard.menu = {
     'tc': {
         title: 'Quality of Service',
         icon: '<i class="fa fa-globe" aria-hidden="true"></i>',
-        info: 'Netdata collects and visualizes tc class utilization using its <a href="https://github.com/firehol/netdata/blob/master/plugins.d/tc-qos-helper.sh" target="_blank">tc-helper plugin</a>. If you also use <a href="http://firehol.org/#fireqos" target="_blank">FireQOS</a> for setting up QoS, netdata automatically collects interface and class names. If your QoS configuration includes overheads calculation, the values shown here will include these overheads (the total bandwidth for the same interface as reported in the Network Interfaces section, will be lower than the total bandwidth reported here). QoS data collection may have a slight time difference compared to the interface (QoS data collection uses a BASH script, so a shift in data collection of a few milliseconds should be justified).'
+        info: 'Netdata collects and visualizes <code>tc</code> class utilization using its <a href="https://github.com/firehol/netdata/blob/master/plugins.d/tc-qos-helper.sh" target="_blank">tc-helper plugin</a>. If you also use <a href="http://firehol.org/#fireqos" target="_blank">FireQOS</a> for setting up QoS, netdata automatically collects interface and class names. If your QoS configuration includes overheads calculation, the values shown here will include these overheads (the total bandwidth for the same interface as reported in the Network Interfaces section, will be lower than the total bandwidth reported here). QoS data collection may have a slight time difference compared to the interface (QoS data collection uses a BASH script, so a shift in data collection of a few milliseconds should be justified).'
     },
 
     'net': {
@@ -222,7 +222,7 @@ netdataDashboard.menu = {
     'web_log': {
         title: undefined,
         icon: '<i class="fa fa-file-text-o" aria-hidden="true"></i>',
-        info: 'Information extracted from the web server log file. netdata <code>python.d/web_log</code> plugin incrementally parses web server log files to provide a real-time break down of key web server performance metrics. A special log file format is also supported (for <code>nginx</code> and <code>apache</code>) that allows netdata to extract timing information for the web server responses and bandwidth for both requests and responses. The <code>web_log</code> plugin can also be configured to provide a break down of requests per URL pattern (check <a href="https://github.com/firehol/netdata/blob/master/conf.d/python.d/web_log.conf" target="_blank"><code>/etc/netdata/python.d/web_log.conf</code></a>). netdata provides also several alarms based on the information on these charts, such as <b>too many bad requests</b>, <b>too many redirects</b>, <b>too many internal errros</b>, <b>unreasonably slow responses</b>, <b>too many requests</b> and <b>too few requests</b>.'
+        info: 'Information extracted from a web server log file. <code>python.d/web_log</code> plugin incrementally parses the web server log file to provide, in real-time, a break down of key web server performance metrics. A special log file format may optionally be used (for <code>nginx</code> and <code>apache</code>) allowing the plugin to extract timing information for the web server responses and bandwidth for both requests and responses. <code>web_log</code> plugin may also be configured to provide a break down of requests per URL pattern (check <a href="https://github.com/firehol/netdata/blob/master/conf.d/python.d/web_log.conf" target="_blank"><code>/etc/netdata/python.d/web_log.conf</code></a>). netdata attaches several alarms on these charts, such as <b>too many bad requests</b>, <b>too many redirects</b>, <b>too many internal errors</b>, <b>unreasonably slow responses</b>, <b>unreasonably many requests</b> (i.e. web attack) and <b>unreasonably few requests</b> (i.e. something is wrong).'
     },
 
     'named': {
@@ -955,7 +955,7 @@ netdataDashboard.context = {
     },
 
     'web_log.clients': {
-        info: 'Unique client IPs accessing the web server, within each data collection iteration. So, if data collection is <b>per second</b>, this chart shows <b>unique client IPs per second</b>.'
+        info: 'Unique client IPs accessing the web server, within each data collection iteration. If data collection is <b>per second</b>, this chart shows <b>unique client IPs per second</b>.'
     },
 
     'web_log.clients_all': {

--- a/web/index.html
+++ b/web/index.html
@@ -2800,7 +2800,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20170211-19',
+                url: NETDATA.serverDefault + 'dashboard_info.js?v20170211-20',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });


### PR DESCRIPTION
1. fixed typos in web_log alarms
2. web_log alarms now require 120 requests / min to be triggered (had a lot of false positives at 30)
3. gauges at web_log now have fixed number of fractional digits
4. web_log "too few requests" alarm is now operational again