### PR TITLE
SPEC: Update source url.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -80,7 +80,7 @@ Version:	@PACKAGE_RPM_VERSION@
 Release:	1%{?dist}
 License:	GPLv3+
 Group:		Applications/System
-Source0:	https://firehol.org/download/netdata/releases/v@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.xz
+Source0:	https://github.com/firehol/%{name}/releases/download/v@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.xz
 URL:		http://my-netdata.io
 BuildRequires:	pkgconfig
 BuildRequires:	xz


### PR DESCRIPTION
Try build 1.6.0 release.

```shell
[k0ste@rpmshit SPECS]$ spectool -g -R netdata.spec                                                                                                        
Getting https://firehol.org/download/netdata/releases/v1.6.0/netdata-1.6.0.tar.xz to /home/k0ste/rpmbuild/SOURCES/netdata-1.6.0.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
```

Change upstream to github (hope macros works fine after build).