### PR TITLE
various timing improvements; new idlejitter plugin; fixed color palette management

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2878,24 +2878,24 @@ static void normalize_utilization(struct target *root) {
 }
 #endif // ALL_PIDS_ARE_READ_INSTANTLY
 
-static void send_collected_data_to_netdata(struct target *root, const char *type, usec_t usec) {
+static void send_collected_data_to_netdata(struct target *root, const char *type, usec_t dt) {
     struct target *w;
 
-    send_BEGIN(type, "cpu", usec);
+    send_BEGIN(type, "cpu", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (kernel_uint_t)(w->utime * utime_fix_ratio) + (kernel_uint_t)(w->stime * stime_fix_ratio) + (kernel_uint_t)(w->gtime * gtime_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cutime * cutime_fix_ratio) + (kernel_uint_t)(w->cstime * cstime_fix_ratio) + (kernel_uint_t)(w->cgtime * cgtime_fix_ratio)):0ULL));
     }
     send_END();
 
-    send_BEGIN(type, "cpu_user", usec);
+    send_BEGIN(type, "cpu_user", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (kernel_uint_t)(w->utime * utime_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cutime * cutime_fix_ratio)):0ULL));
     }
     send_END();
 
-    send_BEGIN(type, "cpu_system", usec);
+    send_BEGIN(type, "cpu_system", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (kernel_uint_t)(w->stime * stime_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cstime * cstime_fix_ratio)):0ULL));
@@ -2903,7 +2903,7 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
     send_END();
 
     if(show_guest_time) {
-        send_BEGIN(type, "cpu_guest", usec);
+        send_BEGIN(type, "cpu_guest", dt);
         for (w = root; w ; w = w->next) {
             if(unlikely(w->exposed))
                 send_SET(w->name, (kernel_uint_t)(w->gtime * gtime_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cgtime * cgtime_fix_ratio)):0ULL));
@@ -2911,42 +2911,42 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
         send_END();
     }
 
-    send_BEGIN(type, "threads", usec);
+    send_BEGIN(type, "threads", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->num_threads);
     }
     send_END();
 
-    send_BEGIN(type, "processes", usec);
+    send_BEGIN(type, "processes", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->processes);
     }
     send_END();
 
-    send_BEGIN(type, "mem", usec);
+    send_BEGIN(type, "mem", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (w->statm_resident > w->statm_share)?(w->statm_resident - w->statm_share):0ULL);
     }
     send_END();
 
-    send_BEGIN(type, "vmem", usec);
+    send_BEGIN(type, "vmem", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->statm_size);
     }
     send_END();
 
-    send_BEGIN(type, "minor_faults", usec);
+    send_BEGIN(type, "minor_faults", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (kernel_uint_t)(w->minflt * minflt_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cminflt * cminflt_fix_ratio)):0ULL));
     }
     send_END();
 
-    send_BEGIN(type, "major_faults", usec);
+    send_BEGIN(type, "major_faults", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, (kernel_uint_t)(w->majflt * majflt_fix_ratio) + (include_exited_childs?((kernel_uint_t)(w->cmajflt * cmajflt_fix_ratio)):0ULL));
@@ -2954,14 +2954,14 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
     send_END();
 
 #ifndef __FreeBSD__
-    send_BEGIN(type, "lreads", usec);
+    send_BEGIN(type, "lreads", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->io_logical_bytes_read);
     }
     send_END();
 
-    send_BEGIN(type, "lwrites", usec);
+    send_BEGIN(type, "lwrites", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->io_logical_bytes_written);
@@ -2969,14 +2969,14 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
     send_END();
 #endif
 
-    send_BEGIN(type, "preads", usec);
+    send_BEGIN(type, "preads", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->io_storage_bytes_read);
     }
     send_END();
 
-    send_BEGIN(type, "pwrites", usec);
+    send_BEGIN(type, "pwrites", dt);
     for (w = root; w ; w = w->next) {
         if(unlikely(w->exposed))
             send_SET(w->name, w->io_storage_bytes_written);
@@ -2984,21 +2984,21 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
     send_END();
 
     if(enable_file_charts) {
-        send_BEGIN(type, "files", usec);
+        send_BEGIN(type, "files", dt);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed))
                 send_SET(w->name, w->openfiles);
         }
         send_END();
 
-        send_BEGIN(type, "sockets", usec);
+        send_BEGIN(type, "sockets", dt);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed))
                 send_SET(w->name, w->opensockets);
         }
         send_END();
 
-        send_BEGIN(type, "pipes", usec);
+        send_BEGIN(type, "pipes", dt);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed))
                 send_SET(w->name, w->openpipes);
@@ -3469,7 +3469,6 @@ int main(int argc, char **argv) {
         normalize_utilization(apps_groups_root_target);
 
         send_resource_usage_to_netdata(dt);
-        if(global_iterations_counter == 1) dt = 0;
 
         // this is smart enough to show only newly added apps, when needed
         send_charts_updates_to_netdata(apps_groups_root_target, "apps", "Apps");

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -2599,14 +2599,13 @@ static inline void send_END(void) {
     fprintf(stdout, "END\n");
 }
 
-static usec_t send_resource_usage_to_netdata() {
+void send_resource_usage_to_netdata(usec_t dt) {
     static struct timeval last = { 0, 0 };
     static struct rusage me_last;
 
     struct timeval now;
     struct rusage me;
 
-    usec_t usec;
     usec_t cpuuser;
     usec_t cpusyst;
 
@@ -2614,10 +2613,6 @@ static usec_t send_resource_usage_to_netdata() {
         now_monotonic_timeval(&last);
         getrusage(RUSAGE_SELF, &me_last);
 
-        // the first time, give a zero to allow
-        // netdata calibrate to the current time
-        // usec = update_every * USEC_PER_SEC;
-        usec = 0ULL;
         cpuuser = 0;
         cpusyst = 0;
     }
@@ -2625,7 +2620,6 @@ static usec_t send_resource_usage_to_netdata() {
         now_monotonic_timeval(&now);
         getrusage(RUSAGE_SELF, &me);
 
-        usec = dt_usec(&now, &last);
         cpuuser = me.ru_utime.tv_sec * USEC_PER_SEC + me.ru_utime.tv_usec;
         cpusyst = me.ru_stime.tv_sec * USEC_PER_SEC + me.ru_stime.tv_usec;
 
@@ -2684,10 +2678,10 @@ static usec_t send_resource_usage_to_netdata() {
         "SET targets = %zu\n"
         "SET new_pids = %zu\n"
         "END\n"
-        , usec
+        , dt
         , cpuuser
         , cpusyst
-        , usec
+        , dt
         , calls_counter
         , file_counter
         , all_pids_count
@@ -2705,7 +2699,7 @@ static usec_t send_resource_usage_to_netdata() {
             "SET minflt = %u\n"
             "SET majflt = %u\n"
             "END\n"
-            , usec
+            , dt
             , (unsigned int)(utime_fix_ratio   * 100 * RATES_DETAIL)
             , (unsigned int)(stime_fix_ratio   * 100 * RATES_DETAIL)
             , (unsigned int)(gtime_fix_ratio   * 100 * RATES_DETAIL)
@@ -2722,7 +2716,7 @@ static usec_t send_resource_usage_to_netdata() {
             "SET cminflt = %u\n"
             "SET cmajflt = %u\n"
             "END\n"
-            , usec
+            , dt
             , (unsigned int)(cutime_fix_ratio  * 100 * RATES_DETAIL)
             , (unsigned int)(cstime_fix_ratio  * 100 * RATES_DETAIL)
             , (unsigned int)(cgtime_fix_ratio  * 100 * RATES_DETAIL)
@@ -2730,8 +2724,6 @@ static usec_t send_resource_usage_to_netdata() {
             , (unsigned int)(cmajflt_fix_ratio * 100 * RATES_DETAIL)
             );
 #endif
-
-    return usec;
 }
 
 #if (ALL_PIDS_ARE_READ_INSTANTLY == 0)
@@ -3462,8 +3454,9 @@ int main(int argc, char **argv) {
         static int profiling_count=0;
         profiling_count++;
         if(unlikely(profiling_count > 1000)) exit(0);
+        usec_t dt = update_every * USEC_PER_SEC;
 #else
-        heartbeat_next(&hb, step);
+        usec_t dt = heartbeat_next(&hb, step);
 #endif
 
         if(!collect_data_for_all_processes()) {
@@ -3475,7 +3468,8 @@ int main(int argc, char **argv) {
         calculate_netdata_statistics();
         normalize_utilization(apps_groups_root_target);
 
-        usec_t dt = send_resource_usage_to_netdata();
+        send_resource_usage_to_netdata(dt);
+        if(global_iterations_counter == 1) dt = 0;
 
         // this is smart enough to show only newly added apps, when needed
         send_charts_updates_to_netdata(apps_groups_root_target, "apps", "Apps");

--- a/src/clocks.c
+++ b/src/clocks.c
@@ -115,8 +115,8 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick)
     if(likely(*hb != 0ULL)) {
         usec_t dt = now - *hb;
         *hb = now;
-        if(unlikely(dt / tick > 1))
-            error("heartbeat missed between %llu usec and %llu usec", *hb, now);
+        if(unlikely(dt >= tick + tick / 2))
+            error("heartbeat missed %llu microseconds", dt - tick);
         return dt;
     }
     else {

--- a/src/clocks.h
+++ b/src/clocks.h
@@ -55,6 +55,8 @@ typedef usec_t heartbeat_t;
 #define USEC_PER_SEC    1000000ULL
 #define MSEC_PER_SEC    1000ULL
 
+#define USEC_PER_MS     1000ULL
+
 #ifndef HAVE_CLOCK_GETTIME
 /* Fallback function for POSIX.1-2001 clock_gettime() function.
  *

--- a/src/health.c
+++ b/src/health.c
@@ -356,8 +356,15 @@ void *health_main(void *ptr) {
 
         // detect if boottime and realtime have twice the difference
         // in which case we assume the system was just waken from hibernation
-        if(unlikely(now - last_now > 2 * (now_boottime - last_now_boottime)))
+        if(unlikely(now - last_now > 2 * (now_boottime - last_now_boottime))) {
             apply_hibernation_delay = 1;
+
+            info("Postponing alarm checks for %ld seconds, due to boottime discrepancy (realtime dt: %ld, boottime dt: %ld)."
+            , hibernation_delay
+            , (long)(now - last_now)
+            , (long)(now_boottime - last_now_boottime)
+            );
+        }
 
         last_now = now;
         last_now_boottime = now_boottime;
@@ -374,11 +381,9 @@ void *health_main(void *ptr) {
 
             if(unlikely(apply_hibernation_delay)) {
 
-                info("Postponing alarm checks for %ld seconds, on host '%s', due to boottime discrepancy (realtime dt: %ld, boottime dt: %ld)."
+                info("Postponing alarm checks for %ld seconds, on host '%s'."
                      , hibernation_delay
                      , host->hostname
-                     , (long)(now - last_now)
-                     , (long)(now_boottime - last_now_boottime)
                 );
 
                 host->health_delay_up_to = now + hibernation_delay;

--- a/src/main.c
+++ b/src/main.c
@@ -920,7 +920,7 @@ int main(int argc, char **argv) {
         web_server_threading_selection();
 
         if(web_server_mode != WEB_SERVER_MODE_NONE)
-            create_api_listen_sockets();
+            api_listen_sockets_setup();
     }
 
     // initialize the log files

--- a/src/main.c
+++ b/src/main.c
@@ -920,7 +920,7 @@ int main(int argc, char **argv) {
         web_server_threading_selection();
 
         if(web_server_mode != WEB_SERVER_MODE_NONE)
-            create_listen_sockets();
+            create_api_listen_sockets();
     }
 
     // initialize the log files

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -259,7 +259,7 @@ int rrddim_hide(RRDSET *st, const char *id) {
 
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s).", id, st->name, st->id);
+        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, st->rrdhost->hostname);
         return 1;
     }
 
@@ -272,7 +272,7 @@ int rrddim_unhide(RRDSET *st, const char *id) {
 
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s).", id, st->name, st->id);
+        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, st->rrdhost->hostname);
         return 1;
     }
 
@@ -301,7 +301,7 @@ inline collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_
 collected_number rrddim_set(RRDSET *st, const char *id, collected_number value) {
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s).", id, st->name, st->id);
+        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, st->rrdhost->hostname);
         return 0;
     }
 

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -309,7 +309,7 @@ RRDHOST *rrdhost_find_or_create(
         if(host->rrd_update_every != update_every)
             error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds.", host->hostname, host->rrd_update_every, update_every);
 
-        if(host->rrd_history_entries != history)
+        if(host->rrd_history_entries < history)
             error("Host '%s' has history of %ld entries, but the wanted one is %ld entries.", host->hostname, host->rrd_history_entries, history);
 
         if(host->rrd_memory_mode != mode)
@@ -502,7 +502,7 @@ void rrdhost_free_all(void) {
 void rrdhost_save(RRDHOST *host) {
     if(!host) return;
 
-    info("Saving database of host '%s'...", host->hostname);
+    info("Saving/Closing database of host '%s'...", host->hostname);
 
     RRDSET *st;
 

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -57,7 +57,7 @@ int rrdpush_init() {
 // to its current clock, we send for this many
 // iterations a BEGIN line without microseconds
 // this is for the first iterations of each chart
-static unsigned int remote_clock_resync_iterations = 60;
+unsigned int remote_clock_resync_iterations = 60;
 
 #define rrdpush_lock(host) netdata_mutex_lock(&((host)->rrdpush_mutex))
 #define rrdpush_unlock(host) netdata_mutex_unlock(&((host)->rrdpush_mutex))

--- a/src/rrdpush.h
+++ b/src/rrdpush.h
@@ -4,6 +4,7 @@
 extern int default_rrdpush_enabled;
 extern char *default_rrdpush_destination;
 extern char *default_rrdpush_api_key;
+extern unsigned int remote_clock_resync_iterations;
 
 extern int rrdpush_init();
 extern void rrdset_done_push(RRDSET *st);

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,328 @@
 #include "common.h"
 
+// --------------------------------------------------------------------------------------------------------------------
+// listening sockets
+
+int create_listen_socket4(int socktype, const char *ip, int port, int listen_backlog) {
+    int sock;
+    int sockopt = 1;
+
+    debug(D_LISTENER, "IPv4 creating new listening socket on ip '%s' port %d", ip, port);
+
+    sock = socket(AF_INET, socktype, 0);
+    if(sock < 0) {
+        error("IPv4 socket() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    /* avoid "address already in use" */
+    if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void*)&sockopt, sizeof(sockopt)) != 0)
+        error("Cannot set SO_REUSEADDR on ip '%s' port's %d.", ip, port);
+
+    struct sockaddr_in name;
+    memset(&name, 0, sizeof(struct sockaddr_in));
+    name.sin_family = AF_INET;
+    name.sin_port = htons (port);
+
+    int ret = inet_pton(AF_INET, ip, (void *)&name.sin_addr.s_addr);
+    if(ret != 1) {
+        error("Failed to convert IP '%s' to a valid IPv4 address.", ip);
+        close(sock);
+        return -1;
+    }
+
+    if(bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
+        close(sock);
+        error("IPv4 bind() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    if(listen(sock, listen_backlog) < 0) {
+        close(sock);
+        error("IPv4 listen() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    debug(D_LISTENER, "Listening on IPv4 ip '%s' port %d", ip, port);
+    return sock;
+}
+
+int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int port, int listen_backlog) {
+    int sock = -1;
+    int sockopt = 1;
+    int ipv6only = 1;
+
+    debug(D_LISTENER, "IPv6 creating new listening socket on ip '%s' port %d", ip, port);
+
+    sock = socket(AF_INET6, socktype, 0);
+    if (sock < 0) {
+        error("IPv6 socket() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    /* avoid "address already in use" */
+    if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void*)&sockopt, sizeof(sockopt)) != 0)
+        error("Cannot set SO_REUSEADDR on ip '%s' port's %d.", ip, port);
+
+    /* IPv6 only */
+    if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&ipv6only, sizeof(ipv6only)) != 0)
+        error("Cannot set IPV6_V6ONLY on ip '%s' port's %d.", ip, port);
+
+    struct sockaddr_in6 name;
+    memset(&name, 0, sizeof(struct sockaddr_in6));
+    name.sin6_family = AF_INET6;
+    name.sin6_port = htons ((uint16_t) port);
+    name.sin6_scope_id = scope_id;
+
+    int ret = inet_pton(AF_INET6, ip, (void *)&name.sin6_addr.s6_addr);
+    if(ret != 1) {
+        error("Failed to convert IP '%s' to a valid IPv6 address.", ip);
+        close(sock);
+        return -1;
+    }
+
+    name.sin6_scope_id = scope_id;
+
+    if (bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
+        close(sock);
+        error("IPv6 bind() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    if (listen(sock, listen_backlog) < 0) {
+        close(sock);
+        error("IPv6 listen() on ip '%s' port %d failed.", ip, port);
+        return -1;
+    }
+
+    debug(D_LISTENER, "Listening on IPv6 ip '%s' port %d", ip, port);
+    return sock;
+}
+
+static inline int listen_sockets_add(LISTEN_SOCKETS *sockets, int fd, const char *protocol, const char *ip, int port) {
+    if(sockets->opened >= MAX_LISTEN_FDS) {
+        error("Too many listening sockets. Failed to add listening %s socket at ip '%s' port %d", protocol, ip, port);
+        close(fd);
+        return -1;
+    }
+
+    sockets->fds[sockets->opened] = fd;
+
+    char buffer[100 + 1];
+    snprintfz(buffer, 100, "%s:[%s]:%d", protocol, ip, port);
+    sockets->fds_names[sockets->opened] = strdupz(buffer);
+
+    sockets->opened++;
+    return 0;
+}
+
+int listen_sockets_check_is_member(LISTEN_SOCKETS *sockets, int fd) {
+    size_t i;
+    for(i = 0; i < sockets->opened ;i++)
+        if(sockets->fds[i] == fd) return 1;
+
+    return 0;
+}
+
+static inline void listen_sockets_init(LISTEN_SOCKETS *sockets) {
+    size_t i;
+    for(i = 0; i < MAX_LISTEN_FDS ;i++) {
+        sockets->fds[i] = -1;
+        sockets->fds_names[i] = NULL;
+    }
+
+    sockets->opened = 0;
+    sockets->failed = 0;
+}
+
+void listen_sockets_close(LISTEN_SOCKETS *sockets) {
+    size_t i;
+    for(i = 0; i < sockets->opened ;i++) {
+        close(sockets->fds[i]);
+        sockets->fds[i] = -1;
+
+        freez(sockets->fds_names[i]);
+        sockets->fds_names[i] = NULL;
+    }
+
+    sockets->opened = 0;
+    sockets->failed = 0;
+}
+
+static inline int bind_to_one(LISTEN_SOCKETS *sockets, const char *definition, int default_port, int listen_backlog) {
+    int added = 0;
+    struct addrinfo hints;
+    struct addrinfo *result = NULL, *rp = NULL;
+
+    char buffer[strlen(definition) + 1];
+    strcpy(buffer, definition);
+
+    char buffer2[10 + 1];
+    snprintfz(buffer2, 10, "%d", default_port);
+
+    char *ip = buffer, *port = buffer2, *interface = "";;
+
+    int protocol = IPPROTO_TCP, socktype = SOCK_STREAM;
+    const char *protocol_str = "tcp";
+
+    if(strncmp(ip, "tcp:", 4) == 0) {
+        ip += 4;
+        protocol = IPPROTO_TCP;
+        socktype = SOCK_STREAM;
+        protocol_str = "tcp";
+    }
+    else if(strncmp(ip, "udp:", 4) == 0) {
+        ip += 4;
+        protocol = IPPROTO_UDP;
+        socktype = SOCK_DGRAM;
+        protocol_str = "udp";
+    }
+
+    char *e = ip;
+    if(*e == '[') {
+        e = ++ip;
+        while(*e && *e != ']') e++;
+        if(*e == ']') {
+            *e = '\0';
+            e++;
+        }
+    }
+    else {
+        while(*e && *e != ':' && *e != '%') e++;
+    }
+
+    if(*e == '%') {
+        *e = '\0';
+        e++;
+        interface = e;
+        while(*e && *e != ':') e++;
+    }
+
+    if(*e == ':') {
+        port = e + 1;
+        *e = '\0';
+    }
+
+    uint32_t scope_id = 0;
+    if(*interface) {
+        scope_id = if_nametoindex(interface);
+        if(!scope_id)
+            error("Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
+    }
+
+    if(!*ip || *ip == '*' || !strcmp(ip, "any") || !strcmp(ip, "all"))
+        ip = NULL;
+
+    if(!*port)
+        port = buffer2;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;  /* Allow IPv4 or IPv6 */
+    hints.ai_socktype = socktype;
+    hints.ai_flags = AI_PASSIVE;  /* For wildcard IP address */
+    hints.ai_protocol = protocol;
+    hints.ai_canonname = NULL;
+    hints.ai_addr = NULL;
+    hints.ai_next = NULL;
+
+    int r = getaddrinfo(ip, port, &hints, &result);
+    if (r != 0) {
+        error("getaddrinfo('%s', '%s'): %s\n", ip, port, gai_strerror(r));
+        return -1;
+    }
+
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        int fd = -1;
+
+        char rip[INET_ADDRSTRLEN + INET6_ADDRSTRLEN] = "INVALID";
+        int rport = default_port;
+
+        switch (rp->ai_addr->sa_family) {
+            case AF_INET: {
+                struct sockaddr_in *sin = (struct sockaddr_in *) rp->ai_addr;
+                inet_ntop(AF_INET, &sin->sin_addr, rip, INET_ADDRSTRLEN);
+                rport = ntohs(sin->sin_port);
+                fd = create_listen_socket4(socktype, rip, rport, listen_backlog);
+                break;
+            }
+
+            case AF_INET6: {
+                struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) rp->ai_addr;
+                inet_ntop(AF_INET6, &sin6->sin6_addr, rip, INET6_ADDRSTRLEN);
+                rport = ntohs(sin6->sin6_port);
+                fd = create_listen_socket6(socktype, scope_id, rip, rport, listen_backlog);
+                break;
+            }
+
+            default:
+                debug(D_LISTENER, "Unknown socket family %d", rp->ai_addr->sa_family);
+                break;
+        }
+
+        if (fd == -1) {
+            error("Cannot bind to ip '%s', port %d", rip, rport);
+            sockets->failed++;
+        }
+        else {
+            listen_sockets_add(sockets, fd, protocol_str, rip, rport);
+            added++;
+        }
+    }
+
+    freeaddrinfo(result);
+
+    return added;
+}
+
+int listen_sockets_setup(LISTEN_SOCKETS *sockets) {
+    listen_sockets_init(sockets);
+
+    sockets->backlog = (int) config_get_number(sockets->config_section, "listen backlog", sockets->backlog);
+
+    int old_port = sockets->default_port;
+    sockets->default_port = (int) config_get_number(sockets->config_section, "default port", sockets->default_port);
+    if(sockets->default_port < 1 || sockets->default_port > 65535) {
+        error("Invalid listen port %d given. Defaulting to %d.", sockets->default_port, old_port);
+        sockets->default_port = (int) config_set_number(sockets->config_section, "default port", old_port);
+    }
+    debug(D_OPTIONS, "Default listen port set to %d.", sockets->default_port);
+
+    char *s = config_get(sockets->config_section, "bind to", "*");
+    while(*s) {
+        char *e = s;
+
+        // skip separators, moving both s(tart) and e(nd)
+        while(isspace(*e) || *e == ',') s = ++e;
+
+        // move e(nd) to the first separator
+        while(*e && !isspace(*e) && *e != ',') e++;
+
+        // is there anything?
+        if(!*s || s == e) break;
+
+        char buf[e - s + 1];
+        strncpyz(buf, s, e - s);
+        bind_to_one(sockets, buf, sockets->default_port, sockets->backlog);
+
+        s = e;
+    }
+
+    if(!sockets->opened)
+        fatal("Cannot listen on any socket. Exiting...");
+
+    else if(sockets->failed) {
+        size_t i;
+        for(i = 0; i < sockets->opened ;i++)
+            info("Listen socket %s opened successfully.", sockets->fds_names[i]);
+    }
+
+    return (int)sockets->opened;
+}
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// connect to another host/port
+
 // _connect_to()
 // protocol    IPPROTO_TCP, IPPROTO_UDP
 // socktype    SOCK_STREAM, SOCK_DGRAM
@@ -228,6 +551,10 @@ int connect_to_one_of(const char *destination, int default_port, struct timeval 
     return sock;
 }
 
+
+// --------------------------------------------------------------------------------------------------------------------
+// helpers to send/receive data in one call, in blocking mode, with a timeout
+
 ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) {
     for(;;) {
         struct pollfd fd = {
@@ -289,3 +616,45 @@ ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) 
 
     return send(sockfd, buf, len, flags);
 }
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// accept4() replacement for systems that do not have one
+
+#ifndef HAVE_ACCEPT4
+int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
+    int fd = accept(sock, addr, addrlen);
+    int newflags = 0;
+
+    if (fd < 0) return fd;
+
+    if (flags & SOCK_NONBLOCK) {
+        newflags |= O_NONBLOCK;
+        flags &= ~SOCK_NONBLOCK;
+    }
+
+#ifdef SOCK_CLOEXEC
+#ifdef O_CLOEXEC
+    if (flags & SOCK_CLOEXEC) {
+        newflags |= O_CLOEXEC;
+        flags &= ~SOCK_CLOEXEC;
+    }
+#endif
+#endif
+
+    if (flags) {
+        errno = -EINVAL;
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFL, newflags) < 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+
+    return fd;
+}
+#endif
+

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,121 @@
 #include "common.h"
 
+// _connect_to()
+// protocol    IPPROTO_TCP, IPPROTO_UDP
+// socktype    SOCK_STREAM, SOCK_DGRAM
+// host        the destination hostname or IP address (IPv4 or IPv6) to connect to
+//             if it resolves to many IPs, all are tried (IPv4 and IPv6)
+// scope_id    the if_index id of the interface to use for connecting (0 = any)
+//             (used only under IPv6)
+// service     the service name or port to connect to
+// timeout     the timeout for establishing a connection
+
+static inline int _connect_to(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout) {
+    struct addrinfo hints;
+    struct addrinfo *ai_head = NULL, *ai = NULL;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = PF_UNSPEC;   /* Allow IPv4 or IPv6 */
+    hints.ai_socktype = socktype;
+    hints.ai_protocol = protocol;
+
+    int ai_err = getaddrinfo(host, service, &hints, &ai_head);
+    if (ai_err != 0) {
+        error("Cannot resolve host '%s', port '%s': %s", host, service, gai_strerror(ai_err));
+        return -1;
+    }
+
+    int fd = -1;
+    for (ai = ai_head; ai != NULL && fd == -1; ai = ai->ai_next) {
+
+        if (ai->ai_family == PF_INET6) {
+            struct sockaddr_in6 *pSadrIn6 = (struct sockaddr_in6 *) ai->ai_addr;
+            if(pSadrIn6->sin6_scope_id == 0) {
+                pSadrIn6->sin6_scope_id = scope_id;
+            }
+        }
+
+        char hostBfr[NI_MAXHOST + 1];
+        char servBfr[NI_MAXSERV + 1];
+
+        getnameinfo(ai->ai_addr,
+                    ai->ai_addrlen,
+                    hostBfr,
+                    sizeof(hostBfr),
+                    servBfr,
+                    sizeof(servBfr),
+                    NI_NUMERICHOST | NI_NUMERICSERV);
+
+        debug(D_CONNECT_TO, "Address info: host = '%s', service = '%s', ai_flags = 0x%02X, ai_family = %d (PF_INET = %d, PF_INET6 = %d), ai_socktype = %d (SOCK_STREAM = %d, SOCK_DGRAM = %d), ai_protocol = %d (IPPROTO_TCP = %d, IPPROTO_UDP = %d), ai_addrlen = %lu (sockaddr_in = %lu, sockaddr_in6 = %lu)",
+              hostBfr,
+              servBfr,
+              (unsigned int)ai->ai_flags,
+              ai->ai_family,
+              PF_INET,
+              PF_INET6,
+              ai->ai_socktype,
+              SOCK_STREAM,
+              SOCK_DGRAM,
+              ai->ai_protocol,
+              IPPROTO_TCP,
+              IPPROTO_UDP,
+              (unsigned long)ai->ai_addrlen,
+              (unsigned long)sizeof(struct sockaddr_in),
+              (unsigned long)sizeof(struct sockaddr_in6));
+
+        switch (ai->ai_addr->sa_family) {
+            case PF_INET: {
+                struct sockaddr_in *pSadrIn = (struct sockaddr_in *)ai->ai_addr;
+                debug(D_CONNECT_TO, "ai_addr = sin_family: %d (AF_INET = %d, AF_INET6 = %d), sin_addr: '%s', sin_port: '%s'",
+                      pSadrIn->sin_family,
+                      AF_INET,
+                      AF_INET6,
+                      hostBfr,
+                      servBfr);
+                break;
+            }
+
+            case PF_INET6: {
+                struct sockaddr_in6 *pSadrIn6 = (struct sockaddr_in6 *) ai->ai_addr;
+                debug(D_CONNECT_TO,"ai_addr = sin6_family: %d (AF_INET = %d, AF_INET6 = %d), sin6_addr: '%s', sin6_port: '%s', sin6_flowinfo: %u, sin6_scope_id: %u",
+                      pSadrIn6->sin6_family,
+                      AF_INET,
+                      AF_INET6,
+                      hostBfr,
+                      servBfr,
+                      pSadrIn6->sin6_flowinfo,
+                      pSadrIn6->sin6_scope_id);
+                break;
+            }
+
+            default: {
+                debug(D_CONNECT_TO, "Unknown protocol family %d.", ai->ai_family);
+                continue;
+            }
+        }
+
+        fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if(fd != -1) {
+            if(timeout) {
+                if(setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *) timeout, sizeof(struct timeval)) < 0)
+                    error("Failed to set timeout on the socket to ip '%s' port '%s'", hostBfr, servBfr);
+            }
+
+            if(connect(fd, ai->ai_addr, ai->ai_addrlen) < 0) {
+                error("Failed to connect to '%s', port '%s'", hostBfr, servBfr);
+                close(fd);
+                fd = -1;
+            }
+
+            debug(D_CONNECT_TO, "Connected to '%s' on port '%s'.", hostBfr, servBfr);
+        }
+    }
+
+    freeaddrinfo(ai_head);
+
+    return fd;
+}
+
 // connect_to()
 //
 // definition format:
@@ -12,9 +128,6 @@
 // PORT      = port number or service name
 
 int connect_to(const char *definition, int default_port, struct timeval *timeout) {
-    struct addrinfo hints;
-    struct addrinfo *ai_head = NULL, *ai = NULL;
-
     char buffer[strlen(definition) + 1];
     strcpy(buffer, definition);
 
@@ -78,106 +191,8 @@ int connect_to(const char *definition, int default_port, struct timeval *timeout
     if(!*service)
         service = default_service;
 
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family   = PF_UNSPEC;   /* Allow IPv4 or IPv6 */
-    hints.ai_socktype = socktype;
-    hints.ai_protocol = protocol;
 
-    int ai_err = getaddrinfo(host, service, &hints, &ai_head);
-    if (ai_err != 0) {
-        error("Cannot resolve host '%s', port '%s': %s", host, service, gai_strerror(ai_err));
-        return -1;
-    }
-
-    int fd = -1;
-    for (ai = ai_head; ai != NULL && fd == -1; ai = ai->ai_next) {
-
-        if (ai->ai_family == PF_INET6) {
-            struct sockaddr_in6 *pSadrIn6 = (struct sockaddr_in6 *) ai->ai_addr;
-            if(pSadrIn6->sin6_scope_id == 0) {
-                pSadrIn6->sin6_scope_id = scope_id;
-            }
-        }
-
-        char hostBfr[NI_MAXHOST + 1];
-        char servBfr[NI_MAXSERV + 1];
-
-        getnameinfo(ai->ai_addr,
-                ai->ai_addrlen,
-                hostBfr,
-                sizeof(hostBfr),
-                servBfr,
-                sizeof(servBfr),
-                NI_NUMERICHOST | NI_NUMERICSERV);
-
-        debug(D_CONNECT_TO, "Address info: host = '%s', service = '%s', ai_flags = 0x%02X, ai_family = %d (PF_INET = %d, PF_INET6 = %d), ai_socktype = %d (SOCK_STREAM = %d, SOCK_DGRAM = %d), ai_protocol = %d (IPPROTO_TCP = %d, IPPROTO_UDP = %d), ai_addrlen = %lu (sockaddr_in = %lu, sockaddr_in6 = %lu)",
-                hostBfr,
-                servBfr,
-                (unsigned int)ai->ai_flags,
-                ai->ai_family,
-                PF_INET,
-                PF_INET6,
-                ai->ai_socktype,
-                SOCK_STREAM,
-                SOCK_DGRAM,
-                ai->ai_protocol,
-                IPPROTO_TCP,
-                IPPROTO_UDP,
-                (unsigned long)ai->ai_addrlen,
-                (unsigned long)sizeof(struct sockaddr_in),
-                (unsigned long)sizeof(struct sockaddr_in6));
-
-        switch (ai->ai_addr->sa_family) {
-            case PF_INET: {
-                struct sockaddr_in *pSadrIn = (struct sockaddr_in *)ai->ai_addr;
-                debug(D_CONNECT_TO, "ai_addr = sin_family: %d (AF_INET = %d, AF_INET6 = %d), sin_addr: '%s', sin_port: '%s'",
-                        pSadrIn->sin_family,
-                        AF_INET,
-                        AF_INET6,
-                        hostBfr,
-                        servBfr);
-                break;
-            }
-
-            case PF_INET6: {
-                struct sockaddr_in6 *pSadrIn6 = (struct sockaddr_in6 *) ai->ai_addr;
-                debug(D_CONNECT_TO,"ai_addr = sin6_family: %d (AF_INET = %d, AF_INET6 = %d), sin6_addr: '%s', sin6_port: '%s', sin6_flowinfo: %u, sin6_scope_id: %u",
-                        pSadrIn6->sin6_family,
-                        AF_INET,
-                        AF_INET6,
-                        hostBfr,
-                        servBfr,
-                        pSadrIn6->sin6_flowinfo,
-                        pSadrIn6->sin6_scope_id);
-                break;
-            }
-
-            default: {
-                debug(D_CONNECT_TO, "Unknown protocol family %d.", ai->ai_family);
-                continue;
-            }
-        }
-
-        fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if(fd != -1) {
-            if(timeout) {
-                if(setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *) timeout, sizeof(struct timeval)) < 0)
-                    error("Failed to set timeout on the socket to ip '%s' port '%s'", hostBfr, servBfr);
-            }
-
-            if(connect(fd, ai->ai_addr, ai->ai_addrlen) < 0) {
-                error("Failed to connect to '%s', port '%s'", hostBfr, servBfr);
-                close(fd);
-                fd = -1;
-            }
-
-            debug(D_CONNECT_TO, "Connected to '%s' on port '%s'.", hostBfr, servBfr);
-        }
-    }
-
-    freeaddrinfo(ai_head);
-
-    return fd;
+    return _connect_to(protocol, socktype, host, scope_id, service, timeout);
 }
 
 int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size) {

--- a/src/socket.h
+++ b/src/socket.h
@@ -1,14 +1,41 @@
-//
-// Created by costa on 24/12/2016.
-//
-
 #ifndef NETDATA_SOCKET_H
 #define NETDATA_SOCKET_H
+
+#ifndef MAX_LISTEN_FDS
+#define MAX_LISTEN_FDS 50
+#endif
+
+typedef struct listen_sockets {
+    const char *config_section;         // the netdata configuration section to read settings from
+    int default_port;                   // the default port to use
+    int backlog;                        // the default listen backlog to use
+
+    size_t opened;                      // the number of sockets opened
+    size_t failed;                      // the number of sockets attempted to open, but failed
+    int fds[MAX_LISTEN_FDS];            // the open sockets
+    char *fds_names[MAX_LISTEN_FDS];    // descriptions for the open sockets
+} LISTEN_SOCKETS;
+
+extern int listen_sockets_setup(LISTEN_SOCKETS *sockets);
+extern void listen_sockets_close(LISTEN_SOCKETS *sockets);
 
 extern int connect_to(const char *definition, int default_port, struct timeval *timeout);
 extern int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
 
 extern ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
 extern ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
+
+#ifndef HAVE_ACCEPT4
+extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
+
+#ifndef SOCK_NONBLOCK
+#define SOCK_NONBLOCK 00004000
+#endif  /* #ifndef SOCK_NONBLOCK */
+
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 02000000
+#endif /* #ifndef SOCK_CLOEXEC */
+
+#endif /* #ifndef HAVE_ACCEPT4 */
 
 #endif //NETDATA_SOCKET_H

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -1,25 +1,9 @@
 #include "common.h"
 
-typedef struct listen_sockets {
-    const char *config_section;
-    size_t opened;
-    size_t failed;
-    int fds[MAX_LISTEN_FDS];
-    char *fds_names[MAX_LISTEN_FDS];
-    int default_port;
-    int backlog;
-    uint32_t flags;
-} LISTEN_SOCKETS;
-
 static LISTEN_SOCKETS api_sockets = {
         .config_section = CONFIG_SECTION_WEB,
-        .opened = 0,
-        .failed = 0,
-        .fds = { [0 ... 99] = -1 },
-        .fds_names = { [0 ... 99] = NULL },
-        .default_port = LISTEN_PORT,
-        .backlog = LISTEN_BACKLOG,
-        .flags = 0
+        .default_port   = API_LISTEN_PORT,
+        .backlog        = API_LISTEN_BACKLOG
 };
 
 WEB_SERVER_MODE web_server_mode = WEB_SERVER_MODE_MULTI_THREADED;
@@ -61,42 +45,7 @@ static void log_allocations(void)
 }
 #endif /* NETDATA_INTERNAL_CHECKS */
 
-#ifndef HAVE_ACCEPT4
-int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
-    int fd = accept(sock, addr, addrlen);
-    int newflags = 0;
-
-    if (fd < 0) return fd;
-
-    if (flags & SOCK_NONBLOCK) {
-        newflags |= O_NONBLOCK;
-        flags &= ~SOCK_NONBLOCK;
-    }
-
-#ifdef SOCK_CLOEXEC
-#ifdef O_CLOEXEC
-    if (flags & SOCK_CLOEXEC) {
-        newflags |= O_CLOEXEC;
-        flags &= ~SOCK_CLOEXEC;
-    }
-#endif
-#endif
-
-    if (flags) {
-        errno = -EINVAL;
-        return -1;
-    }
-
-    if (fcntl(fd, F_SETFL, newflags) < 0) {
-        int saved_errno = errno;
-        close(fd);
-        errno = saved_errno;
-        return -1;
-    }
-
-    return fd;
-}
-#endif
+// --------------------------------------------------------------------------------------
 
 WEB_SERVER_MODE web_server_mode_id(const char *mode) {
     if(!strcmp(mode, "none"))
@@ -121,309 +70,10 @@ const char *web_server_mode_name(WEB_SERVER_MODE id) {
     }
 }
 
-int create_listen_socket4(int socktype, const char *ip, int port, int listen_backlog) {
-    int sock;
-    int sockopt = 1;
+// --------------------------------------------------------------------------------------
 
-    debug(D_LISTENER, "IPv4 creating new listening socket on ip '%s' port %d", ip, port);
-
-    sock = socket(AF_INET, socktype, 0);
-    if(sock < 0) {
-        error("IPv4 socket() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    /* avoid "address already in use" */
-    if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void*)&sockopt, sizeof(sockopt)) != 0)
-        error("Cannot set SO_REUSEADDR on ip '%s' port's %d.", ip, port);
-
-    struct sockaddr_in name;
-    memset(&name, 0, sizeof(struct sockaddr_in));
-    name.sin_family = AF_INET;
-    name.sin_port = htons (port);
-
-    int ret = inet_pton(AF_INET, ip, (void *)&name.sin_addr.s_addr);
-    if(ret != 1) {
-        error("Failed to convert IP '%s' to a valid IPv4 address.", ip);
-        close(sock);
-        return -1;
-    }
-
-    if(bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
-        close(sock);
-        error("IPv4 bind() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    if(listen(sock, listen_backlog) < 0) {
-        close(sock);
-        error("IPv4 listen() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    debug(D_LISTENER, "Listening on IPv4 ip '%s' port %d", ip, port);
-    return sock;
-}
-
-int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int port, int listen_backlog) {
-    int sock = -1;
-    int sockopt = 1;
-    int ipv6only = 1;
-
-    debug(D_LISTENER, "IPv6 creating new listening socket on ip '%s' port %d", ip, port);
-
-    sock = socket(AF_INET6, socktype, 0);
-    if (sock < 0) {
-        error("IPv6 socket() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    /* avoid "address already in use" */
-    if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void*)&sockopt, sizeof(sockopt)) != 0)
-        error("Cannot set SO_REUSEADDR on ip '%s' port's %d.", ip, port);
-
-    /* IPv6 only */
-    if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&ipv6only, sizeof(ipv6only)) != 0)
-        error("Cannot set IPV6_V6ONLY on ip '%s' port's %d.", ip, port);
-
-    struct sockaddr_in6 name;
-    memset(&name, 0, sizeof(struct sockaddr_in6));
-    name.sin6_family = AF_INET6;
-    name.sin6_port = htons ((uint16_t) port);
-    name.sin6_scope_id = scope_id;
-
-    int ret = inet_pton(AF_INET6, ip, (void *)&name.sin6_addr.s6_addr);
-    if(ret != 1) {
-        error("Failed to convert IP '%s' to a valid IPv6 address.", ip);
-        close(sock);
-        return -1;
-    }
-
-    name.sin6_scope_id = scope_id;
-
-    if (bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
-        close(sock);
-        error("IPv6 bind() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    if (listen(sock, listen_backlog) < 0) {
-        close(sock);
-        error("IPv6 listen() on ip '%s' port %d failed.", ip, port);
-        return -1;
-    }
-
-    debug(D_LISTENER, "Listening on IPv6 ip '%s' port %d", ip, port);
-    return sock;
-}
-
-static inline int add_listen_socket(LISTEN_SOCKETS *sockets, int fd, const char *protocol, const char *ip, int port) {
-    if(sockets->opened >= MAX_LISTEN_FDS) {
-        error("Too many listening sockets. Failed to add listening %s socket at ip '%s' port %d", protocol, ip, port);
-        close(fd);
-        return -1;
-    }
-
-    sockets->fds[sockets->opened] = fd;
-
-    char buffer[100 + 1];
-    snprintfz(buffer, 100, "%s:[%s]:%d", protocol, ip, port);
-    sockets->fds_names[sockets->opened] = strdupz(buffer);
-
-    sockets->opened++;
-    return 0;
-}
-
-int is_listen_socket(LISTEN_SOCKETS *sockets, int fd) {
-    size_t i;
-    for(i = 0; i < sockets->opened ;i++)
-        if(sockets->fds[i] == fd) return 1;
-
-    return 0;
-}
-
-static inline void close_listen_sockets(LISTEN_SOCKETS *sockets) {
-    size_t i;
-    for(i = 0; i < sockets->opened ;i++) {
-        close(sockets->fds[i]);
-        sockets->fds[i] = -1;
-
-        freez(sockets->fds_names[i]);
-        sockets->fds_names[i] = NULL;
-    }
-
-    sockets->opened = 0;
-}
-
-static inline int bind_to_one(LISTEN_SOCKETS *sockets, const char *definition, int default_port, int listen_backlog) {
-    int added = 0;
-    struct addrinfo hints;
-    struct addrinfo *result = NULL, *rp = NULL;
-
-    char buffer[strlen(definition) + 1];
-    strcpy(buffer, definition);
-
-    char buffer2[10 + 1];
-    snprintfz(buffer2, 10, "%d", default_port);
-
-    char *ip = buffer, *port = buffer2, *interface = "";;
-
-    int protocol = IPPROTO_TCP, socktype = SOCK_STREAM;
-    const char *protocol_str = "tcp";
-
-    if(strncmp(ip, "tcp:", 4) == 0) {
-        ip += 4;
-        protocol = IPPROTO_TCP;
-        socktype = SOCK_STREAM;
-        protocol_str = "tcp";
-    }
-    else if(strncmp(ip, "udp:", 4) == 0) {
-        ip += 4;
-        protocol = IPPROTO_UDP;
-        socktype = SOCK_DGRAM;
-        protocol_str = "udp";
-    }
-
-    char *e = ip;
-    if(*e == '[') {
-        e = ++ip;
-        while(*e && *e != ']') e++;
-        if(*e == ']') {
-            *e = '\0';
-            e++;
-        }
-    }
-    else {
-        while(*e && *e != ':' && *e != '%') e++;
-    }
-
-    if(*e == '%') {
-        *e = '\0';
-        e++;
-        interface = e;
-        while(*e && *e != ':') e++;
-    }
-
-    if(*e == ':') {
-        port = e + 1;
-        *e = '\0';
-    }
-
-    uint32_t scope_id = 0;
-    if(*interface) {
-        scope_id = if_nametoindex(interface);
-        if(!scope_id)
-            error("Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
-    }
-
-    if(!*ip || *ip == '*' || !strcmp(ip, "any") || !strcmp(ip, "all"))
-        ip = NULL;
-
-    if(!*port)
-        port = buffer2;
-
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;  /* Allow IPv4 or IPv6 */
-    hints.ai_socktype = socktype;
-    hints.ai_flags = AI_PASSIVE;  /* For wildcard IP address */
-    hints.ai_protocol = protocol;
-    hints.ai_canonname = NULL;
-    hints.ai_addr = NULL;
-    hints.ai_next = NULL;
-
-    int r = getaddrinfo(ip, port, &hints, &result);
-    if (r != 0) {
-        error("getaddrinfo('%s', '%s'): %s\n", ip, port, gai_strerror(r));
-        return -1;
-    }
-
-    for (rp = result; rp != NULL; rp = rp->ai_next) {
-        int fd = -1;
-
-        char rip[INET_ADDRSTRLEN + INET6_ADDRSTRLEN] = "INVALID";
-        int rport = default_port;
-
-        switch (rp->ai_addr->sa_family) {
-            case AF_INET: {
-                struct sockaddr_in *sin = (struct sockaddr_in *) rp->ai_addr;
-                inet_ntop(AF_INET, &sin->sin_addr, rip, INET_ADDRSTRLEN);
-                rport = ntohs(sin->sin_port);
-                fd = create_listen_socket4(socktype, rip, rport, listen_backlog);
-                break;
-            }
-
-            case AF_INET6: {
-                struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) rp->ai_addr;
-                inet_ntop(AF_INET6, &sin6->sin6_addr, rip, INET6_ADDRSTRLEN);
-                rport = ntohs(sin6->sin6_port);
-                fd = create_listen_socket6(socktype, scope_id, rip, rport, listen_backlog);
-                break;
-            }
-
-            default:
-                debug(D_LISTENER, "Unknown socket family %d", rp->ai_addr->sa_family);
-                break;
-        }
-
-        if (fd == -1) {
-            error("Cannot bind to ip '%s', port %d", rip, rport);
-            sockets->failed++;
-        }
-        else {
-            add_listen_socket(sockets, fd, protocol_str, rip, rport);
-            added++;
-        }
-    }
-
-    freeaddrinfo(result);
-
-    return added;
-}
-
-int create_listen_sockets(LISTEN_SOCKETS *sockets) {
-    sockets->backlog = (int) config_get_number(sockets->config_section, "listen backlog", LISTEN_BACKLOG);
-
-    int old_port = sockets->default_port;
-    sockets->default_port = (int) config_get_number(sockets->config_section, "default port", sockets->default_port);
-    if(sockets->default_port < 1 || sockets->default_port > 65535) {
-        error("Invalid listen port %d given. Defaulting to %d.", sockets->default_port, old_port);
-        sockets->default_port = (int) config_set_number(sockets->config_section, "default port", old_port);
-    }
-    debug(D_OPTIONS, "Default listen port set to %d.", sockets->default_port);
-
-    char *s = config_get(sockets->config_section, "bind to", "*");
-    while(*s) {
-        char *e = s;
-
-        // skip separators, moving both s(tart) and e(nd)
-        while(isspace(*e) || *e == ',') s = ++e;
-
-        // move e(nd) to the first separator
-        while(*e && !isspace(*e) && *e != ',') e++;
-
-        // is there anything?
-        if(!*s || s == e) break;
-
-        char buf[e - s + 1];
-        strncpyz(buf, s, e - s);
-        bind_to_one(sockets, buf, sockets->default_port, sockets->backlog);
-
-        s = e;
-    }
-
-    if(!sockets->opened)
-        fatal("Cannot listen on any socket. Exiting...");
-    else if(sockets->failed) {
-        size_t i;
-        for(i = 0; i < sockets->opened ;i++)
-            info("Listen socket %s opened successfully.", sockets->fds_names[i]);
-    }
-
-    return (int)sockets->opened;
-}
-
-int create_api_listen_sockets(void) {
-    return create_listen_sockets(&api_sockets);
+int api_listen_sockets_setup(void) {
+    return listen_sockets_setup(&api_sockets);
 }
 
 // --------------------------------------------------------------------------------------
@@ -532,7 +182,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
     }
 
     debug(D_WEB_CLIENT, "LISTENER: exit!");
-    close_listen_sockets(&api_sockets);
+    listen_sockets_close(&api_sockets);
 
     freez(fds);
 
@@ -704,7 +354,7 @@ void *socket_listen_main_single_threaded(void *ptr) {
     }
 
     debug(D_WEB_CLIENT, "LISTENER: exit!");
-    close_listen_sockets(&api_sockets);
+    listen_sockets_close(&api_sockets);
 
     static_thread->enabled = 0;
     pthread_exit(NULL);

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -27,8 +27,7 @@ extern const char *web_server_mode_name(WEB_SERVER_MODE id);
 
 extern void *socket_listen_main_multi_threaded(void *ptr);
 extern void *socket_listen_main_single_threaded(void *ptr);
-extern int create_listen_sockets(void);
-extern int is_listen_socket(int fd);
+extern int create_api_listen_sockets(void);
 
 #ifndef HAVE_ACCEPT4
 extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -6,11 +6,12 @@
 #define WEB_PATH_DATASOURCE         "datasource"
 #define WEB_PATH_GRAPH              "graph"
 
-#define LISTEN_PORT 19999
-#define LISTEN_BACKLOG 100
+#ifndef API_LISTEN_PORT
+#define API_LISTEN_PORT 19999
+#endif
 
-#ifndef MAX_LISTEN_FDS
-#define MAX_LISTEN_FDS 100
+#ifndef API_LISTEN_BACKLOG
+#define API_LISTEN_BACKLOG 4096
 #endif
 
 typedef enum web_server_mode {
@@ -24,22 +25,8 @@ extern WEB_SERVER_MODE web_server_mode;
 extern WEB_SERVER_MODE web_server_mode_id(const char *mode);
 extern const char *web_server_mode_name(WEB_SERVER_MODE id);
 
-
 extern void *socket_listen_main_multi_threaded(void *ptr);
 extern void *socket_listen_main_single_threaded(void *ptr);
-extern int create_api_listen_sockets(void);
-
-#ifndef HAVE_ACCEPT4
-extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
-
-#ifndef SOCK_NONBLOCK
-#define SOCK_NONBLOCK 00004000
-#endif  /* #ifndef SOCK_NONBLOCK */
-
-#ifndef SOCK_CLOEXEC
-#define SOCK_CLOEXEC 02000000
-#endif /* #ifndef SOCK_CLOEXEC */
-
-#endif /* #ifndef HAVE_ACCEPT4 */
+extern int api_listen_sockets_setup(void);
 
 #endif /* NETDATA_WEB_SERVER_H */

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -2721,16 +2721,9 @@ var NETDATA = window.NETDATA || {};
                 }
                 else {
                     c = c.split(' ');
-                    var added = 0;
-
-                    while(added < 20) {
-                        len = c.length;
-                        while(len--) {
-                            added++;
-                            this.colors_available.unshift(c[len]);
-                            // this.log('adding color: ' + c[len]);
-                        }
-                    }
+                    len = c.length;
+                    while(len--)
+                        this.colors_available.unshift(c[len]);
                 }
             }
 

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -426,7 +426,6 @@ netdataDashboard.context = {
     },
 
     'system.idlejitter': {
-        colors: '#5555AA',
         info: 'Idle jitter is calculated by netdata. A thread is spawned that requests to sleep for a few microseconds. When the system wakes it up, it measures how many microseconds have passed. The difference between the requested and the actual duration of the sleep, is the <b>idle jitter</b>. This number is useful in real-time environments, where CPU jitter can affect the quality of the service (like VoIP media gateways).'
     },
 

--- a/web/index.html
+++ b/web/index.html
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170421-1"></script>
+<script type="text/javascript" src="dashboard.js?v20170421-2"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -2895,7 +2895,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20170325-1',
+                url: NETDATA.serverDefault + 'dashboard_info.js?v20170421-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });
@@ -3523,4 +3523,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170419-6"></script>
+<script type="text/javascript" src="dashboard.js?v20170421-1"></script>


### PR DESCRIPTION
1. added checks to make sure the database is always current. Since netdata trusts its plugins or its slaves to provide timing information, issues in these systems may lead to charts having wrong datetime. To fix this issues netdata detected charts running in future time, but did not do anything about charts running in the past. This PR fixes that. netdata now allows up to 10 iterations (10 seconds by default) past charts. When charts are detected to be more than that time behind, netdata will fix them (gap on the dashboard).

   Charts from slaves are checked once every minute (controlled by `initial clock resync iterations` - yes, I used the same setting for 2 functions: a) the slaves will send BEGIN lines with dt = 0 for that many iterations when start streaming and b) the master will ignore the `dt` at BEGIN lines every that many iterations). I thought it was overkill to add another setting...

2. The above PR identified an issue in apps.plugin which was somehow loosing some time. The issue was not noticable on all systems. It is **now fixed**.

3. Improved idlejitter plugin. Now the plugin is a lot more capable to detect CPU jitter. VMs vs bare-matel is now clearly visible.

4. Fixed an issue in charts color palette management. Somehow, custom colors were not allowing the default palette to be appended, resulting in single-color charts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/firehol/netdata/2114)
<!-- Reviewable:end -->
