### PR TITLE
new web_log alarms to account 1xx, 2xx and 304 as successful

### DIFF
--- a/conf.d/health.d/web_log.conf
+++ b/conf.d/health.d/web_log.conf
@@ -25,7 +25,7 @@ families: *
 # i.e. when there are at least 120 requests during the last minute
 
 template: 1m_requests
-      on: web_log.response_codes
+      on: web_log.response_statuses
 families: *
   lookup: sum -1m unaligned
     calc: ($this == 0)?(1):($this)
@@ -33,57 +33,49 @@ families: *
    every: 10s
     info: the sum of all HTTP requests over the last minute
 
-template: 1m_2xx
-      on: web_log.response_codes
-families: *
-  lookup: sum -1m unaligned of 2xx
-    calc: ($this == 0)?(1):($this)
-   units: requests
-   every: 10s
-    info: the sum of successful HTTP requests over the last minute
-
 template: 1m_successful
-      on: web_log.response_codes
+      on: web_log.response_statuses
 families: *
-    calc: $1m_2xx * 100 / $1m_requests
+  lookup: sum -1m unaligned of successful_requests
+    calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 120) ? ($this < (($status >= $WARNING ) ? ( 98 ) : ( 95 )) ) : ( 0 )
-    crit: ($1m_requests > 120) ? ($this < (($status == $CRITICAL) ? ( 95 ) : ( 90 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this < (($status >= $WARNING ) ? ( 95 ) : ( 85 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this < (($status == $CRITICAL) ? ( 85 ) : ( 75 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of successful HTTP responses (2xx) over the last minute
+    info: the ratio of successful HTTP responses (1xx, 2xx, 304) over the last minute
       to: webmaster
 
 template: 1m_redirects
-      on: web_log.detailed_response_codes
+      on: web_log.response_statuses
 families: *
-  lookup: sum -1m unaligned of 301,303,307,308
+  lookup: sum -1m unaligned of redirects
     calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING ) ? ( 1 ) : ( 2 )) ) : ( 0 )
-    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 2 ) : ( 5 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING ) ? (  1 ) : ( 20 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 20 ) : ( 30 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
-    info: the ratio of HTTP redirects (301, 303, 307, 308) over the last minute
+    info: the ratio of HTTP redirects (3xx except 304) over the last minute
       to: webmaster
 
 template: 1m_bad_requests
-      on: web_log.response_codes
+      on: web_log.response_statuses
 families: *
-  lookup: sum -1m unaligned of 4xx
+  lookup: sum -1m unaligned of bad_requests
     calc: $this * 100 / $1m_requests
    units: %
    every: 10s
-    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 1 ) : (  5 )) ) : ( 0 )
-    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 5 ) : ( 10 )) ) : ( 0 )
+    warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 10 ) : ( 30 )) ) : ( 0 )
+    crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 30 ) : ( 50 )) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
     info: the ratio of HTTP bad requests (4xx) over the last minute
       to: webmaster
 
 template: 1m_internal_errors
-      on: web_log.response_codes
+      on: web_log.response_statuses
 families: *
-  lookup: sum -1m unaligned of 5xx
+  lookup: sum -1m unaligned of server_errors
     calc: $this * 100 / $1m_requests
    units: %
    every: 10s
@@ -132,38 +124,38 @@ families: *
 # the following alarms trigger only when there are enough data.
 # we assume there are enough data when:
 #
-#  $5m_2xx_last > 120
+#  $5m_successful_old > 120
 #
 # i.e. when there were at least 120 requests during the 5 minutes starting
 #      at -10m and ending at -5m
 
-template: 5m_2xx_last
-      on: web_log.response_codes
+template: 5m_successful_old
+      on: web_log.response_statuses
 families: *
-  lookup: average -5m at -5m unaligned of 2xx
-   units: requests
+  lookup: average -5m at -5m unaligned of successful_requests
+   units: requests/s
    every: 30s
-    info: average successful HTTP requests over the last 5 minutes
+    info: average rate of successful HTTP requests over the last 5 minutes
 
-template: 5m_2xx_now
-      on: web_log.response_codes
+template: 5m_successful
+      on: web_log.response_statuses
 families: *
-  lookup: average -5m unaligned of 2xx
-   units: requests
+  lookup: average -5m unaligned of successful_requests
+   units: requests/s
    every: 30s
     info: average successful HTTP requests over the last 5 minutes
 
 template: 5m_requests_ratio
       on: web_log.response_codes
 families: *
-    calc: ($5m_2xx_last > 0)?($5m_2xx_now * 100 / $5m_2xx_last):(100)
+    calc: ($5m_successful_old > 0)?($5m_successful * 100 / $5m_successful_old):(100)
    units: %
    every: 30s
-    warn: ($5m_2xx_last > 120) ? ($this > 200 OR $this < 50) : (0)
-    crit: ($5m_2xx_last > 120) ? ($this > 400 OR $this < 25) : (0)
+    warn: ($5m_successful_old > 120) ? ($this > 200 OR $this < 50) : (0)
+    crit: ($5m_successful_old > 120) ? ($this > 400 OR $this < 25) : (0)
    delay: down 15m multiplier 1.5 max 1h
 options: no-clear-notification
-    info: the percentage of web requests over the last 5 minutes, \
+    info: the percentage of successful web requests over the last 5 minutes, \
           compared with the previous 5 minutes
       to: webmaster
 

--- a/configs.signatures
+++ b/configs.signatures
@@ -60,6 +60,7 @@ declare -A configs_signatures=(
   ['2827de41cf34a91b7a8e4d8724f59668']='health.d/net.conf'
   ['28df44a90e8ea4c6156314c03e88bf44']='health.d/softnet.conf'
   ['297160ae7ee01a547ed14f857b4f2c8d']='health.d/memcached.conf'
+  ['298504f331c55dff4055321ff3a7b5cc']='health.d/web_log.conf'
   ['29f97e10b92333790fbe0d2a3617b736']='health_alarm_notify.conf'
   ['2a0794fd43eadf30a51805bc9ba2c64d']='python.d/hddtemp.conf'
   ['2ad55a5d1e885cf142849a78d4b00401']='health.d/net.conf'


### PR DESCRIPTION
#1781 #1780 #1782 

`web_log` alarms now use the new chart of #1782 

The thresholds now are as follows:

alarm|description|warning|critical
:-------:|-------|:------:|:-----:
1m_successful|the ratio of successful HTTP responses (1xx, 2xx, 304) over the last minute|< 85%|<75%
1m_redirects|the ratio of HTTP redirects (3xx except 304) over the last minute|>20%|>30%
1m_bad_requests|the ratio of HTTP bad requests (4xx) over the last minute|>30%|>50%
1m_internal_errors|the ratio of HTTP internal server errors (5xx), over the last minute|>2%|>5%
5m_requests_ratio|the percentage of successful web requests over the last 5 minutes, compared with the previous 5 minutes|>double or <half|>4x or <1/4x
web_slow|the average time to respond to HTTP requests, over the last 1 minute compared to the average of 10 minutes|>2x| >4x


If you have edited your `/etc/netdata/health.d/web_log.conf`, please delete it so that the new one will be installed (if you haven't edited it, it will be replaced with the new).