### PR TITLE
fix lxc-attach not exiting after starting netdata

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -332,8 +332,7 @@ static const char *verify_required_directory(const char *dir) {
     return dir;
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     char *hostname = "localhost";
     int i, check_config = 0;
     int config_loaded = 0;
@@ -506,6 +505,16 @@ int main(int argc, char **argv)
             }
         }
     }
+
+#ifdef _SC_OPEN_MAX
+    // close all open file descriptors, except the standard ones
+    // the caller may have left open files (lxc-attach has this issue)
+    {
+        int fd;
+        for(fd = (int) (sysconf(_SC_OPEN_MAX) - 1); fd > 2; fd--)
+            if(fd_is_valid(fd)) close(fd);
+    }
+#endif
 
     if(!config_loaded)
         load_config(NULL, 0);


### PR DESCRIPTION
lxc-attach seems to leave to child process a `/dev/pts` file descriptor open. So, if you start netdata via an lxc-attach session, you cannot exit the session later. It freezes.

This PR makes netdata close all the third-party file descriptors attached to it, when it starts.