### PR TITLE
ugly fix to fix compile error on FreeBSD 10.3-RELEASE #0 r297264

### DIFF
--- a/src/freebsd_sysctl.c
+++ b/src/freebsd_sysctl.c
@@ -1,3 +1,4 @@
+#define _IFI_OQDROPS
 #include "common.h"
 
 #include <sys/vmmeter.h>


### PR DESCRIPTION
sys/if.h in FreeBSD 10.3 looks like require _IFI_OQDROPS to be defined to have ifi_oqdrops field in if_data structure, just defined it at the top of the file to get it compiled as a quick hack.