### PR TITLE
option to change default behavior (enabled/disabled) for python modules

### DIFF
--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -18,9 +18,13 @@ log_interval: 3600
 
 # ----------------------------------------------------------------------
 # Enable / Disable python.d.plugin modules
+#default_run: yes
 #
-# The default for all modules is enabled (yes).
-# Setting any of these to no will disable it.
+# If "default_run" = "yes" the default for all modules is enabled (yes).
+# Setting any of these to "no" will disable it.
+# 
+# If "default_run" = "no" the default for all modules is disabled (no).
+# Setting any of these to "yes" will enable it.
 
 # apache_cache: yes
 # apache: yes

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -86,13 +86,15 @@ if ORDERED:
     def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
         class OrderedLoader(Loader):
             pass
+
         def construct_mapping(loader, node):
-           loader.flatten_mapping(node)
-           return object_pairs_hook(loader.construct_pairs(node))
+            loader.flatten_mapping(node)
+            return object_pairs_hook(loader.construct_pairs(node))
         OrderedLoader.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             construct_mapping)
         return yaml.load(stream, OrderedLoader)
+
 
 class PythonCharts(object):
     """
@@ -103,12 +105,16 @@ class PythonCharts(object):
                  modules=None,
                  modules_path='../python.d/',
                  modules_configs='../conf.d/',
-                 modules_disabled=None):
+                 modules_disabled=None,
+                 modules_enabled=None,
+                 default_run=None):
         """
         :param modules: list
         :param modules_path: str
         :param modules_configs: str
         :param modules_disabled: list
+        :param modules_enabled: list
+        :param default_run: bool
         """
 
         if modules is None:
@@ -121,13 +127,13 @@ class PythonCharts(object):
         self.configs = modules_configs
 
         # load modules
-        loaded_modules = self._load_modules(modules_path, modules, modules_disabled)
+        loaded_modules = self._load_modules(modules_path, modules, modules_disabled, modules_enabled, default_run)
 
         # load configuration files
         configured_modules = self._load_configs(loaded_modules)
 
         # good economy and prosperity:
-        self.jobs = self._create_jobs(configured_modules)  # type: list
+        self.jobs = self._create_jobs(configured_modules)  # type <list>
 
         # enable timetable override like `python.d.plugin mysql debug 1`
         if DEBUG_FLAG and OVERRIDE_UPDATE_EVERY:
@@ -157,7 +163,7 @@ class PythonCharts(object):
             msg.error("Problem loading", name, str(e))
             return None
 
-    def _load_modules(self, path, modules, disabled):
+    def _load_modules(self, path, modules, disabled, enabled, default_run):
         """
         Load modules from 'modules' list or dynamically every file from 'path' (only .chart.py files)
         :param path: str
@@ -183,7 +189,10 @@ class PythonCharts(object):
                     msg.fatal('no modules found.')
         else:
             # scan directory specified in path and load all modules from there
-            names = os.listdir(path)
+            if default_run is False:
+                names = [module for module in os.listdir(path) if module[:-9] in enabled]
+            else:
+                names = os.listdir(path)
             for mod in names:
                 if mod.replace(MODULE_EXTENSION, "") in disabled:
                     msg.error(mod + ": disabled module ", mod.replace(MODULE_EXTENSION, ""))
@@ -369,7 +378,8 @@ class PythonCharts(object):
                         if job.override_name is not None:
                             new_name = job.__module__ + '_' + sub(r'\s+', '_', job.override_name)
                             if new_name in overridden:
-                                msg.info("DROPPED:", job.name, ", job '" + job.override_name + "' is already served by another job.")
+                                msg.info("DROPPED:", job.name, ", job '" + job.override_name +
+                                         "' is already served by another job.")
                                 self._stop(job)
                                 i -= 1
                             else:
@@ -481,7 +491,7 @@ def parse_cmdline(directory, *commands):
         elif cmd == "trace" or cmd == "all":
             TRACE_FLAG = True
         elif os.path.isfile(directory + cmd + ".chart.py") or os.path.isfile(directory + cmd):
-            #DEBUG_FLAG = True
+            # DEBUG_FLAG = True
             mods.append(cmd.replace(".chart.py", ""))
         else:
             try:
@@ -507,6 +517,8 @@ def run():
 
     # read configuration file
     disabled = ['nginx_log', 'gunicorn_log']
+    enabled = list()
+    default_run = True
     configfile = CONFIG_DIR + "python.d.conf"
     msg.PROGRAM = PROGRAM
     msg.info("reading configuration file:", configfile)
@@ -548,12 +560,17 @@ def run():
         except (KeyError, TypeError):
             pass
 
-        for k, v in conf.items():
-            if k in ("update_every", "debug", "enabled"):
-                continue
-            if v is False:
-                disabled.append(k)
+        default_run = True if ('default_run' not in conf or conf.get('default_run')) else False
 
+        for k, v in conf.items():
+            if k in ("update_every", "debug", "enabled", "default_run"):
+                continue
+            if default_run:
+                if v is False:
+                    disabled.append(k)
+            else:
+                if v is True:
+                    enabled.append(k)
     # parse passed command line arguments
     modules = parse_cmdline(MODULES_DIR, *sys.argv)
     msg.DEBUG_FLAG = DEBUG_FLAG
@@ -568,7 +585,7 @@ def run():
              ", ONLY_MODULES=" + str(modules))
 
     # run plugins
-    charts = PythonCharts(modules, MODULES_DIR, CONFIG_DIR + "python.d/", disabled)
+    charts = PythonCharts(modules, MODULES_DIR, CONFIG_DIR + "python.d/", disabled, enabled, default_run)
     charts.check()
     charts.create()
     charts.update()


### PR DESCRIPTION
Before PR all modules were enabled by default. It is a lot of work to enable the ones i need and disable the rest.

default: `default_run = yes `

from python.d.conf

```
# If "default_run" = "yes" the default for all modules is enabled (yes).
# Setting any of these to "no" will disable it.
# 
# If "default_run" = "no" the default for all modules is disabled (no).
# Setting any of these to "yes" will enable it.
```