### PR TITLE
Seems there was a negated sentence in the docs

### DIFF
--- a/conf.d/stream.conf
+++ b/conf.d/stream.conf
@@ -31,7 +31,7 @@
     # The timeout to connect and send metrics
 	timeout seconds = 60
 
-	# If the destination line above does specify a port, use this
+	# If the destination line above does not specify a port, use this
 	default port = 19999
 
 	# The buffer to use for sending metrics.


### PR DESCRIPTION
It doesn't make sense for a "default" to override a "specific" port. So it "must" be the other way around..