### PR TITLE
Enable build and deploy of self-extractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-dist: precise
+dist: trusty
+sudo: true
 #
 # C includes autotools and make by default
 language: c
+services:
+  - docker
 os:
   - linux
   - osx
@@ -33,12 +36,15 @@ before_script:
 script:
    # make release packages
  - fakeroot ./packaging/git-build
+   # make self-extractor
+ - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./makeself/build-x86_64-static.sh; fi
    # test build and installer
  - fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
 #
 # Deploy as required
 after_success:
   - for i in *.tar.*; do md5sum -b $i > $i.md5; sha512sum -b $i > $i.sha; done
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in *.gz.run; do md5sum -b $i > $i.md5; sha512sum -b $i > $i.sha; done; fi
   - ./.travis/deploy-if-have-key
 deploy:
   # Upload results to GitHub (tag only)
@@ -48,7 +54,9 @@ deploy:
       secure: invJ0ZdNOPi9x8JJmFkqSIQMxljkLROwgRFCbmXMausJ0rA4E/PgLtM7ddWrHlu6lu8N9e5Pus4bG8DWATHbY0blMUhL5C82S5KK4mxAANLCLgTV8Qr7dMWnMqRV/OJBMGM1ZWpC2AA5GVhPLF7Z++54iqK+LM8P0EuOTAKbebIWCIkGybbSpXj+jJqaQXY0tLGSn5fXPFfyV3Tw0URJPcO3Uz5iukELngkLVSve2d0XYwy8M5tpLKHJi5bzc9CwcJZ/JK1WvklqmV3fNdSSzZunaAfDwWosV3hO7QcGnAVEbNl0HBKZJ8JkriV2fDbH4fttoSvLO2tW9HauP7Yf5XqLDudqUj4gPTuGzd31vRb9kx9cAulfE9onMAmDbjbne8Cp2Bq9/yBEqaofqEIaRcLgnlZSNc+PWbH4FQJ6fIOs5nfqLJo0G+3isgRWrqxp/rjILOvbIGbfLkbPl9aV09IvzShyW2lK7E+QOP0TZIwyXGT0NW0Rr/eyzuMXooy8wi9NehKfrxIcUr7784nU2E+EtItrhtTkJpK8XBBh16swn7s2sQ89qx9PYd/wE5qnKfG0yy3SSc2ycKzEpH7Cy3E6lC4Jytw0AM1Mc179WASBhlR2tyElkRcuhlqOFlJ/6iXjp3kqSgW4kvWbwHwT6VsyiDRhf+Ir4XILFBJ26Z8=
     skip_cleanup: true
     file_glob: true
-    file: "netdata*.tar.*"
+    file:
+      - "netdata*.tar.*"
+      - "netdata*.gz.run*"
     on:
       condition: $CC = gcc && $TRAVIS_OS_NAME = linux
       repo: firehol/netdata

--- a/.travis/deploy-if-have-key
+++ b/.travis/deploy-if-have-key
@@ -32,6 +32,12 @@ then
   exit 0
 fi
 
+if [ "$TRAVIS_OS_NAME" != "linux" ]
+then
+  echo "Building non-linux version - skipping deployment to website"
+  exit 0
+fi
+
 if [ "$CC" != "gcc" ]
 then
   echo "Building non-gcc version - skipping deployment to website"
@@ -41,4 +47,5 @@ fi
 ssh-keyscan -H firehol.org >> ~/.ssh/known_hosts
 ssh travis@firehol.org mkdir -p uploads/netdata/$TRAVIS_BRANCH/
 scp -p *.tar.* travis@firehol.org:uploads/netdata/$TRAVIS_BRANCH/
+scp -p *.gz.run* travis@firehol.org:uploads/netdata/$TRAVIS_BRANCH/
 ssh travis@firehol.org touch uploads/netdata/$TRAVIS_BRANCH/complete.txt


### PR DESCRIPTION
Requires full virtualisation (sudo) and docker (which requires trusty)

Make sure we include checksums for binary.

Make sure we only deploy one type of "nightly" build (MacOS one has been sometimes overwriting the linux one and messing up the checksums).

I think this is ready for merging. When you do, all subsequent builds should be being pushed here, including the self-extractor:

* http://firehol.org/download/netdata/unsigned/master/

This was already in place, but I forgot. In theory the release should also publish the extra files to github but I don't know how to test this, other than create a tag.

I propose that you create a -rc.1 or similar before the next final release: this will prove the process and give us a chance to fix things if necessary. It will also show if the draft mechanism works as expected.