### PR TITLE
FreeBSD has CLOCK_UPTIME feature for clock_gettime.

### DIFF
--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -274,7 +274,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
     char mntonname[MNAMELEN + 1];
 
     // NEEDED BY: do_uptime
-    struct timespec boot_time, cur_time;
+    struct timespec up_time;
 
     // --------------------------------------------------------------------
 
@@ -2181,11 +2181,7 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     if (likely(do_uptime)) {
-        if (unlikely(GETSYSCTL("kern.boottime", boot_time))) {
-            do_uptime = 0;
-            error("DISABLED: system.uptime");
-        } else {
-            clock_gettime(CLOCK_REALTIME, &cur_time);
+            clock_gettime(CLOCK_UPTIME, &up_time);
             st = rrdset_find_localhost("system.uptime");
 
             if(unlikely(!st)) {
@@ -2194,9 +2190,8 @@ int do_freebsd_sysctl(int update_every, usec_t dt) {
             }
             else rrdset_next(st);
 
-            rrddim_set(st, "uptime", cur_time.tv_sec - boot_time.tv_sec);
+            rrddim_set(st, "uptime", up_time.tv_sec);
             rrdset_done(st);
-        }
     }
 
     return 0;


### PR DESCRIPTION
https://www.freebsd.org/cgi/man.cgi?query=clock_gettime&apropos=0&sektion=0&manpath=FreeBSD+10.0-RELEASE&arch=default&format=html

the functions below  make the same job,
but clock version is short, fast i think.

```c
#include <time.h>
#include <sys/sysctl.h>
#include <inttypes.h>
#include <stdio.h>

int64_t uptime_via_clock() {
        struct timespec ts;
        clock_gettime(CLOCK_UPTIME , &ts);
        return ts.tv_sec;
}

int64_t uptime_via_sysctl() {
        struct timespec cur_time , boot_time;
        size_t len = sizeof(struct timespec);

        sysctlbyname("kern.boottime" , &boot_time , &len , NULL , 0);
        clock_gettime(CLOCK_REALTIME , &cur_time);

        return (cur_time.tv_sec - boot_time.tv_sec);
}

int main() {
        printf("Uptime Via Clock: %ld\n",uptime_via_clock());
        printf("Uptime Via Sysctl: %ld\n",uptime_via_sysctl());
        return 0;
}
```
