### PR TITLE
Remove manager/status?XML=true URI Requirement

### DIFF
--- a/python.d/tomcat.chart.py
+++ b/python.d/tomcat.chart.py
@@ -51,10 +51,6 @@ class Service(UrlService):
         self.definitions = CHARTS
 
     def check(self):
-        if not self.url.endswith('manager/status?XML=true'):
-            self.error('Bad url(%s). Must be http://<ip.address>:<port>/manager/status?XML=true' % self.url)
-            return False
-
         netloc = urlparse(self.url).netloc.rpartition(':')
         if netloc[1] == ':': port = netloc[2]
         else: port = 80


### PR DESCRIPTION
It would be nice if the end-user could use a different URL to provide the Tomcat status.  Basically you are requiring the manager application be used to provide this, but any app using the org.apache.catalina.manager.StatusManagerServlet servlet is suitable.  I simply do not want to use authentication to provide the information to Netdata.