### PR TITLE
self-cleaning obsolete cgroups and network interfaces from memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ set(NETDATA_SOURCE_FILES
         src/web_client.h
         src/web_server.c
         src/web_server.h
-        src/rrdhost.c src/rrdfamily.c src/rrdset.c src/rrddim.c src/health_log.c src/health_config.c src/health_json.c src/rrdcalc.c src/rrdcalctemplate.c src/rrdvar.c src/rrddimvar.c src/rrdsetvar.c src/rrdpush.c src/rrdpush.h src/web_api_old.c src/web_api_old.h src/web_api_v1.c src/web_api_v1.h)
+        src/rrdhost.c src/rrdfamily.c src/rrdset.c src/rrddim.c src/health_log.c src/health_config.c src/health_json.c src/rrdcalc.c src/rrdcalctemplate.c src/rrdvar.c src/rrddimvar.c src/rrdsetvar.c src/rrdpush.c src/rrdpush.h src/web_api_old.c src/web_api_old.h src/web_api_v1.c src/web_api_v1.h src/rrd2json_api_old.c src/rrd2json_api_old.h)
 
 set(APPS_PLUGIN_SOURCE_FILES
         src/appconfig.c

--- a/conf.d/health.d/net.conf
+++ b/conf.d/health.d/net.conf
@@ -1,18 +1,3 @@
-# -----------------------------------------------------------------------------
-# make sure we collect values for each interface
-
-template: interface_last_collected_secs
-      on: net.net
-families: *
-    calc: $now - $last_collected_t
-   units: seconds ago
-   every: 10s
-    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
-    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
-   delay: down 5m multiplier 1.5 max 1h
-    info: number of seconds since the last successful data collection
-      to: sysadmin
-
 
 # -----------------------------------------------------------------------------
 # dropped packets

--- a/configs.signatures
+++ b/configs.signatures
@@ -78,6 +78,7 @@ declare -A configs_signatures=(
   ['32fde0057c790964f2c743cb3c9aad29']='health.d/nginx.conf'
   ['33b135e28aeaef2b8224ba69a0fde245']='health.d/cpu.conf'
   ['343bc919a2fbc93f687f9d1339ec5f79']='health.d/net.conf'
+  ['35024ebd94542484c0866e6ee6b950cb']='health.d/net.conf'
   ['3634d5eddc46fb0d50cf47f370670c2c']='health.d/redis.conf'
   ['364b6e0081b116c9ec073b4d329a6dcc']='health_alarm_notify.conf'
   ['367d1463e520eb9dc89223bab161c6d1']='python.d/postgres.conf'

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -34,6 +34,6 @@ tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 curl --form token="${token}" \
   --form email=costa@tsaousis.gr \
   --form file=@netdata-coverity-analysis.tgz \
-  --form version="1.5.0rc1" \
+  --form version="1.6.0rc1" \
   --form description="Description" \
   https://scan.coverity.com/builds?project=firehol%2Fnetdata

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ netdata_SOURCES = \
 	rrddimvar.c \
 	rrdsetvar.c \
 	rrd2json.c rrd2json.h \
+	rrd2json_api_old.c rrd2json_api_old.h \
 	rrdpush.c rrdpush.h \
 	storage_number.c storage_number.h \
 	unit_test.c unit_test.h \

--- a/src/common.h
+++ b/src/common.h
@@ -206,6 +206,7 @@
 #include "plugin_tc.h"
 #include "plugins_d.h"
 #include "rrd2json.h"
+#include "rrd2json_api_old.h"
 #include "web_client.h"
 #include "web_server.h"
 #include "registry.h"

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -1003,7 +1003,7 @@ void *tc_main(void *ptr) {
                 rrddim_set(stcpu, "system", thread.ru_stime.tv_sec * 1000000ULL + thread.ru_stime.tv_usec);
                 rrdset_done(stcpu);
 
-                if(unlikely(!sttime)) stcpu = rrdset_find_localhost("netdata.plugin_tc_time");
+                if(unlikely(!sttime)) sttime = rrdset_find_localhost("netdata.plugin_tc_time");
                 if(unlikely(!sttime)) {
                     sttime = rrdset_create_localhost("netdata", "plugin_tc_time", NULL, "tc.helper", NULL
                                                      , "NetData TC script execution", "milliseconds/run", 135001

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -340,6 +340,22 @@ typedef struct rrdset RRDSET;
 
 
 // ----------------------------------------------------------------------------
+// RRDHOST flags
+// use this for configuration flags, not for state control
+// flags are set/unset in a manner that is not thread safe
+// and may lead to missing information.
+
+typedef enum rrdhost_flags {
+    RRDHOST_ORPHAN                 = 1 << 0, // this host is orphan
+    RRDHOST_DELETE_OBSOLETE_FILES  = 1 << 1, // delete files of obsolete charts
+    RRDHOST_DELETE_ORPHAN_FILES    = 1 << 2  // delete the entire host when orphan
+} RRDHOST_FLAGS;
+
+#define rrdhost_flag_check(host, flag) ((host)->flags & flag)
+#define rrdhost_flag_set(host, flag)   (host)->flags |= flag
+#define rrdhost_flag_clear(host, flag) (host)->flags &= ~flag
+
+// ----------------------------------------------------------------------------
 // RRD HOST
 
 struct rrdhost {
@@ -355,6 +371,9 @@ struct rrdhost {
     uint32_t hash_machine_guid;                     // the hash of the unique ID
 
     char *os;                                       // the O/S type of the host
+
+    uint32_t flags;                                 // flags about this RRDHOST
+
     int rrd_update_every;                           // the update frequency of the host
     int rrd_history_entries;                        // the number of history entries for the host's charts
     RRD_MEMORY_MODE rrd_memory_mode;                // the memory more for the charts of this host
@@ -524,9 +543,10 @@ extern RRDSET *rrdset_create(RRDHOST *host
 extern void rrdhost_free_all(void);
 extern void rrdhost_save_all(void);
 
-extern void rrdhost_cleanup_remote_stale(RRDHOST *protected);
+extern void rrdhost_cleanup_orphan(RRDHOST *protected);
 extern void rrdhost_free(RRDHOST *host);
 extern void rrdhost_save(RRDHOST *host);
+extern void rrdhost_delete(RRDHOST *host);
 
 extern RRDSET *rrdset_find(RRDHOST *host, const char *id);
 #define rrdset_find_localhost(id) rrdset_find(localhost, id)
@@ -601,13 +621,10 @@ extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 
 #ifdef NETDATA_RRD_INTERNALS
 
-extern void rrdset_free(RRDSET *st);
 extern avl_tree_lock rrdhost_root_index;
 
 extern char *rrdset_strncpyz_name(char *to, const char *from, size_t length);
 extern char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section);
-
-extern void rrdset_reset(RRDSET *st);
 
 extern void rrddim_free(RRDSET *st, RRDDIM *rd);
 
@@ -623,8 +640,12 @@ extern void rrdfamily_free(RRDHOST *host, RRDFAMILY *rc);
 #define rrdset_index_del(host, st) (RRDSET *)avl_remove_lock(&((host)->rrdset_root_index), (avl *)(st))
 extern RRDSET *rrdset_index_del_name(RRDHOST *host, RRDSET *st);
 
+extern void rrdset_free(RRDSET *st);
+extern void rrdset_reset(RRDSET *st);
 extern void rrdset_save(RRDSET *st);
-extern void rrdhost_cleanup(RRDHOST *host);
+extern void rrdset_delete(RRDSET *st);
+
+extern void rrdhost_cleanup_obsolete(RRDHOST *host);
 
 #endif /* NETDATA_RRD_INTERNALS */
 

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -83,6 +83,8 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb)
     size_t c, dimensions = 0, memory = 0, alarms = 0;
     RRDSET *st;
 
+    time_t now = now_realtime_sec();
+
     buffer_sprintf(wb, "{\n"
            "\t\"hostname\": \"%s\""
         ",\n\t\"version\": \"%s\""
@@ -100,13 +102,15 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb)
     c = 0;
     rrdhost_rdlock(host);
     rrdset_foreach_read(st, host) {
-        if(rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && st->dimensions) {
+        if(rrdset_is_available_for_viewers(st)) {
             if(c) buffer_strcat(wb, ",");
             buffer_strcat(wb, "\n\t\t\"");
             buffer_strcat(wb, st->id);
             buffer_strcat(wb, "\": ");
             rrd_stats_api_v1_chart_with_data(st, wb, &dimensions, &memory);
+
             c++;
+            st->last_accessed_time = now;
         }
     }
 
@@ -134,14 +138,15 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb)
     if(unlikely(rrd_hosts_available > 1)) {
         rrd_rdlock();
         RRDHOST *h;
-        rrdhost_foreach_read(h)
+        rrdhost_foreach_read(h) {
             buffer_sprintf(wb,
-                    "%s\n\t\t{"
-                    "\n\t\t\t\"hostname\": \"%s\""
-                    "\n\t\t}"
-                    , (h != localhost)?",":""
-                    , h->hostname
+                   "%s\n\t\t{"
+                   "\n\t\t\t\"hostname\": \"%s\""
+                   "\n\t\t}"
+                   , (h != localhost) ? "," : ""
+                   , h->hostname
             );
+        }
         rrd_unlock();
     }
     else {
@@ -189,7 +194,7 @@ void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER *wb) {
         prometheus_name_copy(chart, st->id, PROMETHEUS_ELEMENT_MAX);
 
         buffer_strcat(wb, "\n");
-        if(rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && st->dimensions) {
+        if(rrdset_is_available_for_viewers(st)) {
             rrdset_rdlock(st);
 
             // for each dimension
@@ -261,7 +266,7 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
         shell_name_copy(chart, st->id, SHELL_ELEMENT_MAX);
 
         buffer_sprintf(wb, "\n# chart: %s (name: %s)\n", st->id, st->name);
-        if(rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && st->dimensions) {
+        if(rrdset_is_available_for_viewers(st)) {
             rrdset_rdlock(st);
 
             // for each dimension
@@ -316,157 +321,6 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
 
     rrdhost_unlock(host);
 }
-
-// ----------------------------------------------------------------------------
-
-unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb)
-{
-    time_t now = now_realtime_sec();
-
-    rrdset_rdlock(st);
-
-    buffer_sprintf(wb,
-        "\t\t{\n"
-        "\t\t\t\"id\": \"%s\",\n"
-        "\t\t\t\"name\": \"%s\",\n"
-        "\t\t\t\"type\": \"%s\",\n"
-        "\t\t\t\"family\": \"%s\",\n"
-        "\t\t\t\"context\": \"%s\",\n"
-        "\t\t\t\"title\": \"%s\",\n"
-        "\t\t\t\"priority\": %ld,\n"
-        "\t\t\t\"enabled\": %d,\n"
-        "\t\t\t\"units\": \"%s\",\n"
-        "\t\t\t\"url\": \"/data/%s/%s\",\n"
-        "\t\t\t\"chart_type\": \"%s\",\n"
-        "\t\t\t\"counter\": %lu,\n"
-        "\t\t\t\"entries\": %ld,\n"
-        "\t\t\t\"first_entry_t\": %ld,\n"
-        "\t\t\t\"last_entry\": %lu,\n"
-        "\t\t\t\"last_entry_t\": %ld,\n"
-        "\t\t\t\"last_entry_secs_ago\": %ld,\n"
-        "\t\t\t\"update_every\": %d,\n"
-        "\t\t\t\"isdetail\": %d,\n"
-        "\t\t\t\"usec_since_last_update\": %llu,\n"
-        "\t\t\t\"collected_total\": " TOTAL_NUMBER_FORMAT ",\n"
-        "\t\t\t\"last_collected_total\": " TOTAL_NUMBER_FORMAT ",\n"
-        "\t\t\t\"dimensions\": [\n"
-        , st->id
-        , st->name
-        , st->type
-        , st->family
-        , st->context
-        , st->title
-        , st->priority
-        , rrdset_flag_check(st, RRDSET_FLAG_ENABLED)?1:0
-        , st->units
-        , st->name, options?options:""
-        , rrdset_type_name(st->chart_type)
-        , st->counter
-        , st->entries
-        , rrdset_first_entry_t(st)
-        , rrdset_last_slot(st)
-        , rrdset_last_entry_t(st)
-        , (now < rrdset_last_entry_t(st)) ? (time_t)0 : now - rrdset_last_entry_t(st)
-        , st->update_every
-        , rrdset_flag_check(st, RRDSET_FLAG_DETAIL)?1:0
-        , st->usec_since_last_update
-        , st->collected_total
-        , st->last_collected_total
-        );
-
-    unsigned long memory = st->memsize;
-
-    RRDDIM *rd;
-    rrddim_foreach_read(rd, st) {
-
-        memory += rd->memsize;
-
-        buffer_sprintf(wb,
-            "\t\t\t\t{\n"
-            "\t\t\t\t\t\"id\": \"%s\",\n"
-            "\t\t\t\t\t\"name\": \"%s\",\n"
-            "\t\t\t\t\t\"entries\": %ld,\n"
-            "\t\t\t\t\t\"isHidden\": %d,\n"
-            "\t\t\t\t\t\"algorithm\": \"%s\",\n"
-            "\t\t\t\t\t\"multiplier\": " COLLECTED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"divisor\": " COLLECTED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"last_entry_t\": %ld,\n"
-            "\t\t\t\t\t\"collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"calculated_value\": " CALCULATED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"last_collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"last_calculated_value\": " CALCULATED_NUMBER_FORMAT ",\n"
-            "\t\t\t\t\t\"memory\": %lu\n"
-            "\t\t\t\t}%s\n"
-            , rd->id
-            , rd->name
-            , rd->entries
-            , rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)?1:0
-            , rrd_algorithm_name(rd->algorithm)
-            , rd->multiplier
-            , rd->divisor
-            , rd->last_collected_time.tv_sec
-            , rd->collected_value
-            , rd->calculated_value
-            , rd->last_collected_value
-            , rd->last_calculated_value
-            , rd->memsize
-            , rd->next?",":""
-            );
-    }
-
-    buffer_sprintf(wb,
-        "\t\t\t],\n"
-        "\t\t\t\"memory\" : %lu\n"
-        "\t\t}"
-        , memory
-        );
-
-    rrdset_unlock(st);
-    return memory;
-}
-
-#define RRD_GRAPH_JSON_HEADER "{\n\t\"charts\": [\n"
-#define RRD_GRAPH_JSON_FOOTER "\n\t]\n}\n"
-
-void rrd_stats_graph_json(RRDSET *st, char *options, BUFFER *wb)
-{
-    buffer_strcat(wb, RRD_GRAPH_JSON_HEADER);
-    rrd_stats_one_json(st, options, wb);
-    buffer_strcat(wb, RRD_GRAPH_JSON_FOOTER);
-}
-
-void rrd_stats_all_json(RRDHOST *host, BUFFER *wb)
-{
-    unsigned long memory = 0;
-    long c = 0;
-    RRDSET *st;
-
-    buffer_strcat(wb, RRD_GRAPH_JSON_HEADER);
-
-    rrdhost_rdlock(host);
-    rrdset_foreach_read(st, host) {
-        if(rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && st->dimensions) {
-            if(c) buffer_strcat(wb, ",\n");
-            memory += rrd_stats_one_json(st, NULL, wb);
-            c++;
-        }
-    }
-    rrdhost_unlock(host);
-
-    buffer_sprintf(wb, "\n\t],\n"
-        "\t\"hostname\": \"%s\",\n"
-        "\t\"update_every\": %d,\n"
-        "\t\"history\": %d,\n"
-        "\t\"memory\": %lu\n"
-        "}\n"
-        , host->hostname
-        , host->rrd_update_every
-        , host->rrd_history_entries
-        , memory
-        );
-}
-
-
 
 // ----------------------------------------------------------------------------
 
@@ -1665,7 +1519,7 @@ RRDR *rrd2rrdr(RRDSET *st, long points, long long after, long long before, int g
             );
 
     r->group = group;
-    r->update_every = group * st->update_every;
+    r->update_every = (int)group * st->update_every;
     r->before = now;
     r->after = now;
 
@@ -1817,8 +1671,20 @@ RRDR *rrd2rrdr(RRDSET *st, long points, long long after, long long before, int g
     return r;
 }
 
-int rrd2value(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points, long long after, long long before, int group_method, uint32_t options, time_t *db_after, time_t *db_before, int *value_is_null)
-{
+int rrdset2value_api_v1(
+          RRDSET *st
+        , BUFFER *wb
+        , calculated_number *n
+        , const char *dimensions
+        , long points
+        , long long after
+        , long long before
+        , int group_method
+        , uint32_t options
+        , time_t *db_after
+        , time_t *db_before
+        , int *value_is_null
+) {
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, !(options & RRDR_OPTION_NOT_ALIGNED));
     if(!r) {
         if(value_is_null) *value_is_null = 1;
@@ -1855,8 +1721,20 @@ int rrd2value(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensio
     return 200;
 }
 
-int rrd2format(RRDSET *st, BUFFER *wb, BUFFER *dimensions, uint32_t format, long points, long long after, long long before, int group_method, uint32_t options, time_t *latest_timestamp)
-{
+int rrdset2anything_api_v1(
+          RRDSET *st
+        , BUFFER *wb
+        , BUFFER *dimensions
+        , uint32_t format
+        , long points
+        , long long after
+        , long long before
+        , int group_method
+        , uint32_t options
+        , time_t *latest_timestamp
+) {
+    st->last_accessed_time = now_realtime_sec();
+
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, !(options & RRDR_OPTION_NOT_ALIGNED));
     if(!r) {
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
@@ -2027,328 +1905,4 @@ int rrd2format(RRDSET *st, BUFFER *wb, BUFFER *dimensions, uint32_t format, long
 
     rrdr_free(r);
     return 200;
-}
-
-time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long points, long group, int group_method, time_t after, time_t before, int only_non_zero)
-{
-    int c;
-    rrdset_rdlock(st);
-
-
-    // -------------------------------------------------------------------------
-    // switch from JSON to google JSON
-
-    char kq[2] = "\"";
-    char sq[2] = "\"";
-    switch(type) {
-        case DATASOURCE_DATATABLE_JSON:
-        case DATASOURCE_DATATABLE_JSONP:
-            kq[0] = '\0';
-            sq[0] = '\'';
-            break;
-
-        case DATASOURCE_JSON:
-        default:
-            break;
-    }
-
-
-    // -------------------------------------------------------------------------
-    // validate the parameters
-
-    if(points < 1) points = 1;
-    if(group < 1) group = 1;
-
-    if(before == 0 || before > rrdset_last_entry_t(st)) before = rrdset_last_entry_t(st);
-    if(after  == 0 || after < rrdset_first_entry_t(st)) after = rrdset_first_entry_t(st);
-
-    // ---
-
-    // our return value (the last timestamp printed)
-    // this is required to detect re-transmit in google JSONP
-    time_t last_timestamp = 0;
-
-
-    // -------------------------------------------------------------------------
-    // find how many dimensions we have
-
-    int dimensions = 0;
-    RRDDIM *rd;
-    rrddim_foreach_read(rd, st) dimensions++;
-    if(!dimensions) {
-        rrdset_unlock(st);
-        buffer_strcat(wb, "No dimensions yet.");
-        return 0;
-    }
-
-
-    // -------------------------------------------------------------------------
-    // prepare various strings, to speed up the loop
-
-    char overflow_annotation[201]; snprintfz(overflow_annotation, 200, ",{%sv%s:%sRESET OR OVERFLOW%s},{%sv%s:%sThe counters have been wrapped.%s}", kq, kq, sq, sq, kq, kq, sq, sq);
-    char normal_annotation[201];   snprintfz(normal_annotation,   200, ",{%sv%s:null},{%sv%s:null}", kq, kq, kq, kq);
-    char pre_date[51];             snprintfz(pre_date,             50, "        {%sc%s:[{%sv%s:%s", kq, kq, kq, kq, sq);
-    char post_date[21];            snprintfz(post_date,            20, "%s}", sq);
-    char pre_value[21];            snprintfz(pre_value,            20, ",{%sv%s:", kq, kq);
-    char post_value[21];           strcpy(post_value,                  "}");
-
-
-    // -------------------------------------------------------------------------
-    // checks for debugging
-
-    if(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)) {
-        debug(D_RRD_STATS, "%s first_entry_t = %ld, last_entry_t = %ld, duration = %ld, after = %ld, before = %ld, duration = %ld, entries_to_show = %ld, group = %ld"
-            , st->id
-            , rrdset_first_entry_t(st)
-            , rrdset_last_entry_t(st)
-            , rrdset_last_entry_t(st) - rrdset_first_entry_t(st)
-            , after
-            , before
-            , before - after
-            , points
-            , group
-            );
-
-        if(before < after)
-            debug(D_RRD_STATS, "WARNING: %s The newest value in the database (%ld) is earlier than the oldest (%ld)", st->name, before, after);
-
-        if((before - after) > st->entries * st->update_every)
-            debug(D_RRD_STATS, "WARNING: %s The time difference between the oldest and the newest entries (%ld) is higher than the capacity of the database (%ld)", st->name, before - after, st->entries * st->update_every);
-    }
-
-
-    // -------------------------------------------------------------------------
-    // temp arrays for keeping values per dimension
-
-    calculated_number group_values[dimensions]; // keep sums when grouping
-    int               print_hidden[dimensions]; // keep hidden flags
-    int               found_non_zero[dimensions];
-    int               found_non_existing[dimensions];
-
-    // initialize them
-    for( rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
-        group_values[c] = 0;
-        print_hidden[c] = rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)?1:0;
-        found_non_zero[c] = 0;
-        found_non_existing[c] = 0;
-    }
-
-
-    // error("OLD: points=%d after=%d before=%d group=%d, duration=%d", entries_to_show, before - (st->update_every * group * entries_to_show), before, group, before - after + 1);
-    // rrd2array(st, entries_to_show, before - (st->update_every * group * entries_to_show), before, group_method, only_non_zero);
-    // rrd2rrdr(st, entries_to_show, before - (st->update_every * group * entries_to_show), before, group_method);
-
-    // -------------------------------------------------------------------------
-    // remove dimensions that contain only zeros
-
-    int max_loop = 1;
-    if(only_non_zero) max_loop = 2;
-
-    for(; max_loop ; max_loop--) {
-
-        // -------------------------------------------------------------------------
-        // print the JSON header
-
-        buffer_sprintf(wb, "{\n %scols%s:\n [\n", kq, kq);
-        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%stime%s,%spattern%s:%s%s,%stype%s:%sdatetime%s},\n", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq);
-        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%s%s,%spattern%s:%s%s,%stype%s:%sstring%s,%sp%s:{%srole%s:%sannotation%s}},\n", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, kq, kq, sq, sq);
-        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%s%s,%spattern%s:%s%s,%stype%s:%sstring%s,%sp%s:{%srole%s:%sannotationText%s}}", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, kq, kq, sq, sq);
-
-        // print the header for each dimension
-        // and update the print_hidden array for the dimensions that should be hidden
-        int pc = 0;
-        for( rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
-            if(!print_hidden[c]) {
-                pc++;
-                buffer_sprintf(wb, ",\n     {%sid%s:%s%s,%slabel%s:%s%s%s,%spattern%s:%s%s,%stype%s:%snumber%s}", kq, kq, sq, sq, kq, kq, sq, rd->name, sq, kq, kq, sq, sq, kq, kq, sq, sq);
-            }
-        }
-        if(!pc) {
-            buffer_sprintf(wb, ",\n     {%sid%s:%s%s,%slabel%s:%s%s%s,%spattern%s:%s%s,%stype%s:%snumber%s}", kq, kq, sq, sq, kq, kq, sq, "no data", sq, kq, kq, sq, sq, kq, kq, sq, sq);
-        }
-
-        // print the begin of row data
-        buffer_sprintf(wb, "\n  ],\n    %srows%s:\n [\n", kq, kq);
-
-
-        // -------------------------------------------------------------------------
-        // the main loop
-
-        int annotate_reset = 0;
-        int annotation_count = 0;
-
-        long    t = rrdset_time2slot(st, before),
-                stop_at_t = rrdset_time2slot(st, after),
-                stop_now = 0;
-
-        t -= t % group;
-
-        time_t  now = rrdset_slot2time(st, t),
-                dt = st->update_every;
-
-        long count = 0, printed = 0, group_count = 0;
-        last_timestamp = 0;
-
-        if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
-            debug(D_RRD_STATS, "%s: REQUEST after:%u before:%u, points:%ld, group:%ld, CHART cur:%ld first: %u last:%u, CALC start_t:%ld, stop_t:%ld"
-                    , st->id
-                    , (uint32_t)after
-                    , (uint32_t)before
-                    , points
-                    , group
-                    , st->current_entry
-                    , (uint32_t)rrdset_first_entry_t(st)
-                    , (uint32_t)rrdset_last_entry_t(st)
-                    , t
-                    , stop_at_t
-                    );
-
-        long counter = 0;
-        for(; !stop_now ; now -= dt, t--, counter++) {
-            if(t < 0) t = st->entries - 1;
-            if(t == stop_at_t) stop_now = counter;
-
-            int print_this = 0;
-
-            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
-                debug(D_RRD_STATS, "%s t = %ld, count = %ld, group_count = %ld, printed = %ld, now = %ld, %s %s"
-                    , st->id
-                    , t
-                    , count + 1
-                    , group_count + 1
-                    , printed
-                    , now
-                    , (group_count + 1 == group)?"PRINT":"  -  "
-                    , (now >= after && now <= before)?"RANGE":"  -  "
-                    );
-
-
-            // make sure we return data in the proper time range
-            if(now > before) continue;
-            if(now < after) break;
-
-            //if(rrdset_slot2time(st, t) != now)
-            //  error("%s: slot=%ld, now=%ld, slot2time=%ld, diff=%ld, last_entry_t=%ld, rrdset_last_slot=%ld", st->id, t, now, rrdset_slot2time(st,t), now - rrdset_slot2time(st,t), rrdset_last_entry_t(st), rrdset_last_slot(st));
-
-            count++;
-            group_count++;
-
-            // check if we have to print this now
-            if(group_count == group) {
-                if(printed >= points) {
-                    // debug(D_RRD_STATS, "Already printed all rows. Stopping.");
-                    break;
-                }
-
-                // generate the local date time
-                struct tm tmbuf, *tm = localtime_r(&now, &tmbuf);
-                if(!tm) { error("localtime() failed."); continue; }
-                if(now > last_timestamp) last_timestamp = now;
-
-                if(printed) buffer_strcat(wb, "]},\n");
-                buffer_strcat(wb, pre_date);
-                buffer_jsdate(wb, tm->tm_year + 1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
-                buffer_strcat(wb, post_date);
-
-                print_this = 1;
-            }
-
-            // do the calculations
-            for(rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
-                storage_number n = rd->values[t];
-                calculated_number value = unpack_storage_number(n);
-
-                if(!does_storage_number_exist(n)) {
-                    value = 0.0;
-                    found_non_existing[c]++;
-                }
-                if(did_storage_number_reset(n)) annotate_reset = 1;
-
-                switch(group_method) {
-                    case GROUP_MAX:
-                        if(abs(value) > abs(group_values[c])) group_values[c] = value;
-                        break;
-
-                    case GROUP_SUM:
-                        group_values[c] += value;
-                        break;
-
-                    default:
-                    case GROUP_AVERAGE:
-                        group_values[c] += value;
-                        if(print_this) group_values[c] /= ( group_count - found_non_existing[c] );
-                        break;
-                }
-            }
-
-            if(print_this) {
-                if(annotate_reset) {
-                    annotation_count++;
-                    buffer_strcat(wb, overflow_annotation);
-                    annotate_reset = 0;
-                }
-                else
-                    buffer_strcat(wb, normal_annotation);
-
-                pc = 0;
-                for(c = 0 ; c < dimensions ; c++) {
-                    if(found_non_existing[c] == group_count) {
-                        // all entries are non-existing
-                        pc++;
-                        buffer_strcat(wb, pre_value);
-                        buffer_strcat(wb, "null");
-                        buffer_strcat(wb, post_value);
-                    }
-                    else if(!print_hidden[c]) {
-                        pc++;
-                        buffer_strcat(wb, pre_value);
-                        buffer_rrd_value(wb, group_values[c]);
-                        buffer_strcat(wb, post_value);
-
-                        if(group_values[c]) found_non_zero[c]++;
-                    }
-
-                    // reset them for the next loop
-                    group_values[c] = 0;
-                    found_non_existing[c] = 0;
-                }
-
-                // if all dimensions are hidden, print a null
-                if(!pc) {
-                    buffer_strcat(wb, pre_value);
-                    buffer_strcat(wb, "null");
-                    buffer_strcat(wb, post_value);
-                }
-
-                printed++;
-                group_count = 0;
-            }
-        }
-
-        if(printed) buffer_strcat(wb, "]}");
-        buffer_strcat(wb, "\n   ]\n}\n");
-
-        if(only_non_zero && max_loop > 1) {
-            int changed = 0;
-            for(rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
-                group_values[c] = 0;
-                found_non_existing[c] = 0;
-
-                if(!print_hidden[c] && !found_non_zero[c]) {
-                    changed = 1;
-                    print_hidden[c] = 1;
-                }
-            }
-
-            if(changed) buffer_flush(wb);
-            else break;
-        }
-        else break;
-
-    } // max_loop
-
-    debug(D_RRD_STATS, "RRD_STATS_JSON: %s total %zu bytes", st->name, wb->len);
-
-    rrdset_unlock(st);
-    return last_timestamp;
 }

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -64,15 +64,11 @@ extern void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER *wb);
 
-extern unsigned long rrd_stats_one_json(RRDSET *st, char *options, BUFFER *wb);
-
-extern void rrd_stats_graph_json(RRDSET *st, char *options, BUFFER *wb);
-
-extern void rrd_stats_all_json(RRDHOST *host, BUFFER *wb);
-
-extern time_t rrd_stats_json(int type, RRDSET *st, BUFFER *wb, long entries_to_show, long group, int group_method, time_t after, time_t before, int only_non_zero);
-
-extern int rrd2format(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points, long long after, long long before, int group_method, uint32_t options, time_t *latest_timestamp);
-extern int rrd2value(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points, long long after, long long before, int group_method, uint32_t options, time_t *db_before, time_t *db_after, int *value_is_null);
+extern int rrdset2anything_api_v1(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points
+                                  , long long after, long long before, int group_method, uint32_t options
+                                  , time_t *latest_timestamp);
+extern int rrdset2value_api_v1(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points
+                               , long long after, long long before, int group_method, uint32_t options
+                               , time_t *db_before, time_t *db_after, int *value_is_null);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/src/rrd2json_api_old.c
+++ b/src/rrd2json_api_old.c
@@ -1,0 +1,487 @@
+#include "common.h"
+
+unsigned long rrdset_info2json_api_old(RRDSET *st, char *options, BUFFER *wb) {
+    time_t now = now_realtime_sec();
+
+    rrdset_rdlock(st);
+
+    st->last_accessed_time = now;
+
+    buffer_sprintf(wb,
+            "\t\t{\n"
+            "\t\t\t\"id\": \"%s\",\n"
+            "\t\t\t\"name\": \"%s\",\n"
+            "\t\t\t\"type\": \"%s\",\n"
+            "\t\t\t\"family\": \"%s\",\n"
+            "\t\t\t\"context\": \"%s\",\n"
+            "\t\t\t\"title\": \"%s\",\n"
+            "\t\t\t\"priority\": %ld,\n"
+            "\t\t\t\"enabled\": %d,\n"
+            "\t\t\t\"units\": \"%s\",\n"
+            "\t\t\t\"url\": \"/data/%s/%s\",\n"
+            "\t\t\t\"chart_type\": \"%s\",\n"
+            "\t\t\t\"counter\": %lu,\n"
+            "\t\t\t\"entries\": %ld,\n"
+            "\t\t\t\"first_entry_t\": %ld,\n"
+            "\t\t\t\"last_entry\": %lu,\n"
+            "\t\t\t\"last_entry_t\": %ld,\n"
+            "\t\t\t\"last_entry_secs_ago\": %ld,\n"
+            "\t\t\t\"update_every\": %d,\n"
+            "\t\t\t\"isdetail\": %d,\n"
+            "\t\t\t\"usec_since_last_update\": %llu,\n"
+            "\t\t\t\"collected_total\": " TOTAL_NUMBER_FORMAT ",\n"
+            "\t\t\t\"last_collected_total\": " TOTAL_NUMBER_FORMAT ",\n"
+            "\t\t\t\"dimensions\": [\n"
+            , st->id
+            , st->name
+            , st->type
+            , st->family
+            , st->context
+            , st->title
+            , st->priority
+            , rrdset_flag_check(st, RRDSET_FLAG_ENABLED)?1:0
+            , st->units
+            , st->name, options?options:""
+            , rrdset_type_name(st->chart_type)
+            , st->counter
+            , st->entries
+            , rrdset_first_entry_t(st)
+            , rrdset_last_slot(st)
+            , rrdset_last_entry_t(st)
+            , (now < rrdset_last_entry_t(st)) ? (time_t)0 : now - rrdset_last_entry_t(st)
+            , st->update_every
+            , rrdset_flag_check(st, RRDSET_FLAG_DETAIL)?1:0
+            , st->usec_since_last_update
+            , st->collected_total
+            , st->last_collected_total
+    );
+
+    unsigned long memory = st->memsize;
+
+    RRDDIM *rd;
+    rrddim_foreach_read(rd, st) {
+
+        memory += rd->memsize;
+
+        buffer_sprintf(wb,
+                "\t\t\t\t{\n"
+                "\t\t\t\t\t\"id\": \"%s\",\n"
+                "\t\t\t\t\t\"name\": \"%s\",\n"
+                "\t\t\t\t\t\"entries\": %ld,\n"
+                "\t\t\t\t\t\"isHidden\": %d,\n"
+                "\t\t\t\t\t\"algorithm\": \"%s\",\n"
+                "\t\t\t\t\t\"multiplier\": " COLLECTED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"divisor\": " COLLECTED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"last_entry_t\": %ld,\n"
+                "\t\t\t\t\t\"collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"calculated_value\": " CALCULATED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"last_collected_value\": " COLLECTED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"last_calculated_value\": " CALCULATED_NUMBER_FORMAT ",\n"
+                "\t\t\t\t\t\"memory\": %lu\n"
+                "\t\t\t\t}%s\n"
+                , rd->id
+                , rd->name
+                , rd->entries
+                , rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)?1:0
+                , rrd_algorithm_name(rd->algorithm)
+                , rd->multiplier
+                , rd->divisor
+                , rd->last_collected_time.tv_sec
+                , rd->collected_value
+                , rd->calculated_value
+                , rd->last_collected_value
+                , rd->last_calculated_value
+                , rd->memsize
+                , rd->next?",":""
+        );
+    }
+
+    buffer_sprintf(wb,
+            "\t\t\t],\n"
+                    "\t\t\t\"memory\" : %lu\n"
+                    "\t\t}"
+                   , memory
+    );
+
+    rrdset_unlock(st);
+    return memory;
+}
+
+#define RRD_GRAPH_JSON_HEADER "{\n\t\"charts\": [\n"
+#define RRD_GRAPH_JSON_FOOTER "\n\t]\n}\n"
+
+void rrd_graph2json_api_old(RRDSET *st, char *options, BUFFER *wb)
+{
+    buffer_strcat(wb, RRD_GRAPH_JSON_HEADER);
+    rrdset_info2json_api_old(st, options, wb);
+    buffer_strcat(wb, RRD_GRAPH_JSON_FOOTER);
+}
+
+void rrd_all2json_api_old(RRDHOST *host, BUFFER *wb)
+{
+    unsigned long memory = 0;
+    long c = 0;
+    RRDSET *st;
+
+    time_t now = now_realtime_sec();
+
+    buffer_strcat(wb, RRD_GRAPH_JSON_HEADER);
+
+    rrdhost_rdlock(host);
+    rrdset_foreach_read(st, host) {
+        if(rrdset_is_available_for_viewers(st)) {
+            if(c) buffer_strcat(wb, ",\n");
+            memory += rrdset_info2json_api_old(st, NULL, wb);
+
+            c++;
+            st->last_accessed_time = now;
+        }
+    }
+    rrdhost_unlock(host);
+
+    buffer_sprintf(wb, "\n\t],\n"
+                    "\t\"hostname\": \"%s\",\n"
+                    "\t\"update_every\": %d,\n"
+                    "\t\"history\": %d,\n"
+                    "\t\"memory\": %lu\n"
+                    "}\n"
+                   , host->hostname
+                   , host->rrd_update_every
+                   , host->rrd_history_entries
+                   , memory
+    );
+}
+
+time_t rrdset2json_api_old(
+        int type
+        , RRDSET *st
+        , BUFFER *wb
+        , long points
+        , long group
+        , int group_method
+        , time_t after
+        , time_t before
+        , int only_non_zero
+) {
+    int c;
+    rrdset_rdlock(st);
+
+    st->last_accessed_time = now_realtime_sec();
+
+    // -------------------------------------------------------------------------
+    // switch from JSON to google JSON
+
+    char kq[2] = "\"";
+    char sq[2] = "\"";
+    switch(type) {
+        case DATASOURCE_DATATABLE_JSON:
+        case DATASOURCE_DATATABLE_JSONP:
+            kq[0] = '\0';
+            sq[0] = '\'';
+            break;
+
+        case DATASOURCE_JSON:
+        default:
+            break;
+    }
+
+
+    // -------------------------------------------------------------------------
+    // validate the parameters
+
+    if(points < 1) points = 1;
+    if(group < 1) group = 1;
+
+    if(before == 0 || before > rrdset_last_entry_t(st)) before = rrdset_last_entry_t(st);
+    if(after  == 0 || after < rrdset_first_entry_t(st)) after = rrdset_first_entry_t(st);
+
+    // ---
+
+    // our return value (the last timestamp printed)
+    // this is required to detect re-transmit in google JSONP
+    time_t last_timestamp = 0;
+
+
+    // -------------------------------------------------------------------------
+    // find how many dimensions we have
+
+    int dimensions = 0;
+    RRDDIM *rd;
+    rrddim_foreach_read(rd, st) dimensions++;
+    if(!dimensions) {
+        rrdset_unlock(st);
+        buffer_strcat(wb, "No dimensions yet.");
+        return 0;
+    }
+
+
+    // -------------------------------------------------------------------------
+    // prepare various strings, to speed up the loop
+
+    char overflow_annotation[201]; snprintfz(overflow_annotation, 200, ",{%sv%s:%sRESET OR OVERFLOW%s},{%sv%s:%sThe counters have been wrapped.%s}", kq, kq, sq, sq, kq, kq, sq, sq);
+    char normal_annotation[201];   snprintfz(normal_annotation,   200, ",{%sv%s:null},{%sv%s:null}", kq, kq, kq, kq);
+    char pre_date[51];             snprintfz(pre_date,             50, "        {%sc%s:[{%sv%s:%s", kq, kq, kq, kq, sq);
+    char post_date[21];            snprintfz(post_date,            20, "%s}", sq);
+    char pre_value[21];            snprintfz(pre_value,            20, ",{%sv%s:", kq, kq);
+    char post_value[21];           strcpy(post_value,                  "}");
+
+
+    // -------------------------------------------------------------------------
+    // checks for debugging
+
+    if(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)) {
+        debug(D_RRD_STATS, "%s first_entry_t = %ld, last_entry_t = %ld, duration = %ld, after = %ld, before = %ld, duration = %ld, entries_to_show = %ld, group = %ld"
+              , st->id
+              , rrdset_first_entry_t(st)
+              , rrdset_last_entry_t(st)
+              , rrdset_last_entry_t(st) - rrdset_first_entry_t(st)
+              , after
+              , before
+              , before - after
+              , points
+              , group
+        );
+
+        if(before < after)
+            debug(D_RRD_STATS, "WARNING: %s The newest value in the database (%ld) is earlier than the oldest (%ld)", st->name, before, after);
+
+        if((before - after) > st->entries * st->update_every)
+            debug(D_RRD_STATS, "WARNING: %s The time difference between the oldest and the newest entries (%ld) is higher than the capacity of the database (%ld)", st->name, before - after, st->entries * st->update_every);
+    }
+
+
+    // -------------------------------------------------------------------------
+    // temp arrays for keeping values per dimension
+
+    calculated_number group_values[dimensions]; // keep sums when grouping
+    int               print_hidden[dimensions]; // keep hidden flags
+    int               found_non_zero[dimensions];
+    int               found_non_existing[dimensions];
+
+    // initialize them
+    for( rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
+        group_values[c] = 0;
+        print_hidden[c] = rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)?1:0;
+        found_non_zero[c] = 0;
+        found_non_existing[c] = 0;
+    }
+
+
+    // error("OLD: points=%d after=%d before=%d group=%d, duration=%d", entries_to_show, before - (st->update_every * group * entries_to_show), before, group, before - after + 1);
+    // rrd2array(st, entries_to_show, before - (st->update_every * group * entries_to_show), before, group_method, only_non_zero);
+    // rrd2rrdr(st, entries_to_show, before - (st->update_every * group * entries_to_show), before, group_method);
+
+    // -------------------------------------------------------------------------
+    // remove dimensions that contain only zeros
+
+    int max_loop = 1;
+    if(only_non_zero) max_loop = 2;
+
+    for(; max_loop ; max_loop--) {
+
+        // -------------------------------------------------------------------------
+        // print the JSON header
+
+        buffer_sprintf(wb, "{\n %scols%s:\n [\n", kq, kq);
+        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%stime%s,%spattern%s:%s%s,%stype%s:%sdatetime%s},\n", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq);
+        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%s%s,%spattern%s:%s%s,%stype%s:%sstring%s,%sp%s:{%srole%s:%sannotation%s}},\n", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, kq, kq, sq, sq);
+        buffer_sprintf(wb, "        {%sid%s:%s%s,%slabel%s:%s%s,%spattern%s:%s%s,%stype%s:%sstring%s,%sp%s:{%srole%s:%sannotationText%s}}", kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, sq, sq, kq, kq, kq, kq, sq, sq);
+
+        // print the header for each dimension
+        // and update the print_hidden array for the dimensions that should be hidden
+        int pc = 0;
+        for( rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
+            if(!print_hidden[c]) {
+                pc++;
+                buffer_sprintf(wb, ",\n     {%sid%s:%s%s,%slabel%s:%s%s%s,%spattern%s:%s%s,%stype%s:%snumber%s}", kq, kq, sq, sq, kq, kq, sq, rd->name, sq, kq, kq, sq, sq, kq, kq, sq, sq);
+            }
+        }
+        if(!pc) {
+            buffer_sprintf(wb, ",\n     {%sid%s:%s%s,%slabel%s:%s%s%s,%spattern%s:%s%s,%stype%s:%snumber%s}", kq, kq, sq, sq, kq, kq, sq, "no data", sq, kq, kq, sq, sq, kq, kq, sq, sq);
+        }
+
+        // print the begin of row data
+        buffer_sprintf(wb, "\n  ],\n    %srows%s:\n [\n", kq, kq);
+
+
+        // -------------------------------------------------------------------------
+        // the main loop
+
+        int annotate_reset = 0;
+        int annotation_count = 0;
+
+        long    t = rrdset_time2slot(st, before),
+                stop_at_t = rrdset_time2slot(st, after),
+                stop_now = 0;
+
+        t -= t % group;
+
+        time_t  now = rrdset_slot2time(st, t),
+                dt = st->update_every;
+
+        long count = 0, printed = 0, group_count = 0;
+        last_timestamp = 0;
+
+        if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
+            debug(D_RRD_STATS, "%s: REQUEST after:%u before:%u, points:%ld, group:%ld, CHART cur:%ld first: %u last:%u, CALC start_t:%ld, stop_t:%ld"
+                  , st->id
+                  , (uint32_t)after
+                  , (uint32_t)before
+                  , points
+                  , group
+                  , st->current_entry
+                  , (uint32_t)rrdset_first_entry_t(st)
+                  , (uint32_t)rrdset_last_entry_t(st)
+                  , t
+                  , stop_at_t
+            );
+
+        long counter = 0;
+        for(; !stop_now ; now -= dt, t--, counter++) {
+            if(t < 0) t = st->entries - 1;
+            if(t == stop_at_t) stop_now = counter;
+
+            int print_this = 0;
+
+            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
+                debug(D_RRD_STATS, "%s t = %ld, count = %ld, group_count = %ld, printed = %ld, now = %ld, %s %s"
+                      , st->id
+                      , t
+                      , count + 1
+                      , group_count + 1
+                      , printed
+                      , now
+                      , (group_count + 1 == group)?"PRINT":"  -  "
+                      , (now >= after && now <= before)?"RANGE":"  -  "
+                );
+
+
+            // make sure we return data in the proper time range
+            if(now > before) continue;
+            if(now < after) break;
+
+            //if(rrdset_slot2time(st, t) != now)
+            //  error("%s: slot=%ld, now=%ld, slot2time=%ld, diff=%ld, last_entry_t=%ld, rrdset_last_slot=%ld", st->id, t, now, rrdset_slot2time(st,t), now - rrdset_slot2time(st,t), rrdset_last_entry_t(st), rrdset_last_slot(st));
+
+            count++;
+            group_count++;
+
+            // check if we have to print this now
+            if(group_count == group) {
+                if(printed >= points) {
+                    // debug(D_RRD_STATS, "Already printed all rows. Stopping.");
+                    break;
+                }
+
+                // generate the local date time
+                struct tm tmbuf, *tm = localtime_r(&now, &tmbuf);
+                if(!tm) { error("localtime() failed."); continue; }
+                if(now > last_timestamp) last_timestamp = now;
+
+                if(printed) buffer_strcat(wb, "]},\n");
+                buffer_strcat(wb, pre_date);
+                buffer_jsdate(wb, tm->tm_year + 1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+                buffer_strcat(wb, post_date);
+
+                print_this = 1;
+            }
+
+            // do the calculations
+            for(rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
+                storage_number n = rd->values[t];
+                calculated_number value = unpack_storage_number(n);
+
+                if(!does_storage_number_exist(n)) {
+                    value = 0.0;
+                    found_non_existing[c]++;
+                }
+                if(did_storage_number_reset(n)) annotate_reset = 1;
+
+                switch(group_method) {
+                    case GROUP_MAX:
+                        if(abs(value) > abs(group_values[c])) group_values[c] = value;
+                        break;
+
+                    case GROUP_SUM:
+                        group_values[c] += value;
+                        break;
+
+                    default:
+                    case GROUP_AVERAGE:
+                        group_values[c] += value;
+                        if(print_this) group_values[c] /= ( group_count - found_non_existing[c] );
+                        break;
+                }
+            }
+
+            if(print_this) {
+                if(annotate_reset) {
+                    annotation_count++;
+                    buffer_strcat(wb, overflow_annotation);
+                    annotate_reset = 0;
+                }
+                else
+                    buffer_strcat(wb, normal_annotation);
+
+                pc = 0;
+                for(c = 0 ; c < dimensions ; c++) {
+                    if(found_non_existing[c] == group_count) {
+                        // all entries are non-existing
+                        pc++;
+                        buffer_strcat(wb, pre_value);
+                        buffer_strcat(wb, "null");
+                        buffer_strcat(wb, post_value);
+                    }
+                    else if(!print_hidden[c]) {
+                        pc++;
+                        buffer_strcat(wb, pre_value);
+                        buffer_rrd_value(wb, group_values[c]);
+                        buffer_strcat(wb, post_value);
+
+                        if(group_values[c]) found_non_zero[c]++;
+                    }
+
+                    // reset them for the next loop
+                    group_values[c] = 0;
+                    found_non_existing[c] = 0;
+                }
+
+                // if all dimensions are hidden, print a null
+                if(!pc) {
+                    buffer_strcat(wb, pre_value);
+                    buffer_strcat(wb, "null");
+                    buffer_strcat(wb, post_value);
+                }
+
+                printed++;
+                group_count = 0;
+            }
+        }
+
+        if(printed) buffer_strcat(wb, "]}");
+        buffer_strcat(wb, "\n   ]\n}\n");
+
+        if(only_non_zero && max_loop > 1) {
+            int changed = 0;
+            for(rd = st->dimensions, c = 0 ; rd && c < dimensions ; rd = rd->next, c++) {
+                group_values[c] = 0;
+                found_non_existing[c] = 0;
+
+                if(!print_hidden[c] && !found_non_zero[c]) {
+                    changed = 1;
+                    print_hidden[c] = 1;
+                }
+            }
+
+            if(changed) buffer_flush(wb);
+            else break;
+        }
+        else break;
+
+    } // max_loop
+
+    debug(D_RRD_STATS, "RRD_STATS_JSON: %s total %zu bytes", st->name, wb->len);
+
+    rrdset_unlock(st);
+    return last_timestamp;
+}

--- a/src/rrd2json_api_old.h
+++ b/src/rrd2json_api_old.h
@@ -1,0 +1,14 @@
+#ifndef NETDATA_RRD2JSON_API_OLD_H
+#define NETDATA_RRD2JSON_API_OLD_H
+
+extern unsigned long rrdset_info2json_api_old(RRDSET *st, char *options, BUFFER *wb);
+
+extern void rrd_graph2json_api_old(RRDSET *st, char *options, BUFFER *wb);
+
+extern void rrd_all2json_api_old(RRDHOST *host, BUFFER *wb);
+
+extern time_t rrdset2json_api_old(int type, RRDSET *st, BUFFER *wb, long entries_to_show, long group, int group_method
+                                  , time_t after, time_t before, int only_non_zero);
+
+
+#endif //NETDATA_RRD2JSON_API_OLD_H

--- a/src/rrdcalctemplate.c
+++ b/src/rrdcalctemplate.c
@@ -23,6 +23,8 @@ void rrdcalctemplate_link_matching(RRDSET *st) {
 }
 
 inline void rrdcalctemplate_free(RRDHOST *host, RRDCALCTEMPLATE *rt) {
+    if(unlikely(!rt)) return;
+
     debug(D_HEALTH, "Health removing template '%s' of host '%s'", rt->name, host->hostname);
 
     if(host->templates == rt) {

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -409,6 +409,10 @@ void rrdhost_free(RRDHOST *host) {
     info("Freeing all memory for host '%s'...", host->hostname);
 
     rrd_check_wrlock();     // make sure the RRDs are write locked
+
+    // stop a possibly running thread
+    rrdpush_sender_thread_stop(host);
+
     rrdhost_wrlock(host);   // lock this RRDHOST
 
     // ------------------------------------------------------------------------
@@ -446,8 +450,6 @@ void rrdhost_free(RRDHOST *host) {
 
     // ------------------------------------------------------------------------
     // free it
-
-    rrdpush_sender_thread_stop(host);
 
     freez(host->os);
     freez(host->cache_dir);

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -453,7 +453,7 @@ cleanup:
 
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
         error("STREAM %s [send]: cannot set pthread cancel state to ENABLE.", host->hostname);
-    
+
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -219,6 +219,8 @@ static void rrdpush_sender_thread_cleanup_locked_all(RRDHOST *host) {
     host->rrdpush_buffer = NULL;
 
     host->rrdpush_spawn = 0;
+
+    rrdhost_flag_set(host, RRDHOST_ORPHAN);
 }
 
 void rrdpush_sender_thread_stop(RRDHOST *host) {
@@ -645,6 +647,7 @@ void rrdpush_sender_thread_spawn(RRDHOST *host) {
         else if(pthread_detach(host->rrdpush_thread))
             error("STREAM %s [send]: cannot request detach newly created thread.", host->hostname);
 
+        rrdhost_flag_clear(host, RRDHOST_ORPHAN);
         host->rrdpush_spawn = 1;
     }
 

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -442,12 +442,18 @@ void *rrdpush_sender_thread(void *ptr) {
 cleanup:
     debug(D_WEB_CLIENT, "STREAM %s [send]: sending thread exits.", host->hostname);
 
+    if(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL) != 0)
+        error("STREAM %s [send]: cannot set pthread cancel state to DISABLE.", host->hostname);
+
     rrdpush_lock(host);
     rrdhost_wrlock(host);
     rrdpush_sender_thread_cleanup_locked_all(host);
     rrdhost_unlock(host);
     rrdpush_unlock(host);
 
+    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+        error("STREAM %s [send]: cannot set pthread cancel state to ENABLE.", host->hostname);
+    
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -466,8 +466,8 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 
         unsigned long i = procfile_linewords(ff, 0);
         if(unlikely(i == 0)) {
-            return;
             ca->updated = 0;
+            return;
         }
 
         // we may have 1 more CPU reported
@@ -2113,7 +2113,7 @@ void update_cgroup_charts(int update_every) {
                 );
 
                 for(i = 0; i < cg->cpuacct_usage.cpus; i++) {
-                    snprintfz(id, CHART_TITLE_MAX, "cpu%u", i);
+                    snprintfz(id, RRD_ID_LENGTH_MAX, "cpu%u", i);
                     rrddim_add(cg->st_cpu_per_core, id, NULL, 100, 1000000000, RRD_ALGORITHM_INCREMENTAL);
                 }
             }
@@ -2121,7 +2121,7 @@ void update_cgroup_charts(int update_every) {
                 rrdset_next(cg->st_cpu_per_core);
 
             for(i = 0; i < cg->cpuacct_usage.cpus ;i++) {
-                snprintfz(id, CHART_TITLE_MAX, "cpu%u", i);
+                snprintfz(id, RRD_ID_LENGTH_MAX, "cpu%u", i);
                 rrddim_set(cg->st_cpu_per_core, id, cg->cpuacct_usage.cpu_percpu[i]);
             }
             rrdset_done(cg->st_cpu_per_core);


### PR DESCRIPTION
fixes #1163 
fixes #1358

## the problem

Containers are ephemeral by nature. Prior to this PR, netdata had 2 issues:

1. network interface alarms where triggering when containers were stopped
2. charts were never cleaned up, so after some time dozens of containers were showing up on the dashboard, and they were occupying memory.

## the solution

network interfaces and cgroups are now self-cleaned.

So, when a network interface or container stops, netdata might log a few errors in error.log complaining about files it cannot find, but immediately:

1. it will detect this is a removed container or network interface
2. it will freeze/pause all alarms for them
3. it will mark their charts as obsolete
4. obsolete charts are not be offered on new dashboard sessions (so hit F5 and the charts are gone)
5. existing dashboard sessions will continue to see them, but of course they will not be refreshing
6. obsolete charts will be removed from memory, 1 hour after the last user viewed them (configurable with `[global].cleanup obsolete charts after seconds = 3600` (at netdata.conf).
7. when obsolete charts are removed from memory they are also deleted from disk (configurable with `[global].delete obsolete charts files = yes`)
