### PR TITLE
Adding amzn-2017.03 to install_non_systemd_init

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -422,6 +422,7 @@ install_non_systemd_init() {
             return 0
 
         elif [ "${key}" = "amzn-2016.09" \
+            -o "${key}" = "amzn-2017.03" \
             -o "${key}" = "CentOS release 6.6 (Final)" \
             -o "${key}" = "CentOS release 6.8 (Final)" \
             ]

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -420,12 +420,7 @@ install_non_systemd_init() {
             run update-rc.d netdata defaults && \
             run update-rc.d netdata enable && \
             return 0
-
-        elif [ "${key}" = "amzn-2016.09" \
-            -o "${key}" = "amzn-2017.03" \
-            -o "${key}" = "CentOS release 6.6 (Final)" \
-            -o "${key}" = "CentOS release 6.8 (Final)" \
-            ]
+        elif [[ "${key}" =~ ^(amzn-201[567]|CentOS release 6).* ]]
             then
             echo >&2 "Installing init.d file..."
             run cp system/netdata-init-d /etc/init.d/netdata && \


### PR DESCRIPTION
Current version of Amazon Linux is 2017.03 which is not handled by install_non_systemd_init so init scripts are not copied into place - just adding the version to install_non_systemd_init, would be easier with regex but that would be a bit more refactoring to use double braces in the test statement.