### PR TITLE
minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ before_script:
 script:
    # make release packages
  - fakeroot ./packaging/git-build
-   # default build
- - ./autogen.sh && ./configure && make -j4
-   # test installer
+   # test build and installer
  - fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
 #
 # Deploy as required

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,4 +60,5 @@ dist_noinst_SCRIPTS= \
 	coverity-scan.sh \
 	docker-build.sh \
 	netdata-installer.sh \
+	installer/functions.sh \
 	$(NULL)

--- a/conf.d/python.d/web_log.conf
+++ b/conf.d/python.d/web_log.conf
@@ -70,9 +70,11 @@
 # ----------------------------------------------------------------------
 # WEB SERVER CONFIGURATION
 #
-# Make sure the log directory and file can be read by user 'netdata'.
+# Make sure the web server log directory and the web server log files
+# can be read by user 'netdata'.
 #
-# Preferable Log Format. You need to change to this to collect all metrics.
+# To enable the timings chart and the requests size dimension, the
+# web server needs to log them. This is how to add them:
 #
 # nginx:
 #   log_format netdata '$remote_addr - $remote_user [$time_local] '
@@ -81,9 +83,10 @@
 #                      '"$http_referer" "$http_user_agent"';
 #   access_log /var/log/nginx/access.log netdata;
 #
-# apache:
-#   LogFormat "%h %l %u %t \"%r\" %>s %O %I %D \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-#   LogFormat "%h %l %u %t \"%r\" %>s %O %I %D \"%{Referer}i\" \"%{User-Agent}i\"" combined
+# apache (you need mod_logio enabled):
+#   LogFormat "%h %l %u %t \"%r\" %>s %O %I %D \"%{Referer}i\" \"%{User-Agent}i\"" vhost_netdata
+#   LogFormat "%h %l %u %t \"%r\" %>s %O %I %D \"%{Referer}i\" \"%{User-Agent}i\"" netdata
+#   CustomLog "/var/log/apache2/access.log" netdata
 
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -1,0 +1,307 @@
+# no shebang necessary - this is a library to be sourced
+
+# -----------------------------------------------------------------------------
+# checking the availability of commands
+
+which_cmd() {
+    which "${1}" 2>/dev/null || \
+        command -v "${1}" 2>/dev/null
+}
+
+check_cmd() {
+    which_cmd "${1}" >/dev/null 2>&1 && return 0
+    return 1
+}
+
+
+# -----------------------------------------------------------------------------
+
+setup_terminal() {
+    # Is stderr on the terminal? If not, then fail
+    test -t 2 || return 1
+
+    if [ ! -z "$TPUT_CMD" ]
+    then
+        if [ $[$($TPUT_CMD colors 2>/dev/null)] -ge 8 ]
+        then
+            # Enable colors
+            COLOR_RESET="\e[0m"
+            COLOR_BLACK="\e[30m"
+            COLOR_RED="\e[31m"
+            COLOR_GREEN="\e[32m"
+            COLOR_YELLOW="\e[33m"
+            COLOR_BLUE="\e[34m"
+            COLOR_PURPLE="\e[35m"
+            COLOR_CYAN="\e[36m"
+            COLOR_WHITE="\e[37m"
+            COLOR_BGBLACK="\e[40m"
+            COLOR_BGRED="\e[41m"
+            COLOR_BGGREEN="\e[42m"
+            COLOR_BGYELLOW="\e[43m"
+            COLOR_BGBLUE="\e[44m"
+            COLOR_BGPURPLE="\e[45m"
+            COLOR_BGCYAN="\e[46m"
+            COLOR_BGWHITE="\e[47m"
+            COLOR_BOLD="\e[1m"
+            COLOR_DIM="\e[2m"
+            COLOR_UNDERLINED="\e[4m"
+            COLOR_BLINK="\e[5m"
+            COLOR_INVERTED="\e[7m"
+        fi
+    fi
+
+    return 0
+}
+TPUT_CMD="$(which_cmd tput)"
+setup_terminal
+
+progress() {
+    printf >&2 " --- ${COLOR_DIM}${COLOR_BOLD}${*}${COLOR_RESET} --- \n"
+}
+
+# -----------------------------------------------------------------------------
+
+netdata_banner() {
+    local   l1="  ^"                                                                            \
+            l2="  |.-.   .-.   .-.   .-.   .-.   .-.   .-.   .-.   .-.   .-.   .-.   .-.   .-"  \
+            l3="  |   '-'   '-'   '-'   '-'   '-'   '-'   '-'   '-'   '-'   '-'   '-'   '-'  "  \
+            l4="  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->" \
+            sp="                                                                              " \
+            netdata="netdata" start end msg="${*}" chartcolor="${COLOR_DIM}"
+
+    [ ${#msg} -lt ${#netdata} ] && msg="${msg}${sp:0:$(( ${#netdata} - ${#msg}))}"
+    [ ${#msg} -gt $(( ${#l2} - 20 )) ] && msg="${msg:0:$(( ${#l2} - 23 ))}..."
+
+    start="$(( ${#l2} / 2 - 4 ))"
+    [ $(( start + ${#msg} + 4 )) -gt ${#l2} ] && start=$((${#l2} - ${#msg} - 4))
+    end=$(( ${start} + ${#msg} + 4 ))
+
+    echo >&2
+    echo >&2 -e "${chartcolor}${l1}${COLOR_RESET}"
+    echo >&2 -e "${chartcolor}${l2:0:start}${sp:0:2}${COLOR_RESET}${COLOR_BOLD}${COLOR_GREEN}${netdata}${COLOR_RESET}${chartcolor}${sp:0:$((end - start - 2 - ${#netdata}))}${l2:end:$((${#l2} - end))}${COLOR_RESET}"
+    echo >&2 -e "${chartcolor}${l3:0:start}${sp:0:2}${COLOR_RESET}${COLOR_BOLD}${COLOR_CYAN}${msg}${COLOR_RESET}${chartcolor}${sp:0:2}${l3:end:$((${#l2} - end))}${COLOR_RESET}"
+    echo >&2 -e "${chartcolor}${l4}${COLOR_RESET}"
+    echo >&2
+}
+
+# -----------------------------------------------------------------------------
+# portable service command
+
+service_cmd="$(which_cmd service)"
+systemctl_cmd="$(which_cmd systemctl)"
+service() {
+    local cmd="${1}" action="${2}"
+
+    if [ ! -z "${service_cmd}" ]
+    then
+        run "${service_cmd}" "${cmd}" "${action}"
+        return $?
+    elif [ ! -z "${systemctl_cmd}" ]
+    then
+        run "${systemctl_cmd}" "${action}" "${cmd}"
+        return $?
+    fi
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+
+run_logfile="/dev/null"
+run() {
+    local user="${USER}" dir="$(basename "${PWD}")" info info_console
+
+    if [ "${UID}" = "0" ]
+        then
+        info="[root ${dir}]# "
+        info_console="[${COLOR_DIM}${dir}${COLOR_RESET}]# "
+    else
+        info="[${user} ${dir}]$ "
+        info_console="[${COLOR_DIM}${dir}${COLOR_RESET}]$ "
+    fi
+
+    printf >> "${run_logfile}" "${info}"
+    printf >> "${run_logfile}" "%q " "${@}"
+    printf >> "${run_logfile}" " ... "
+
+    printf >&2 "${info_console}${COLOR_BOLD}${COLOR_YELLOW}"
+    printf >&2 "%q " "${@}"
+    printf >&2 "${COLOR_RESET}\n"
+
+    "${@}"
+
+    local ret=$?
+    if [ ${ret} -ne 0 ]
+        then
+        printf >&2 "${COLOR_BGRED}${COLOR_WHITE}${COLOR_BOLD} FAILED ${COLOR_RESET}\n\n"
+        printf >> "${run_logfile}" "FAILED with exit code ${ret}\n"
+    else
+        printf >&2 "${COLOR_BGGREEN}${COLOR_WHITE}${COLOR_BOLD} OK ${COLOR_RESET}\n\n"
+        printf >> "${run_logfile}" "OK\n"
+    fi
+
+    return ${ret}
+}
+
+portable_add_user() {
+    local username="${1}"
+
+    getent passwd "${username}" > /dev/null 2>&1
+    [ $? -eq 0 ] && return 0
+
+    echo >&2 "Adding ${username} user account ..."
+
+    local nologin="$(which nologin 2>/dev/null || command -v nologin 2>/dev/null || echo '/bin/false')"
+
+    # Linux
+    if check_cmd useradd
+    then
+        run useradd -r -g "${username}" -c "${username}" -s "${nologin}" -d / "${username}" && return 0
+    fi
+
+    # FreeBSD
+    if check_cmd pw
+    then
+        run pw useradd "${username}" -d / -g "${username}" -s "${nologin}" && return 0
+    fi
+
+    # BusyBox
+    if check_cmd adduser
+    then
+        run adduser -D -G "${username}" "${username}" && return 0
+    fi
+
+    echo >&2 "Failed to add ${username} user account !"
+
+    return 1
+}
+
+portable_add_group() {
+    local groupname="${1}"
+
+    getent group "${groupname}" > /dev/null 2>&1
+    [ $? -eq 0 ] && return 0
+
+    echo >&2 "Adding ${groupname} user group ..."
+
+    # Linux
+    if check_cmd groupadd
+    then
+        run groupadd -r "${groupname}" && return 0
+    fi
+
+    # FreeBSD
+    if check_cmd pw
+    then
+        run pw groupadd "${groupname}" && return 0
+    fi
+
+    # BusyBox
+    if check_cmd addgroup
+    then
+        run addgroup "${groupname}" && return 0
+    fi
+
+    echo >&2 "Failed to add ${groupname} user group !"
+    return 1
+}
+
+portable_add_user_to_group() {
+    local groupname="${1}" username="${2}"
+
+    getent group "${groupname}" > /dev/null 2>&1
+    [ $? -ne 0 ] && return 1
+
+    # find the user is already in the group
+    local users=$(getent group "${groupname}" | cut -d ':' -f 4)
+    if [[ ",${users}," =~ ,${username}, ]]
+        then
+        # username is already there
+        return 0
+    else
+        # username is not in group
+        echo >&2 "Adding ${username} user to the ${groupname} group ..."
+
+        # Linux
+        if check_cmd usermod
+        then
+            run usermod -a -G "${groupname}" "${username}" && return 0
+        fi
+
+        # FreeBSD
+        if check_cmd pw
+        then
+            run pw groupmod "${groupname}" -m "${username}" && return 0
+        fi
+
+        # BusyBox
+        if check_cmd addgroup
+        then
+            run addgroup "${username}" "${groupname}" && return 0
+        fi
+
+        echo >&2 "Failed to add user ${username} to group ${groupname} !"
+        return 1
+    fi
+}
+
+iscontainer() {
+    # man systemd-detect-virt
+    local cmd=$(which_cmd systemd-detect-virt)
+    if [ ! -z "${cmd}" -a -x "${cmd}" ]
+        then
+        "${cmd}" --container >/dev/null 2>&1 && return 0
+    fi
+
+    # /proc/1/sched exposes the host's pid of our init !
+    # http://stackoverflow.com/a/37016302
+    local pid=$( cat /proc/1/sched | head -n 1 | { IFS='(),#:' read name pid th threads; echo $pid; } )
+    local p=$(( pid + 0 ))
+    [ ${pid} -ne 1 ] && return 0
+
+    # lxc sets environment variable 'container'
+    [ ! -z "${container}" ] && return 0
+
+    # docker creates /.dockerenv
+    # http://stackoverflow.com/a/25518345
+    [ -f "/.dockerenv" ] && return 0
+
+    # ubuntu and debian supply /bin/running-in-container
+    # https://www.apt-browse.org/browse/ubuntu/trusty/main/i386/upstart/1.12.1-0ubuntu4/file/bin/running-in-container
+    if [ -x "/bin/running-in-container" ]
+        then
+        "/bin/running-in-container" >/dev/null 2>&1 && return 0
+    fi
+
+    return 1
+}
+
+issystemd() {
+    local pids p myns ns systemctl
+
+    # if the directory /etc/systemd/system does not exit, it is not systemd
+    [ ! -d /etc/systemd/system ] && return 1
+
+    # if there is no systemctl command, it is not systemd
+    systemctl=$(which systemctl 2>/dev/null || command -v systemctl 2>/dev/null)
+    [ -z "${systemctl}" -o ! -x "${systemctl}" ] && return 1
+
+    # if pid 1 is systemd, it is systemd
+    [ "$(basename $(readlink /proc/1/exe) 2>/dev/null)" = "systemd" ] && return 0
+
+    # if systemd is not running, it is not systemd
+    pids=$(pidof systemd 2>/dev/null)
+    [ -z "${pids}" ] && return 1
+
+    # check if the running systemd processes are not in our namespace
+    myns="$(readlink /proc/self/ns/pid 2>/dev/null)"
+    for p in ${pids}
+    do
+        ns="$(readlink /proc/${p}/ns/pid 2>/dev/null)"
+
+        # if pid of systemd is in our namespace, it is systemd
+        [ ! -z "${myns}" && "${myns}" = "${ns}" ] && return 0
+    done
+
+    # else, it is not systemd
+    return 1
+}

--- a/web/index.html
+++ b/web/index.html
@@ -873,6 +873,7 @@
             submenu_names: {},
             data: null,
             hostname: 'netdata_server', // will be overwritten by the netdata server
+            version: 'unknown',
             categories: [],
             categories_idx: {},
             families: [],
@@ -1420,7 +1421,7 @@
 
             sidebar += '<li class="" style="padding-top:15px;"><a href="https://github.com/firehol/netdata/wiki/Add-more-charts-to-netdata" target="_blank"><i class="fa fa-plus" aria-hidden="true"></i> add more charts</a></li>';
             sidebar += '<li class=""><a href="https://github.com/firehol/netdata/wiki/Add-more-alarms-to-netdata" target="_blank"><i class="fa fa-plus" aria-hidden="true"></i> add more alarms</a></li>';
-            sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' + data.hostname.toString() + '</b>, collects every ' + ((data.update_every == 1)?'second':data.update_every.toString() + ' seconds') + ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' + data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' + data.alarms_count.toLocaleString() + '</b> alarms, using ' + Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' + Math.round(data.history / (3600/data.update_every)).toLocaleString() + ' ' + ((data.history == (3600/data.update_every))?'hour':'hours').toString() + ' of real-time history.</small></li>';
+            sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' + data.hostname.toString() + '</b>, collects every ' + ((data.update_every == 1)?'second':data.update_every.toString() + ' seconds') + ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' + data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' + data.alarms_count.toLocaleString() + '</b> alarms, using ' + Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' + Math.round(data.history / (3600/data.update_every)).toLocaleString() + ' ' + ((data.history == (3600/data.update_every))?'hour':'hours').toString() + ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>v' +  data.version.toString() +'</small></li>';
             sidebar += '</ul>';
             div.innerHTML = html;
             document.getElementById('sidebar').innerHTML = sidebar;
@@ -2252,6 +2253,7 @@
                     if(data !== null) {
                         options.hostname = data.hostname;
                         options.data = data;
+                        options.version = data.version;
                         netdataDashboard.os = data.os;
 
                         // update the dashboard hostname

--- a/web/index.html
+++ b/web/index.html
@@ -2317,12 +2317,14 @@
             })
             .done(function(data) {
                 data = data.replace(/(\r\n|\n|\r| |\t)/gm,"");
-                if(data.length !== 40) {
-                    var c = getNetdataCommitIdFromVersion();
-                    if(c === null) versionLog('Cannot find the git commit id of netdata.');
-                    callback(c);
+
+                var c = getNetdataCommitIdFromVersion();
+                if(c !== null && data.length === 40 && data.substring(0, 7) !== c) {
+                    versionLog('Installed files commit id and internal netdata git commit id do not match');
+                    data = c;
                 }
-                else {
+
+                if(data.length >= 7) {
                     versionLog('Installed git commit id of netdata is ' + data);
                     document.getElementById('netdataCommitId').innerHTML = data.substring(0, 7);
                     callback(data);

--- a/web/index.html
+++ b/web/index.html
@@ -2259,6 +2259,7 @@
                         // update the dashboard hostname
                         document.getElementById('hostname').innerHTML = options.hostname;
                         document.getElementById('hostname').href = NETDATA.serverDefault;
+                        document.getElementById('netdataVersion').innerHTML = options.version;
 
                         // update the dashboard title
                         document.title = options.hostname + ' netdata dashboard';
@@ -2290,8 +2291,23 @@
             document.getElementById('versionCheckLog').innerHTML = msg;
         }
 
-        function getNetdataVersion(callback) {
-            versionLog('Downloading installed version info from netdata...');
+        function getNetdataCommitIdFromVersion() {
+            var s = options.version.split('-');
+
+            if(s.length !== 3) return null;
+            if(s[2][0] == 'g') {
+                var v = s[2].split('_')[0].substring(1, 8);
+                if(v.length === 7) {
+                    versionLog('Installed git commit id of netdata is ' + v);
+                    document.getElementById('netdataCommitId').innerHTML = v;
+                    return v;
+                }
+            }
+            return null;
+        }
+
+        function getNetdataCommitId(force, callback) {
+            versionLog('Downloading installed git commit id from netdata...');
 
             $.ajax({
                 url: 'version.txt',
@@ -2302,23 +2318,31 @@
             .done(function(data) {
                 data = data.replace(/(\r\n|\n|\r| |\t)/gm,"");
                 if(data.length !== 40) {
-                    versionLog('Received version string is invalid.');
-                    callback(null);
+                    var c = getNetdataCommitIdFromVersion();
+                    if(c === null) versionLog('Cannot find the git commit id of netdata.');
+                    callback(c);
                 }
                 else {
-                    versionLog('Installed version of netdata is ' + data);
-                    document.getElementById('netdataVersion').innerHTML = data;
+                    versionLog('Installed git commit id of netdata is ' + data);
+                    document.getElementById('netdataCommitId').innerHTML = data.substring(0, 7);
                     callback(data);
                 }
             })
             .fail(function() {
-                versionLog('Failed to download installed version info from netdata!');
-                callback(null);
+                versionLog('Failed to download installed git commit id from netdata!');
+
+                if(force === true) {
+                    var c = getNetdataCommitIdFromVersion();
+                    if(c === null) versionLog('Cannot find the git commit id of netdata.');
+                    callback(c);
+                }
+                else
+                    callback(null);
             });
         }
 
         function getGithubLatestCommit(callback) {
-            versionLog('Downloading latest version info from github...');
+            versionLog('Downloading latest git commit id info from github...');
 
             $.ajax({
                 url: 'https://api.github.com/repos/firehol/netdata/commits',
@@ -2326,17 +2350,17 @@
                 cache: false
             })
             .done(function(data) {
-                versionLog('Latest version info from github is ' + data[0].sha);
+                versionLog('Latest git commit id from github is ' + data[0].sha);
                 callback(data[0].sha);
             })
             .fail(function() {
-                versionLog('Failed to download installed version info from github!');
+                versionLog('Failed to download installed git commit id from github!');
                 callback(null);
             });
         }
 
-        function checkForUpdate(callback) {
-            getNetdataVersion(function(sha1) {
+        function checkForUpdate(force, callback) {
+            getNetdataCommitId(force, function(sha1) {
                 if(sha1 === null) callback(null, null);
 
                 getGithubLatestCommit(function(sha2) {
@@ -2366,26 +2390,26 @@
                 }
             }
 
-            checkForUpdate(function(sha1, sha2) {
+            checkForUpdate(force, function(sha1, sha2) {
                 var save = false;
 
                 if(sha1 === null) {
                     save = false;
-                    versionLog('<p><big>Failed to get your netdata version!</big></p><p>You can always get the latest version of netdata from <a href="https://github.com/firehol/netdata" target="_blank">its github page</a>.</p>');
+                    versionLog('<p><big>Failed to get your netdata git commit id!</big></p><p>You can always get the latest netdata from <a href="https://github.com/firehol/netdata" target="_blank">its github page</a>.</p>');
                 }
                 else if(sha2 === null) {
                     save = false;
-                    versionLog('<p><big>Failed to get the latest version from github.</big></p><p>You can always get the latest version of netdata from <a href="https://github.com/firehol/netdata" target="_blank">its github page</a>.</p>');
+                    versionLog('<p><big>Failed to get the latest git commit id from github.</big></p><p>You can always get the latest netdata from <a href="https://github.com/firehol/netdata" target="_blank">its github page</a>.</p>');
                 }
                 else if(sha1 === sha2) {
                     save = true;
-                    versionLog('<p><big>You already have the latest version of netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/firehol/netdata" target="_blank">give netdata a <b>Star</b> at its github page</a>.</p>');
+                    versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/firehol/netdata" target="_blank">give netdata a <b>Star</b> at its github page</a>.</p>');
                 }
                 else {
                     save = true;
                     var compare = 'https://github.com/firehol/netdata/compare/' + sha1.toString() + '...' + sha2.toString();
 
-                    versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest version: ' + sha2.toString() + '</p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> since your installed version, and<br/><a href="https://github.com/firehol/netdata/wiki/Updating-Netdata" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated, is generally a good idea.</p>');
+                    versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest commit: <b><code>' + sha2.substring(0, 7).toString() + '</code></b></p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> since your installed version, and<br/><a href="https://github.com/firehol/netdata/wiki/Updating-Netdata" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated, is generally a good idea.</p>');
 
                     document.getElementById('update_badge').innerHTML = '!';
                 }
@@ -3314,7 +3338,8 @@
                     <h4 class="modal-title" id="updateModalLabel">Update Check</h4>
                 </div>
                 <div class="modal-body">
-                    Your netdata version: <b><code><span id="netdataVersion">Unknown</span></code></b>
+                    Your netdata version: <b><code><span id="netdataVersion">Unknown</span></code></b><br/>
+                    Your netdata commit: <b><code><span id="netdataCommitId">Unknown</span></code></b>
                     <br/>
                     <div style="padding: 10px;"></div>
                     <div id="versionCheckLog">Not checked yet. Please press the Check Now button.</div>


### PR DESCRIPTION
1. show netdata version on the dashboard
2. improved information at `web_log.conf`
3. do not compile netdata twice on travis https://github.com/firehol/netdata/issues/1667#issuecomment-279207862
4. use the netdata internal version when checking for updates.

   `version.txt` is used by many folks that use netdata in private/off-internet environments, to disable the automatic checking of version updating (they delete the file, so the dashboard does not make any external calls). This commit still allows this to happen for the automatic checking. If however, the user presses the **update** button on the dashboard and the internal version string of netdata has a commit id, a full check against github will still be made.