### PR TITLE
added X-Frame-Options HTTP header support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,9 @@ void web_server_threading_selection(void) {
 
     web_client_timeout = (int) config_get_number("global", "disconnect idle web clients after seconds", DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS);
 
-    web_donotrack_comply = config_get_boolean("global", "respect web browser do not track policy", web_donotrack_comply);
+    respect_web_browser_do_not_track_policy = config_get_boolean("global", "respect web browser do not track policy", respect_web_browser_do_not_track_policy);
+    web_x_frame_options = config_get("global", "web x-frame-options header", "");
+    if(!*web_x_frame_options) web_x_frame_options = NULL;
 
 #ifdef NETDATA_WITH_ZLIB
     web_enable_gzip = config_get_boolean("global", "enable web responses gzip compression", web_enable_gzip);

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -5,8 +5,13 @@
 extern int web_client_timeout;
 
 #ifdef NETDATA_WITH_ZLIB
-extern int web_enable_gzip, web_gzip_level, web_gzip_strategy, web_donotrack_comply;
+extern int web_enable_gzip,
+        web_gzip_level,
+        web_gzip_strategy;
 #endif /* NETDATA_WITH_ZLIB */
+
+extern int respect_web_browser_do_not_track_policy;
+extern char *web_x_frame_options;
 
 #define WEB_CLIENT_MODE_NORMAL      0
 #define WEB_CLIENT_MODE_FILECOPY    1


### PR DESCRIPTION
fixes #1735 

In `/etc/netdata/netdata.conf` a new option will appear like this:

```
[global]
    web x-frame-options header = 
```

You can set this to whatever the protocol accepts: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options