### PR TITLE
delete files of obsoleted charts, from disk

### DIFF
--- a/makeself/jobs/50-bash-4.4.install.sh
+++ b/makeself/jobs/50-bash-4.4.install.sh
@@ -44,3 +44,4 @@ EOF
 
 run make install
 
+run strip ${NETDATA_INSTALL_PATH}/bin/bash

--- a/makeself/jobs/50-curl-7.53.1.install.sh
+++ b/makeself/jobs/50-curl-7.53.1.install.sh
@@ -26,3 +26,5 @@ run sed -i -e "s/curl_LDFLAGS =/curl_LDFLAGS = -all-static/" src/Makefile
 run make clean
 run make -j${PROCESSORS}
 run make install
+
+run strip ${NETDATA_INSTALL_PATH}/bin/curl

--- a/makeself/jobs/50-fping-3.16.install.sh
+++ b/makeself/jobs/50-fping-3.16.install.sh
@@ -24,3 +24,5 @@ run make clean
 run make -j${PROCESSORS}
 run make install
 
+run strip ${NETDATA_INSTALL_PATH}/bin/fping
+run strip ${NETDATA_INSTALL_PATH}/bin/fping6

--- a/makeself/jobs/70-netdata-git.install.sh
+++ b/makeself/jobs/70-netdata-git.install.sh
@@ -11,3 +11,6 @@ run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
     --dont-start-it \
     ${NULL}
 
+run strip ${NETDATA_INSTALL_PATH}/bin/netdata
+run strip ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/apps.plugin
+

--- a/src/common.c
+++ b/src/common.c
@@ -1228,3 +1228,45 @@ unsigned long end_tsc(void) {
     return (((unsigned long)d << 32) | (unsigned long)a) - tsc;
 }
 */
+
+int recursively_delete_dir(const char *path, const char *reason) {
+    DIR *dir = opendir(path);
+    if(!dir) {
+        error("Cannot read %s directory to be deleted '%s'", reason?reason:"", path);
+        return -1;
+    }
+
+    int ret = 0;
+    struct dirent *de = NULL;
+    while((de = readdir(dir))) {
+        if(de->d_type == DT_DIR
+           && (
+                   (de->d_name[0] == '.' && de->d_name[1] == '\0')
+                   || (de->d_name[0] == '.' && de->d_name[1] == '.' && de->d_name[2] == '\0')
+           ))
+            continue;
+
+        char fullpath[FILENAME_MAX + 1];
+        snprintfz(fullpath, FILENAME_MAX, "%s/%s", path, de->d_name);
+
+        if(de->d_type == DT_DIR) {
+            int r = recursively_delete_dir(fullpath, reason);
+            if(r > 0) ret += r;
+            continue;
+        }
+
+        info("Deleting %s file '%s'", reason?reason:"", fullpath);
+        if(unlikely(unlink(fullpath) == -1))
+            error("Cannot delete %s file '%s'", reason?reason:"", fullpath);
+        else
+            ret++;
+    }
+
+    info("Deleting empty directory '%s'", path);
+    if(unlikely(rmdir(path) == -1))
+        error("Cannot delete empty directory '%s'", path);
+    else
+        ret++;
+
+    return ret;
+}

--- a/src/common.h
+++ b/src/common.h
@@ -289,6 +289,8 @@ extern pid_t get_system_pid_max(void);
 extern unsigned int hz;
 extern void get_system_HZ(void);
 
+extern int recursively_delete_dir(const char *path, const char *reason);
+
 extern volatile sig_atomic_t netdata_exit;
 extern const char *os_type;
 

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -233,10 +233,6 @@ void rrddim_free(RRDSET *st, RRDDIM *rd)
 
     switch(rd->rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
-            debug(D_RRD_CALLS, "Saving dimension '%s' to '%s'.", rd->name, rd->cache_filename);
-            savememory(rd->cache_filename, rd, rd->memsize);
-            // continue to map mode - no break;
-
         case RRD_MEMORY_MODE_MAP:
             debug(D_RRD_CALLS, "Unmapping dimension '%s'.", rd->name);
             freez((void *)rd->id);

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -539,6 +539,8 @@ void rrdhost_delete(RRDHOST *host) {
         rrdset_unlock(st);
     }
 
+    recursively_delete_dir(host->cache_dir, "left over host");
+
     rrdhost_unlock(host);
 }
 


### PR DESCRIPTION
fixes #1358 

There were 2 issues:

1. files were deleted, but a few of them were re-created during cleanup.
2. chart and host directories were not deleted.

both are fixed now.