### PR TITLE
dashboard number formatting compatibility and performance improvements

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -894,7 +894,7 @@ var NETDATA = window.NETDATA || {};
                 s = "";
             }
 
-            console.log('NumberFormat: ', s);
+            // console.log('NumberFormat: ', s);
             return (s == e1 || s == e2);
         },
 
@@ -914,22 +914,22 @@ var NETDATA = window.NETDATA || {};
                 s = "";
             }
 
-            console.log('localeString: ', s);
+            // console.log('localeString: ', s);
             return (s == e1 || s == e2);
         },
 
         // on first run we decide which formatter to use
         get: function(min, max) {
             if(this.testIntlNumberFormat()) {
-                console.log('numberformat');
+                // console.log('numberformat');
                 this.get = this.getIntlNumberFormat;
             }
             else if(this.testLocaleString()) {
-                console.log('localestring');
+                // console.log('localestring');
                 this.get = this.getLocaleString;
             }
             else {
-                console.log('fixed');
+                // console.log('fixed');
                 this.get = this.getFixed;
             }
             return this.get(min, max);

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -737,10 +737,11 @@ var NETDATA = window.NETDATA || {};
     // fast numbers formating
 
     NETDATA.fastNumberFormat = {
+        numberFormatWorks: undefined,
         formatters_fixed: [],
         formatters_zero_based: [],
 
-        get: function(min, max) {
+        getIntlNumberFormat: function(min, max) {
             var key = max;
             if(min == max) {
                 if(typeof this.formatters_fixed[key] == 'undefined')
@@ -783,6 +784,69 @@ var NETDATA = window.NETDATA || {};
                     maximumFractionDigits: max
                 });
             }
+        },
+
+        getLocaleString: function(min, max) {
+            var key = max;
+            if(min == max) {
+                if(typeof this.formatters_fixed[key] == 'undefined')
+                    this.formatters_fixed[key] = {
+                        format: function (value) {
+                            return value.toLocaleString(undefined, {
+                                // style: 'decimal',
+                                // minimumIntegerDigits: 1,
+                                // minimumSignificantDigits: 1,
+                                // maximumSignificantDigits: 1,
+                                useGrouping: true,
+                                minimumFractionDigits: min,
+                                maximumFractionDigits: max
+                            });
+                        }
+                    };
+
+                return this.formatters_fixed[key];
+            }
+            else if(min == 0) {
+                if(typeof this.formatters_zero_based[key] == 'undefined')
+                    this.formatters_zero_based[key] = {
+                        format: function (value) {
+                            return value.toLocaleString(undefined, {
+                                // style: 'decimal',
+                                // minimumIntegerDigits: 1,
+                                // minimumSignificantDigits: 1,
+                                // maximumSignificantDigits: 1,
+                                useGrouping: true,
+                                minimumFractionDigits: min,
+                                maximumFractionDigits: max
+                            });
+                        }
+                    };
+
+                return this.formatters_zero_based[key];
+            }
+            else {
+                return {
+                    format: function (value) {
+                        return value.toLocaleString(undefined, {
+                            // style: 'decimal',
+                            // minimumIntegerDigits: 1,
+                            // minimumSignificantDigits: 1,
+                            // maximumSignificantDigits: 1,
+                            useGrouping: true,
+                            minimumFractionDigits: min,
+                            maximumFractionDigits: max
+                        });
+                    }
+                };
+            }
+        },
+
+        get: function(min, max) {
+            //console.log('numberformat');
+            //this.get = this.getIntlNumberFormat;
+            console.log('localestring');
+            this.get = this.getLocaleString;
+            return this.get(min, max);
         }
     };
 

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -841,11 +841,37 @@ var NETDATA = window.NETDATA || {};
             }
         },
 
+        testIntlNumberFormat: function() {
+            var n = 1.12345;
+            var e1 = "1.12", e2 = "1,12";
+            var s = "";
+
+            try {
+                var x = new Intl.NumberFormat(undefined, {
+                    useGrouping: true,
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                });
+
+                s = x.format(n);
+            }
+            catch(e) {
+                s = "";
+            }
+
+            console.log(s);
+            return (s == e1 || s == e2);
+        },
+
         get: function(min, max) {
-            //console.log('numberformat');
-            //this.get = this.getIntlNumberFormat;
-            console.log('localestring');
-            this.get = this.getLocaleString;
+            if(this.testIntlNumberFormat()) {
+                console.log('numberformat');
+                this.get = this.getIntlNumberFormat;
+            }
+            else {
+                console.log('localestring');
+                this.get = this.getLocaleString;
+            }
             return this.get(min, max);
         }
     };

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -743,8 +743,8 @@ var NETDATA = window.NETDATA || {};
         // this is the fastest and the preferred
         getIntlNumberFormat: function(min, max) {
             var key = max;
-            if(min == max) {
-                if(typeof this.formatters_fixed[key] == 'undefined')
+            if(min === max) {
+                if(typeof this.formatters_fixed[key] === 'undefined')
                     this.formatters_fixed[key] = new Intl.NumberFormat(undefined, {
                         // style: 'decimal',
                         // minimumIntegerDigits: 1,
@@ -757,8 +757,8 @@ var NETDATA = window.NETDATA || {};
 
                 return this.formatters_fixed[key];
             }
-            else if(min == 0) {
-                if(typeof this.formatters_zero_based[key] == 'undefined')
+            else if(min === 0) {
+                if(typeof this.formatters_zero_based[key] === 'undefined')
                     this.formatters_zero_based[key] = new Intl.NumberFormat(undefined, {
                         // style: 'decimal',
                         // minimumIntegerDigits: 1,
@@ -789,8 +789,8 @@ var NETDATA = window.NETDATA || {};
         // this respects locale
         getLocaleString: function(min, max) {
             var key = max;
-            if(min == max) {
-                if(typeof this.formatters_fixed[key] == 'undefined')
+            if(min === max) {
+                if(typeof this.formatters_fixed[key] === 'undefined')
                     this.formatters_fixed[key] = {
                         format: function (value) {
                             return value.toLocaleString(undefined, {
@@ -807,8 +807,8 @@ var NETDATA = window.NETDATA || {};
 
                 return this.formatters_fixed[key];
             }
-            else if(min == 0) {
-                if(typeof this.formatters_zero_based[key] == 'undefined')
+            else if(min === 0) {
+                if(typeof this.formatters_zero_based[key] === 'undefined')
                     this.formatters_zero_based[key] = {
                         format: function (value) {
                             return value.toLocaleString(undefined, {
@@ -844,8 +844,8 @@ var NETDATA = window.NETDATA || {};
 
         getFixed: function(min, max) {
             var key = max;
-            if(min == max) {
-                if(typeof this.formatters_fixed[key] == 'undefined')
+            if(min === max) {
+                if(typeof this.formatters_fixed[key] === 'undefined')
                     this.formatters_fixed[key] = {
                         format: function (value) {
                             if(value === 0) return "0";
@@ -855,8 +855,8 @@ var NETDATA = window.NETDATA || {};
 
                 return this.formatters_fixed[key];
             }
-            else if(min == 0) {
-                if(typeof this.formatters_zero_based[key] == 'undefined')
+            else if(min === 0) {
+                if(typeof this.formatters_zero_based[key] === 'undefined')
                     this.formatters_zero_based[key] = {
                         format: function (value) {
                             if(value === 0) return "0";
@@ -895,7 +895,7 @@ var NETDATA = window.NETDATA || {};
             }
 
             // console.log('NumberFormat: ', s);
-            return (s == e1 || s == e2);
+            return (s === e1 || s === e2);
         },
 
         testLocaleString: function() {
@@ -915,7 +915,7 @@ var NETDATA = window.NETDATA || {};
             }
 
             // console.log('localeString: ', s);
-            return (s == e1 || s == e2);
+            return (s === e1 || s === e2);
         },
 
         // on first run we decide which formatter to use
@@ -2485,7 +2485,7 @@ var NETDATA = window.NETDATA || {};
                 else                  __legendFormatValueChartDecimals = 4;
             }
 
-            if(__legendFormatValueChartDecimals != old) {
+            if(__legendFormatValueChartDecimals !== old) {
                 if(__legendFormatValueChartDecimals < 0)
                     __intlNumberFormat = null;
                 else

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170419-5"></script>
+<script type="text/javascript" src="dashboard.js?v20170419-6"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170419-2"></script>
+<script type="text/javascript" src="dashboard.js?v20170419-3"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170402-1"></script>
+<script type="text/javascript" src="dashboard.js?v20170419-1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170419-1"></script>
+<script type="text/javascript" src="dashboard.js?v20170419-2"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170419-3"></script>
+<script type="text/javascript" src="dashboard.js?v20170419-5"></script>


### PR DESCRIPTION
fixes #2103 


netdata now has 3 implementations for formating values:

1. Using `Intl.NumberFormat()` - I just added this, it is the fastest of all.
2. Using `Number.toLocaleString()` - the one used before, which gives wrong decimal points on older systems (like Safari 8, and I guess javaFX webview).
3. Using `Number.toFixed()` - which should work everywhere, but it is not locale aware. That is, no thousands seperators.

netdata will prefer them in the above order. It tests them to find if they work as expected (i.e. providing the right number of fractional digits) or not.
