### PR TITLE
Add FreeBSD support to apps.plugin

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -61,7 +61,11 @@ static int
         debug = 0,
         update_every = 1,
         enable_guest_charts = 0,
+#ifdef __FreeBSD__
+        enable_file_charts = 0,
+#else
         enable_file_charts = 1,
+#endif
         enable_users_charts = 1,
         enable_groups_charts = 1,
         include_exited_childs = 1;


### PR DESCRIPTION
@ktsaou is it OK for `apps.plugin` to consume 50% of one CPU core when 100-120 thousand files are opened in a system? I don't have any idea how to make `read_pid_file_descriptors()` be less resource consuming without changing the original logic of `apps.plugin`.