### PR TITLE
enable libvirt cgroups; more command line arguments

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -337,7 +337,7 @@ const char *appconfig_set_default(struct config *root, const char *section, cons
 {
     struct config_option *cv;
 
-    debug(D_CONFIG, "request to set config in section '%s', name '%s', value '%s'", section, name, value);
+    debug(D_CONFIG, "request to set default config in section '%s', name '%s', value '%s'", section, name, value);
 
     struct section *co = appconfig_section_find(root, section);
     if(!co) return appconfig_set(root, section, name, value);
@@ -558,7 +558,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
                 if(only_changed && !changed) continue;
 
                 if(!used) {
-                    buffer_sprintf(wb, "\n# node '%s' is not used.", co->name);
+                    buffer_sprintf(wb, "\n# section '%s' is not used.", co->name);
                 }
 
                 buffer_sprintf(wb, "\n[%s]\n", co->name);

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -56,7 +56,7 @@ extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed
 #define config_get_boolean(section, name, value) appconfig_get_boolean(&netdata_config, section, name, value)
 #define config_get_boolean_ondemand(section, name, value) appconfig_get_boolean_ondemand(&netdata_config, section, name, value)
 
-#define config_set(section, name, default_value) appconfig_get(&netdata_config, section, name, default_value)
+#define config_set(section, name, default_value) appconfig_set(&netdata_config, section, name, default_value)
 #define config_set_default(section, name, value) appconfig_set_default(&netdata_config, section, name, value)
 #define config_set_number(section, name, value) appconfig_set_number(&netdata_config, section, name, value)
 #define config_set_boolean(section, name, value) appconfig_set_boolean(&netdata_config, section, name, value)

--- a/src/main.c
+++ b/src/main.c
@@ -625,6 +625,7 @@ int main(int argc, char **argv) {
                     {
                         char* stacksize_string = "stacksize=";
                         char* debug_flags_string = "debug_flags=";
+
                         if(strcmp(optarg, "unittest") == 0) {
                             default_rrd_update_every = 1;
                             default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
@@ -691,9 +692,36 @@ int main(int argc, char **argv) {
                             config_set(CONFIG_SECTION_GLOBAL, "debug flags",  optarg);
                             debug_flags = strtoull(optarg, NULL, 0);
                         }
+                        else if(strcmp(optarg, "set") == 0) {
+                            if(optind + 3 > argc) {
+                                fprintf(stderr, "%s", "\nUSAGE: -W set 'section' 'key' 'value'\n\n"
+                                        " Overwrites settings of netdata.conf.\n"
+                                        "\n"
+                                );
+                                exit(1);
+                            }
+                            const char *section = argv[optind];
+                            const char *key = argv[optind + 1];
+                            const char *value = argv[optind + 2];
+                            optind += 3;
+
+                            // set this one as the default
+                            // only if it is not already set in the config file
+                            // so the caller can use -c netdata.conf before or
+                            // after this parameter to prevent or allow overwriting
+                            // variables at netdata.conf
+                            config_set_default(section, key,  value);
+
+                            // fprintf(stderr, "SET section '%s', key '%s', value '%s'\n", section, key, value);
+                        }
+                        else {
+                            fprintf(stderr, "Unknown -W parameter '%s'\n", optarg);
+                            help(1);
+                        }
                     }
                     break;
                 default: /* ? */
+                    fprintf(stderr, "Unknown parameter '%c'\n", opt);
                     help(1);
                     break;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -299,6 +299,8 @@ void help(int exitcode) {
             "  -W stacksize=N           Set the stacksize (in bytes).\n\n"
             "  -W debug_flags=N         Set runtime tracing to debug.log.\n\n"
             "  -W unittest              Run internal unittests and exit.\n\n"
+            "  -W set section option value\n"
+            "                           set netdata.conf option from the command line.\n\n"
             "  -W simple-pattern pattern string\n"
             "                           Check if string matches pattern and exit.\n\n"
     );
@@ -696,6 +698,14 @@ int main(int argc, char **argv) {
                             if(optind + 3 > argc) {
                                 fprintf(stderr, "%s", "\nUSAGE: -W set 'section' 'key' 'value'\n\n"
                                         " Overwrites settings of netdata.conf.\n"
+                                        "\n"
+                                        " These options interact with: -c netdata.conf\n"
+                                        " If -c netdata.conf is given on the command line,\n"
+                                        " before -W set... the user may overwrite command\n"
+                                        " line parameters at netdata.conf\n"
+                                        " If -c netdata.conf is given after (or missing)\n"
+                                        " -W set... the user cannot overwrite the command line\n"
+                                        " parameters."
                                         "\n"
                                 );
                                 exit(1);

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -147,11 +147,17 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_patterns = simple_pattern_create(
             config_get("plugin:cgroups", "enable by default cgroups matching",
-                    " /system.slice/docker-*.scope "
-                    " /qemu.slice/*.scope "                // #1949
+            // ----------------------------------------------------------------
+
+                    " !*/init.scope "                      // ignore init.scope
+                    " *.scope "                            // we need all *.scope for sure
+
+            // ----------------------------------------------------------------
+
+                    " !*/vcpu* "                           // libvirtd adds these sub-cgroups
+                    " !*/emulator "                        // libvirtd adds these sub-cgroups
                     " !*.mount "
                     " !*.partition "
-                    " !*.scope "
                     " !*.service "
                     " !*.slice "
                     " !*.swap "
@@ -171,12 +177,14 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_paths = simple_pattern_create(
             config_get("plugin:cgroups", "search for cgroups in subpaths matching",
-                    " !*-qemu "                           //  #345
+                    " !*/init.scope "                      // ignore init.scope
+                    " !*-qemu "                            //  #345
                     " !/init.scope "
                     " !/system "
                     " !/systemd "
                     " !/user "
                     " !/user.slice "
+                    " !*.scope "
                     " * "
             ), SIMPLE_PATTERN_EXACT);
 
@@ -185,13 +193,13 @@ void read_cgroup_plugin_configuration() {
 
     enabled_cgroup_renames = simple_pattern_create(
             config_get("plugin:cgroups", "run script to rename cgroups matching",
-                    " /qemu.slice/*.scope "                // #1949
+                    " *.scope "
                     " *docker* "
                     " *lxc* "
+                    " *qemu* "
                     " !/ "
                     " !*.mount "
                     " !*.partition "
-                    " !*.scope "
                     " !*.service "
                     " !*.slice "
                     " !*.swap "

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -184,7 +184,6 @@ void read_cgroup_plugin_configuration() {
                     " !/systemd "
                     " !/user "
                     " !/user.slice "
-                    " !*.scope "
                     " * "
             ), SIMPLE_PATTERN_EXACT);
 


### PR DESCRIPTION
This PR:

1. explicitly enables all `*.scope` cgroups and disables various libvirt cgroups that are not of general use.

2. adds the command line argument:

```
netdata ... -W set section option value ...
```

   which allows the user to overwrite any `netdata.conf` option, from the command line.
