### PR TITLE
data collection of netfilter connection tracker metrics using netlink (libmnl)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,11 +51,11 @@ AC_ARG_ENABLE(
     [plugin-nfacct],
     [AS_HELP_STRING([--enable-plugin-nfacct], [enable nfacct plugin, requires root])],
     ,
-    [enable_plugin_nfacct="no"]
+    [enable_plugin_nfacct="detect"]
 )
 AC_ARG_ENABLE(
     [plugin-freeipmi],
-    [AS_HELP_STRING([--enable-plugin-freeipmi], [freeipmi plugin, requires root])],
+    [AS_HELP_STRING([--enable-plugin-freeipmi], [enable freeipmi plugin])],
     ,
     [enable_plugin_freeipmi="detect"]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -363,18 +363,33 @@ AM_CONDITIONAL([ENABLE_PLUGIN_FREEIPMI], [test "${enable_plugin_freeipmi}" = "ye
 # -----------------------------------------------------------------------------
 # nfacct.plugin - libmnl, libnetfilter_acct
 
+AC_CHECK_HEADERS_ONCE([linux/netfilter/nfnetlink_conntrack.h])
+
 PKG_CHECK_MODULES(
     [NFACCT],
     [libnetfilter_acct],
     [have_libnetfilter_acct=yes],
     [have_libnetfilter_acct=no]
 )
+
+if test "${have_libnetfilter_acct}" = "yes"; then
+    AC_DEFINE([HAVE_LIBNETFILTER_ACCT], [1], [libnetfilter_acct usability])
+    OPTIONAL_NFACCT_CLFAGS="${OPTIONAL_NFACCT_CLFAGS} ${NFACCT_CFLAGS}"
+    OPTIONAL_NFACCT_LIBS="${OPTIONAL_NFACCT_LIBS} ${NFACCT_LIBS}"
+fi
+
 PKG_CHECK_MODULES(
     [LIBMNL],
     [libmnl],
     [have_libmnl=yes],
     [have_libmnl=no]
 )
+
+if test "${have_libmnl}" = "yes"; then
+    AC_DEFINE([HAVE_LIBMNL], [1], [libmnl usability])
+    OPTIONAL_NFACCT_CLFAGS="${OPTIONAL_NFACCT_CLFAGS} ${LIBMNL_CFLAGS}"
+    OPTIONAL_NFACCT_LIBS="${OPTIONAL_NFACCT_LIBS} ${LIBMNL_LIBS}"
+fi
 
 test "${enable_plugin_nfacct}" = "yes" -a "${have_libnetfilter_acct}" != "yes" && \
     AC_MSG_ERROR([netfilter_acct required but not found])

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_ARG_ENABLE(
     [plugin-nfacct],
     [AS_HELP_STRING([--enable-plugin-nfacct], [enable nfacct plugin, requires root])],
     ,
-    [enable_plugin_nfacct="detect"]
+    [enable_plugin_nfacct="no"]
 )
 AC_ARG_ENABLE(
     [plugin-freeipmi],

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -104,6 +104,12 @@ Valid <installer options> are:
         Enable/disable the FreeIPMI plugin.
         Default: enable it when libipmimonitoring is available.
 
+   --enable-plugin-nfacct
+   --disable-plugin-nfacct
+
+        Enable/disable the nfacct plugin.
+        Default: enable it when libmnl and libnetfilter_acct are available.
+
    --enable-lto
    --disable-lto
 
@@ -204,6 +210,14 @@ do
     elif [ "$1" = "--disable-plugin-freeipmi" ]
         then
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --disable-plugin-freeipmi"
+        shift 1
+    elif [ "$1" = "--enable-plugin-nfacct" ]
+        then
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --enable-plugin-nfacct"
+        shift 1
+    elif [ "$1" = "--disable-plugin-nfacct" ]
+        then
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --disable-plugin-nfacct"
         shift 1
     elif [ "$1" = "--enable-lto" ]
         then

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -432,7 +432,7 @@ static void nfstat_send_metrics() {
         if(!st_expect) {
             st_expect = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
-                    , RRD_TYPE_NET_STAT_CONNTRACK "_search"
+                    , RRD_TYPE_NET_STAT_CONNTRACK "_expect"
                     , NULL
                     , RRD_TYPE_NET_STAT_CONNTRACK
                     , NULL

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -1,7 +1,334 @@
 #include "common.h"
 
 #ifdef INTERNAL_PLUGIN_NFACCT
+
+#ifdef HAVE_LIBMNL
 #include <libmnl/libmnl.h>
+
+
+// ----------------------------------------------------------------------------
+// DO_NFSTAT - collect netfilter connection tracker statistics via netlink
+// example: https://github.com/formorer/pkg-conntrack-tools/blob/master/src/conntrack.c
+
+#ifdef HAVE_LINUX_NETFILTER_NFNETLINK_CONNTRACK_H
+#define DO_NFSTAT 1
+
+#include <linux/netfilter/nfnetlink_conntrack.h>
+
+static struct {
+    int update_every;
+    char *buf;
+    size_t buf_size;
+    struct mnl_socket *mnl;
+    struct nlmsghdr *nlh;
+    struct nfgenmsg *nfh;
+    unsigned int seq;
+    uint32_t portid;
+    struct nlattr *tb[CTA_STATS_MAX+1];
+    const char *attr2name[CTA_STATS_MAX+1];
+    kernel_uint_t metrics[CTA_STATS_MAX+1];
+} nfstat_root = {
+        .update_every = 1,
+        .buf = NULL,
+        .buf_size = 0,
+        .mnl = NULL,
+        .nlh = NULL,
+        .nfh = NULL,
+        .seq = 0,
+        .portid = 0,
+        .tb = {},
+        .attr2name = {
+                [CTA_STATS_SEARCHED]	   = "searched",
+                [CTA_STATS_FOUND]	       = "found",
+                [CTA_STATS_NEW]		       = "new",
+                [CTA_STATS_INVALID]	       = "invalid",
+                [CTA_STATS_IGNORE]	       = "ignore",
+                [CTA_STATS_DELETE]	       = "delete",
+                [CTA_STATS_DELETE_LIST]	   = "delete_list",
+                [CTA_STATS_INSERT]	       = "insert",
+                [CTA_STATS_INSERT_FAILED]  = "insert_failed",
+                [CTA_STATS_DROP]	       = "drop",
+                [CTA_STATS_EARLY_DROP]	   = "early_drop",
+                [CTA_STATS_ERROR]	       = "icmp_error",
+                [CTA_STATS_SEARCH_RESTART] = "search_restart",
+        },
+        .metrics = {}
+};
+
+
+static int nfstat_init(int update_every) {
+    nfstat_root.update_every = update_every;
+
+    nfstat_root.buf_size = (size_t)MNL_SOCKET_BUFFER_SIZE;
+    nfstat_root.buf = mallocz(nfstat_root.buf_size);
+
+    nfstat_root.mnl  = mnl_socket_open(NETLINK_NETFILTER);
+    if(!nfstat_root.mnl) {
+        error("NFSTAT: mnl_socket_open() failed");
+        return 1;
+    }
+
+    nfstat_root.seq = (unsigned int)now_realtime_sec() - 1;
+
+    if(mnl_socket_bind(nfstat_root.mnl, 0, MNL_SOCKET_AUTOPID) < 0) {
+        error("NFSTAT: mnl_socket_bind() failed");
+        return 1;
+    }
+    nfstat_root.portid = mnl_socket_get_portid(nfstat_root.mnl);
+
+    return 0;
+}
+
+static void nfstat_cleanup() {
+    if(nfstat_root.mnl) {
+        mnl_socket_close(nfstat_root.mnl);
+        nfstat_root.mnl = NULL;
+    }
+
+    freez(nfstat_root.buf);
+    nfstat_root.buf = NULL;
+    nfstat_root.buf_size = 0;
+}
+
+static int nfct_stats_attr_cb(const struct nlattr *attr, void *data) {
+    const struct nlattr **tb = data;
+    int type = mnl_attr_get_type(attr);
+
+    if (mnl_attr_type_valid(attr, CTA_STATS_MAX) < 0)
+        return MNL_CB_OK;
+
+    if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
+        error("NFSTAT: mnl_attr_validate() failed");
+        return MNL_CB_ERROR;
+    }
+
+    tb[type] = attr;
+    return MNL_CB_OK;
+}
+
+static int nfstat_callback(const struct nlmsghdr *nlh, void *data) {
+    (void)data;
+
+    struct nfgenmsg *nfg = mnl_nlmsg_get_payload(nlh);
+
+    mnl_attr_parse(nlh, sizeof(*nfg), nfct_stats_attr_cb, nfstat_root.tb);
+
+    // printf("cpu=%-4u\t", ntohs(nfg->res_id));
+
+    int i;
+    // add the metrics of this CPU into the metrics
+    for (i = 0; i < CTA_STATS_MAX+1; i++) {
+        if (nfstat_root.tb[i]) {
+            // printf("%s=%u ", nfstat_root.attr2name[i], ntohl(mnl_attr_get_u32(nfstat_root.tb[i])));
+            nfstat_root.metrics[i] += ntohl(mnl_attr_get_u32(nfstat_root.tb[i]));
+        }
+    }
+    // printf("\n");
+
+    return MNL_CB_OK;
+}
+
+static int nfstat_collect() {
+    int i;
+
+    // zero all metrics - we will sum the metrics of all CPUs later
+    for (i = 0; i < CTA_STATS_MAX+1; i++)
+        nfstat_root.metrics[i] = 0;
+
+    // prepare the request
+    nfstat_root.nlh = mnl_nlmsg_put_header(nfstat_root.buf);
+    nfstat_root.nlh->nlmsg_type = (NFNL_SUBSYS_CTNETLINK << 8) | IPCTNL_MSG_CT_GET_STATS_CPU;
+    nfstat_root.nlh->nlmsg_flags = NLM_F_REQUEST|NLM_F_DUMP;
+    nfstat_root.nlh->nlmsg_seq = nfstat_root.seq++;
+
+    nfstat_root.nfh = mnl_nlmsg_put_extra_header(nfstat_root.nlh, sizeof(struct nfgenmsg));
+    nfstat_root.nfh->nfgen_family = AF_UNSPEC;
+    nfstat_root.nfh->version = NFNETLINK_V0;
+    nfstat_root.nfh->res_id = 0;
+
+    // send the request
+    if(mnl_socket_sendto(nfstat_root.mnl, nfstat_root.nlh, nfstat_root.nlh->nlmsg_len) < 0) {
+        error("NFSTAT: mnl_socket_sendto() failed");
+        return 1;
+    }
+
+    // get the reply
+    ssize_t ret;
+    while ((ret = mnl_socket_recvfrom(nfstat_root.mnl, nfstat_root.buf, nfstat_root.buf_size)) > 0) {
+        if(mnl_cb_run(
+                nfstat_root.buf
+                , (size_t)ret
+                , nfstat_root.nlh->nlmsg_seq
+                , nfstat_root.portid
+                , nfstat_callback
+                , NULL
+        ) <= MNL_CB_STOP)
+            break;
+    }
+
+    // verify we run without issues
+    if (ret == -1) {
+        error("NFSTAT: error communicating with kernel. This plugin can only work when netdata runs as root.");
+        return 1;
+    }
+
+    return 0;
+}
+
+#define RRD_TYPE_NET_STAT_NETFILTER "netfilter2"
+#define RRD_TYPE_NET_STAT_CONNTRACK "conntrack2"
+
+static void nfstat_send_metrics() {
+
+    {
+        static RRDSET *st_new = NULL;
+        static RRDDIM *rd_new = NULL, *rd_ignore = NULL, *rd_invalid = NULL;
+
+        if(!st_new) {
+            st_new = rrdset_create_localhost(
+                    RRD_TYPE_NET_STAT_NETFILTER
+                    , RRD_TYPE_NET_STAT_CONNTRACK "_new"
+                    , NULL
+                    , RRD_TYPE_NET_STAT_CONNTRACK
+                    , NULL
+                    , "Connection Tracker New Connections"
+                    , "connections/s"
+                    , 3001
+                    , nfstat_root.update_every
+                    , RRDSET_TYPE_LINE
+            );
+
+            rd_new     = rrddim_add(st_new, nfstat_root.attr2name[CTA_STATS_NEW], NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_ignore  = rrddim_add(st_new, nfstat_root.attr2name[CTA_STATS_IGNORE], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_invalid = rrddim_add(st_new, nfstat_root.attr2name[CTA_STATS_INVALID], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        }
+        else
+            rrdset_next(st_new);
+
+        rrddim_set_by_pointer(st_new, rd_new, (collected_number) nfstat_root.metrics[CTA_STATS_NEW]);
+        rrddim_set_by_pointer(st_new, rd_ignore, (collected_number) nfstat_root.metrics[CTA_STATS_IGNORE]);
+        rrddim_set_by_pointer(st_new, rd_invalid, (collected_number) nfstat_root.metrics[CTA_STATS_INVALID]);
+
+        rrdset_done(st_new);
+    }
+
+    // ----------------------------------------------------------------
+
+    {
+        static RRDSET *st_changes = NULL;
+        static RRDDIM *rd_inserted = NULL, *rd_deleted = NULL, *rd_delete_list = NULL;
+
+        if(!st_changes) {
+            st_changes = rrdset_create_localhost(
+                    RRD_TYPE_NET_STAT_NETFILTER
+                    , RRD_TYPE_NET_STAT_CONNTRACK "_changes"
+                    , NULL
+                    , RRD_TYPE_NET_STAT_CONNTRACK
+                    , NULL
+                    , "Connection Tracker Changes"
+                    , "changes/s"
+                    , 3002
+                    , nfstat_root.update_every
+                    , RRDSET_TYPE_LINE
+            );
+            rrdset_flag_set(st_changes, RRDSET_FLAG_DETAIL);
+
+            rd_inserted = rrddim_add(st_changes, nfstat_root.attr2name[CTA_STATS_INSERT], NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_deleted = rrddim_add(st_changes, nfstat_root.attr2name[CTA_STATS_DELETE], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_delete_list = rrddim_add(st_changes, nfstat_root.attr2name[CTA_STATS_DELETE_LIST], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        }
+        else
+            rrdset_next(st_changes);
+
+        rrddim_set_by_pointer(st_changes, rd_inserted, (collected_number) nfstat_root.metrics[CTA_STATS_INSERT]);
+        rrddim_set_by_pointer(st_changes, rd_deleted, (collected_number) nfstat_root.metrics[CTA_STATS_DELETE]);
+        rrddim_set_by_pointer(st_changes, rd_delete_list, (collected_number) nfstat_root.metrics[CTA_STATS_DELETE_LIST]);
+
+        rrdset_done(st_changes);
+    }
+
+    // ----------------------------------------------------------------
+
+    {
+        static RRDSET *st_search = NULL;
+        static RRDDIM *rd_searched = NULL, *rd_restarted = NULL, *rd_found = NULL;
+
+        if(!st_search) {
+            st_search = rrdset_create_localhost(
+                    RRD_TYPE_NET_STAT_NETFILTER
+                    , RRD_TYPE_NET_STAT_CONNTRACK "_search"
+                    , NULL
+                    , RRD_TYPE_NET_STAT_CONNTRACK
+                    , NULL
+                    , "Connection Tracker Searches"
+                    , "searches/s"
+                    , 3010
+                    , nfstat_root.update_every
+                    , RRDSET_TYPE_LINE
+            );
+            rrdset_flag_set(st_search, RRDSET_FLAG_DETAIL);
+
+            rd_searched = rrddim_add(st_search, nfstat_root.attr2name[CTA_STATS_SEARCHED], NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_restarted = rrddim_add(st_search, nfstat_root.attr2name[CTA_STATS_SEARCH_RESTART], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_found = rrddim_add(st_search, nfstat_root.attr2name[CTA_STATS_FOUND], NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        }
+        else
+            rrdset_next(st_search);
+
+        rrddim_set_by_pointer(st_search, rd_searched, (collected_number) nfstat_root.metrics[CTA_STATS_SEARCHED]);
+        rrddim_set_by_pointer(st_search, rd_restarted, (collected_number) nfstat_root.metrics[CTA_STATS_SEARCH_RESTART]);
+        rrddim_set_by_pointer(st_search, rd_found, (collected_number) nfstat_root.metrics[CTA_STATS_FOUND]);
+
+        rrdset_done(st_search);
+    }
+
+    // ----------------------------------------------------------------
+
+    {
+        static RRDSET *st_errors = NULL;
+        static RRDDIM *rd_error = NULL, *rd_insert_failed = NULL, *rd_drop = NULL, *rd_early_drop = NULL;
+
+        if(!st_errors) {
+            st_errors = rrdset_create_localhost(
+                    RRD_TYPE_NET_STAT_NETFILTER
+                    , RRD_TYPE_NET_STAT_CONNTRACK "_errors"
+                    , NULL
+                    , RRD_TYPE_NET_STAT_CONNTRACK
+                    , NULL
+                    , "Connection Tracker Errors"
+                    , "events/s"
+                    , 3005
+                    , nfstat_root.update_every
+                    , RRDSET_TYPE_LINE
+            );
+            rrdset_flag_set(st_errors, RRDSET_FLAG_DETAIL);
+
+            rd_error = rrddim_add(st_errors, nfstat_root.attr2name[CTA_STATS_ERROR], NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_insert_failed = rrddim_add(st_errors, nfstat_root.attr2name[CTA_STATS_INSERT_FAILED], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_drop = rrddim_add(st_errors, nfstat_root.attr2name[CTA_STATS_DROP], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_early_drop = rrddim_add(st_errors, nfstat_root.attr2name[CTA_STATS_EARLY_DROP], NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        }
+        else
+            rrdset_next(st_errors);
+
+        rrddim_set_by_pointer(st_errors, rd_error, (collected_number) nfstat_root.metrics[CTA_STATS_ERROR]);
+        rrddim_set_by_pointer(st_errors, rd_insert_failed, (collected_number) nfstat_root.metrics[CTA_STATS_INSERT_FAILED]);
+        rrddim_set_by_pointer(st_errors, rd_drop, (collected_number) nfstat_root.metrics[CTA_STATS_DROP]);
+        rrddim_set_by_pointer(st_errors, rd_early_drop, (collected_number) nfstat_root.metrics[CTA_STATS_EARLY_DROP]);
+
+        rrdset_done(st_errors);
+    }
+}
+
+#endif // HAVE_LINUX_NETFILTER_NFNETLINK_CONNTRACK_H
+
+
+// ----------------------------------------------------------------------------
+// DO_NFACCT - collect netfilter accounting statistics via netlink
+
+#ifdef HAVE_LIBNETFILTER_ACCT
+#define DO_NFACCT 1
+
 #include <libnetfilter_acct/libnetfilter_acct.h>
 
 struct nfacct_data {
@@ -19,10 +346,24 @@ struct nfacct_data {
     struct nfacct_data *next;
 };
 
-static struct nfacct_list {
+static struct {
+    int update_every;
+    char *buf;
+    size_t buf_size;
+    struct mnl_socket *mnl;
+    struct nlmsghdr *nlh;
+    unsigned int seq;
+    uint32_t portid;
     struct nfacct *nfacct_buffer;
     struct nfacct_data *nfacct_metrics;
 } nfacct_root = {
+        .update_every = 1,
+        .buf = NULL,
+        .buf_size = 0,
+        .mnl = NULL,
+        .nlh = NULL,
+        .seq = 0,
+        .portid = 0,
         .nfacct_buffer = NULL,
         .nfacct_metrics = NULL
 };
@@ -50,11 +391,58 @@ static inline struct nfacct_data *nfacct_data_get(const char *name, uint32_t has
     return d;
 }
 
+static int nfacct_init(int update_every) {
+    nfacct_root.update_every = update_every;
+
+    nfacct_root.buf_size = (size_t)MNL_SOCKET_BUFFER_SIZE;
+    nfacct_root.buf = mallocz(nfacct_root.buf_size);
+
+    nfacct_root.nfacct_buffer = nfacct_alloc();
+    if(!nfacct_root.nfacct_buffer) {
+        error("nfacct.plugin: nfacct_alloc() failed.");
+        return 0;
+    }
+
+    nfacct_root.seq = (unsigned int)now_realtime_sec() - 1;
+
+    nfacct_root.mnl  = mnl_socket_open(NETLINK_NETFILTER);
+    if(!nfacct_root.mnl) {
+        error("nfacct.plugin: mnl_socket_open() failed");
+        return 1;
+    }
+
+    if(mnl_socket_bind(nfacct_root.mnl, 0, MNL_SOCKET_AUTOPID) < 0) {
+        error("nfacct.plugin: mnl_socket_bind() failed");
+        return 1;
+    }
+    nfacct_root.portid = mnl_socket_get_portid(nfacct_root.mnl);
+
+    return 0;
+}
+
+static void nfacct_cleanup() {
+    if(nfacct_root.mnl) {
+        mnl_socket_close(nfacct_root.mnl);
+        nfacct_root.mnl = NULL;
+    }
+
+    if(nfacct_root.nfacct_buffer) {
+        nfacct_free(nfacct_root.nfacct_buffer);
+        nfacct_root.nfacct_buffer = NULL;
+    }
+
+    freez(nfacct_root.buf);
+    nfacct_root.buf = NULL;
+    nfacct_root.buf_size = 0;
+
+    // FIXME: cleanup the metrics linked list
+}
+
 static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {
     (void)data;
 
     if(nfacct_nlmsg_parse_payload(nlh, nfacct_root.nfacct_buffer) < 0) {
-        error("nfacct.plugin: nfacct_nlmsg_parse_payload() failed.");
+        error("NFACCT: nfacct_nlmsg_parse_payload() failed.");
         return MNL_CB_OK;
     }
 
@@ -70,49 +458,165 @@ static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {
     return MNL_CB_OK;
 }
 
+static int nfacct_collect() {
+    // mark all old metrics as not-updated
+    struct nfacct_data *d;
+    for(d = nfacct_root.nfacct_metrics; d ; d = d->next)
+        d->updated = 0;
+
+    // prepare the request
+    nfacct_root.seq++;
+    nfacct_root.nlh = nfacct_nlmsg_build_hdr(nfacct_root.buf, NFNL_MSG_ACCT_GET, NLM_F_DUMP, (uint32_t)nfacct_root.seq);
+    if(!nfacct_root.nlh) {
+        error("NFACCT: nfacct_nlmsg_build_hdr() failed");
+        return 1;
+    }
+
+    // send the request
+    if(mnl_socket_sendto(nfacct_root.mnl, nfacct_root.nlh, nfacct_root.nlh->nlmsg_len) < 0) {
+        error("NFACCT: mnl_socket_sendto() failed");
+        return 1;
+    }
+
+    // get the reply
+    ssize_t ret;
+    while((ret = mnl_socket_recvfrom(nfacct_root.mnl, nfacct_root.buf, nfacct_root.buf_size)) > 0) {
+        if(mnl_cb_run(
+                nfacct_root.buf
+                , (size_t)ret
+                , nfacct_root.seq
+                , nfacct_root.portid
+                , nfacct_callback
+                , NULL
+        ) <= 0)
+            break;
+    }
+
+    // verify we run without issues
+    if (ret == -1) {
+        error("NFACCT: error communicating with kernel. This plugin can only work when netdata runs as root.");
+        return 1;
+    }
+
+    return 0;
+}
+
+static void nfacct_send_metrics() {
+    static RRDSET *st_bytes = NULL, *st_packets = NULL;
+
+    if(!nfacct_root.nfacct_metrics) return;
+    struct nfacct_data *d;
+
+    if(!st_packets) {
+        st_packets = rrdset_create_localhost(
+                "netfilter"
+                , "nfacct_packets"
+                , NULL
+                , "nfacct"
+                , NULL
+                , "Netfilter Accounting Packets"
+                , "packets/s"
+                , 3206
+                , nfacct_root.update_every
+                , RRDSET_TYPE_STACKED
+        );
+    }
+    else rrdset_next(st_packets);
+
+    for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
+        if(likely(d->updated)) {
+            if(unlikely(!d->rd_packets))
+                d->rd_packets = rrddim_add(
+                        st_packets
+                        , d->name
+                        , NULL
+                        , 1
+                        , nfacct_root.update_every
+                        , RRD_ALGORITHM_INCREMENTAL
+                );
+
+            rrddim_set_by_pointer(
+                    st_packets
+                    , d->rd_packets
+                    , (collected_number)d->pkts
+            );
+        }
+    }
+
+    rrdset_done(st_packets);
+
+    // ----------------------------------------------------------------
+
+    st_bytes = rrdset_find_bytype_localhost("netfilter", "nfacct_bytes");
+    if(!st_bytes) {
+        st_bytes = rrdset_create_localhost(
+                "netfilter"
+                , "nfacct_bytes"
+                , NULL
+                , "nfacct"
+                , NULL
+                , "Netfilter Accounting Bandwidth"
+                , "kilobytes/s"
+                , 3207
+                , nfacct_root.update_every
+                , RRDSET_TYPE_STACKED
+        );
+    }
+    else rrdset_next(st_bytes);
+
+    for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
+        if(likely(d->updated)) {
+            if(unlikely(!d->rd_bytes))
+                d->rd_bytes = rrddim_add(
+                        st_bytes
+                        , d->name
+                        , NULL
+                        , 1
+                        , 1000 * nfacct_root.update_every
+                        , RRD_ALGORITHM_INCREMENTAL
+                );
+
+            rrddim_set_by_pointer(
+                    st_bytes
+                    , d->rd_bytes
+                    , (collected_number)d->bytes
+            );
+        }
+    }
+
+    rrdset_done(st_bytes);
+}
+
+#endif // HAVE_LIBNETFILTER_ACCT
+#endif // HAVE_LIBMNL
+
+// ----------------------------------------------------------------------------
+
 void *nfacct_main(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
-    info("NFACCT thread created with task id %d", gettid());
+    info("NETFILTER thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("nfacct.plugin: Cannot set pthread cancel type to DEFERRED.");
+        error("NETFILTER: Cannot set pthread cancel type to DEFERRED.");
 
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("nfacct.plugin: Cannot set pthread cancel state to ENABLE.");
+        error("NETFILTER: Cannot set pthread cancel state to ENABLE.");
 
-    nfacct_root.nfacct_buffer = nfacct_alloc();
-    if(!nfacct_root.nfacct_buffer)
-        fatal("nfacct.plugin: nfacct_alloc() failed.");
 
-    char buf[MNL_SOCKET_BUFFER_SIZE];
-    struct mnl_socket *nl = NULL;
-    struct nlmsghdr *nlh = NULL;
-    unsigned int seq = 0, portid = 0;
-
-    seq = (unsigned int)now_realtime_sec() - 1;
-
-    nl  = mnl_socket_open(NETLINK_NETFILTER);
-    if(!nl) {
-        error("nfacct.plugin: mnl_socket_open() failed");
-        goto cleanup;
-    }
-
-    if(mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        error("nfacct.plugin: mnl_socket_bind() failed");
-        goto cleanup;
-    }
-    portid = mnl_socket_get_portid(nl);
-
-    // ------------------------------------------------------------------------
-
-    RRDSET *st_bytes = NULL, *st_packets = NULL;
-
-    // ------------------------------------------------------------------------
-
-    int update_every = (int)config_get_number("plugin:nfacct", "update every", localhost->rrd_update_every);
+    int update_every = (int)config_get_number("plugin:netfilter", "update every", localhost->rrd_update_every);
     if(update_every < localhost->rrd_update_every)
         update_every = localhost->rrd_update_every;
+
+#ifdef DO_NFACCT
+    int nfacct = !nfacct_init(update_every);
+#endif
+
+#ifdef DO_NFSTAT
+    int nfstat = !nfstat_init(update_every);
+#endif
+
+    // ------------------------------------------------------------------------
 
     usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
@@ -123,129 +627,38 @@ void *nfacct_main(void *ptr) {
 
         if(unlikely(netdata_exit)) break;
 
-        seq++;
+#ifdef DO_NFACCT
+        if(likely(nfacct)) {
+            nfacct = !nfacct_collect();
 
-        nlh = nfacct_nlmsg_build_hdr(buf, NFNL_MSG_ACCT_GET, NLM_F_DUMP, (uint32_t)seq);
-        if(!nlh) {
-            error("nfacct.plugin: nfacct_nlmsg_build_hdr() failed");
-            goto cleanup;
+            if(likely(nfacct))
+                nfacct_send_metrics();
         }
+#endif
 
-        if(mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
-            error("nfacct.plugin: mnl_socket_send");
-            goto cleanup;
+#ifdef DO_NFSTAT
+        if(likely(nfstat)) {
+            nfstat = !nfstat_collect();
+
+            if(likely(nfstat))
+                nfstat_send_metrics();
         }
-
-        ssize_t ret;
-        while((ret = mnl_socket_recvfrom(nl, buf, sizeof(buf))) > 0) {
-            if((ret = mnl_cb_run(buf, (size_t)ret, seq, portid, nfacct_callback, NULL)) <= 0) break;
-        }
-
-        if (ret == -1) {
-            error("nfacct.plugin: error communicating with kernel. NFACCT plugin can only work when netdata runs as root.");
-            goto cleanup;
-        }
-
-        // --------------------------------------------------------------------
-
-        if(nfacct_root.nfacct_metrics) {
-            struct nfacct_data *d;
-
-            if(!st_packets) {
-                st_packets = rrdset_create_localhost(
-                        "netfilter"
-                        , "nfacct_packets"
-                        , NULL
-                        , "nfacct"
-                        , NULL
-                        , "Netfilter Accounting Packets"
-                        , "packets/s"
-                        , 3206
-                        , update_every
-                        , RRDSET_TYPE_STACKED
-                );
-            }
-            else rrdset_next(st_packets);
-
-            for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-                if(likely(d->updated)) {
-                    if(unlikely(!d->rd_packets))
-                        d->rd_packets = rrddim_add(
-                                st_packets
-                                , d->name
-                                , NULL
-                                , 1
-                                , update_every
-                                , RRD_ALGORITHM_INCREMENTAL
-                        );
-
-                    rrddim_set_by_pointer(
-                            st_packets
-                            , d->rd_packets
-                            , (collected_number)d->pkts
-                    );
-                }
-            }
-
-            rrdset_done(st_packets);
-
-            // ----------------------------------------------------------------
-
-            st_bytes = rrdset_find_bytype_localhost("netfilter", "nfacct_bytes");
-            if(!st_bytes) {
-                st_bytes = rrdset_create_localhost(
-                        "netfilter"
-                        , "nfacct_bytes"
-                        , NULL
-                        , "nfacct"
-                        , NULL
-                        , "Netfilter Accounting Bandwidth"
-                        , "kilobytes/s"
-                        , 3207
-                        , update_every
-                        , RRDSET_TYPE_STACKED
-                );
-            }
-            else rrdset_next(st_bytes);
-
-            for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-                if(likely(d->updated)) {
-                    if(unlikely(!d->rd_bytes))
-                        d->rd_bytes = rrddim_add(
-                                st_bytes
-                                , d->name
-                                , NULL
-                                , 1
-                                , 1000 * update_every
-                                , RRD_ALGORITHM_INCREMENTAL
-                        );
-
-                    rrddim_set_by_pointer(
-                            st_bytes
-                            , d->rd_bytes
-                            , (collected_number)d->bytes
-                    );
-                }
-            }
-
-            rrdset_done(st_bytes);
-
-
-            // ----------------------------------------------------------------
-            // prepare for the next loop
-
-            for(d = nfacct_root.nfacct_metrics; d ; d = d->next)
-                d->updated = 0;
-        }
+#endif
     }
 
-cleanup:
-    info("NFACCT thread exiting");
+    info("NETFILTER thread exiting");
 
-    if(nl) mnl_socket_close(nl);
+#ifdef DO_NFACCT
+    nfacct_cleanup();
+#endif
+
+#ifdef DO_NFSTAT
+    nfstat_cleanup();
+#endif
 
     static_thread->enabled = 0;
     pthread_exit(NULL);
     return NULL;
 }
-#endif
+
+#endif // INTERNAL_PLUGIN_NFACCT

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -53,6 +53,9 @@ static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {
             error("nfacct.plugin: nfacct_alloc() failed.");
             return MNL_CB_OK;
         }
+
+        if(unlikely(!nfacct_list))
+            nfacct_list_grow();
     }
 
     if(nfacct_nlmsg_parse_payload(nlh, nfacct) < 0) {

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -13,6 +13,9 @@
 #ifdef HAVE_LINUX_NETFILTER_NFNETLINK_CONNTRACK_H
 #define DO_NFSTAT 1
 
+#define RRD_TYPE_NET_STAT_NETFILTER "netfilter"
+#define RRD_TYPE_NET_STAT_CONNTRACK "netlink" // FIXME: should be "conntrack" when merged with the /proc plugin
+
 #include <linux/netfilter/nfnetlink_conntrack.h>
 
 static struct {
@@ -174,9 +177,6 @@ static int nfstat_collect() {
 
     return 0;
 }
-
-#define RRD_TYPE_NET_STAT_NETFILTER "netfilter2"
-#define RRD_TYPE_NET_STAT_CONNTRACK "conntrack2"
 
 static void nfstat_send_metrics() {
 

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -32,10 +32,7 @@ static inline void nfacct_list_grow() {
         info("nfacct.plugin: increasing nfacct_list to size %d", size);
 
         nfacct_list = reallocz(nfacct_list, sizeof(struct nfacct_list) + (sizeof(struct mynfacct) * size));
-
-        nfacct_list->data[len].rd_bytes = NULL;
-        nfacct_list->data[len].rd_packets = NULL;
-        nfacct_list->data[len].updated = 0;
+        memset(&nfacct_list->data[len], 0, sizeof(struct mynfacct));
 
         nfacct_list->size = size;
         nfacct_list->len = len;


### PR DESCRIPTION
The internal nfacct plugin:

1. is now synced with the current development of netdata
2. can collect connection tracker metrics too; fixes #161 

The plugin still requires netdata to be running as root. The next step is to move it away from the netdata daemon to an external plugin, that will be setuid to root.

But in order to do this, it has to be merged with the internal netfilter plugin, so that only one method of netfilter data collection will be used at any time. So, if netlink is available it should be used, otherwise the proc filesystem should be used, but if even this is not available the plugin should stop and exit.
