### PR TITLE
web_log plugin: initial "custom_log_format" feature support added"

### DIFF
--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -400,12 +400,12 @@ class Service(LogService):
         if self.url_pattern:
             self.definitions['requests_per_url'] = {'options': [None, 'Requests Per Url', 'requests/s',
                                                                 'urls', 'web_log.requests_per_url', 'stacked'],
-                                                    'lines': [['other_url', 'other', 'incremental']]}
+                                                    'lines': [['pur_other', 'other', 'incremental']]}
             for elem in self.url_pattern:
-                self.definitions['requests_per_url']['lines'].append([elem.description, elem.description,
+                self.definitions['requests_per_url']['lines'].append([elem.description, elem.description[4:],
                                                                       'incremental'])
                 self.data.update({elem.description: 0})
-            self.data.update({'other_url': 0})
+            self.data.update({'pur_other': 0})
         else:
             self.order.remove('requests_per_url')
 
@@ -529,7 +529,7 @@ class Service(LogService):
                 match = True
                 break
         if not match:
-            self.data['other_url'] += 1
+            self.data['pur_other'] += 1
 
     def _get_data_statuses(self, code):
         """
@@ -607,7 +607,7 @@ def check_req_per_url_pattern(url_pattern):
     for dimension, regex in url_pattern.items():
         valid_pattern = is_valid_pattern(regex)
         if isinstance(dimension, str) and valid_pattern:
-            result.append(NAMED_URL_PATTERN(description=dimension, pattern=valid_pattern))
+            result.append(NAMED_URL_PATTERN(description='_'.join(['pur', dimension]), pattern=valid_pattern))
 
     return result or None
 

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -55,6 +55,7 @@ CHARTS = {
     'http_method': {
         'options': [None, 'Requests Per HTTP Method', 'requests/s', 'http methods', 'web_log.http_method', 'stacked'],
         'lines': [
+            ['GET', 'GET', 'incremental', 1, 1]
         ]},
     'requests_per_ipproto': {
         'options': [None, 'Requests Per IP Protocol', 'requests/s', 'ip protocols', 'web_log.requests_per_ipproto',
@@ -104,7 +105,7 @@ class Service(LogService):
                      'resp_time_avg': 0, 'unique_cur_ipv4': 0, 'unique_cur_ipv6': 0, '2xx': 0,
                      '5xx': 0, '3xx': 0, '4xx': 0, '1xx': 0, '0xx': 0, 'unmatched': 0, 'req_ipv4': 0,
                      'req_ipv6': 0, 'unique_tot_ipv4': 0, 'unique_tot_ipv6': 0, 'successful_requests': 0,
-                     'redirects': 0, 'bad_requests': 0, 'server_errors': 0, 'other_requests': 0}
+                     'redirects': 0, 'bad_requests': 0, 'server_errors': 0, 'other_requests': 0, 'GET': 0}
 
     def check(self):
         """
@@ -374,7 +375,8 @@ class Service(LogService):
                               ' web_log.detailed_response_codes stacked 1 %s\n' % (job_name, self.update_every)
         self.http_method_chart = 'CHART %s.http_method' \
                                  ' "" "Requests Per HTTP Method" requests/s "http methods"' \
-                                 ' web_log.http_method stacked 2 %s\n' % (job_name, self.update_every)
+                                 ' web_log.http_method stacked 2 %s\n' \
+                                 'DIMENSION GET GET incremental\n' % (job_name, self.update_every)
 
         # Remove 'request_time' chart from ORDER if resp_time not in match_dict
         if 'resp_time' not in match_dict:


### PR DESCRIPTION
https://github.com/firehol/netdata/issues/1792
Looks like it works!

New configuration file options added. Example:

```yaml
nginx_log:
  name: 'nginx'
  path: '/var/log/nginx/access.log'
  custom_log_format:
      pattern: '(?P<address>[\da-f.:]+) -.*?"(?P<method>[A-Z]+) (?P<url>.*?)" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d\.\d+) '
```

`time_multiplier` is optional. If not specified:
if '.' in `resp_time`: `time_multiplier` = 1000000 (seconds to microseconds)
if '.' not in `resp_time`: `time_multiplier` = 1 (already in microseconds)

```yaml
...
...
custom_log_format:
    pattern: '...'
    time_multiplier: 1000000  # type <int>
```
