### PR TITLE
python.d.plugin: OrderedDict import for python2.6 added

### DIFF
--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -73,10 +73,16 @@ try:
     DICT = OrderedDict
     msg.info('YAML output is ordered')
 except ImportError:
-    ORDERED = False
-    DICT = dict
-    msg.info('YAML output is unordered')
-else:
+    try:
+        from ordereddict import OrderedDict
+        ORDERED = True
+        DICT = OrderedDict
+        msg.info('YAML output is ordered')
+    except ImportError:
+        ORDERED = False
+        DICT = dict
+        msg.info('YAML output is unordered')
+if ORDERED:
     def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
         class OrderedLoader(Loader):
             pass


### PR DESCRIPTION
Requests Per Url chart can be misleading without OrderedDict (`categories` - unordered collection) which is not built-in in python2.6.
User need to install it manually (pip install ordereddict).

After this PR it will be imported if installed on the system

@adude00 

