### PR TITLE
Fix postgres rds

### DIFF
--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -99,8 +99,8 @@ SELECT
   sum(conflicts) AS conflicts,
   pg_database_size(datname) AS size
 FROM pg_stat_database
-WHERE NOT datname ~* '^template\d+'
-GROUP BY database_name;
+WHERE datname IN %(databases)s
+GROUP BY datname;
 """,
     BGWRITER="""
 SELECT
@@ -332,7 +332,7 @@ class Service(SimpleService):
             return None
 
     def query_stats_(self, cursor, query, metrics):
-        cursor.execute(query)
+        cursor.execute(query, dict(databases=tuple(self.databases)))
         for row in cursor:
             for metric in metrics:
                 dimension_id = '_'.join([row['database_name'], metric]) if 'database_name' in row else metric

--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -146,7 +146,6 @@ SELECT current_setting('is_superuser') = 'on' AS is_superuser;
 QUERY_STATS = {
     QUERIES['DATABASE']: METRICS['DATABASE'],
     QUERIES['BACKENDS']: METRICS['BACKENDS'],
-    QUERIES['ARCHIVE']: METRICS['ARCHIVE'],
     QUERIES['LOCKS']: METRICS['LOCKS']
 }
 
@@ -300,6 +299,7 @@ class Service(SimpleService):
             QUERY_STATS[QUERIES['TABLE_STATS']] = METRICS['TABLE_STATS']
         if is_superuser:
             QUERY_STATS[QUERIES['BGWRITER']] = METRICS['BGWRITER']
+            QUERY_STATS[QUERIES['ARCHIVE']] = METRICS['ARCHIVE']
 
     def create_dynamic_charts_(self):
 


### PR DESCRIPTION
Fix a couple of issues that prevented the plugin from working on RDS:

- Only execute ARCHIVE query if superuser as it requires superuser permissions.
- Ensure we only collect database information on the databases we are interested in. 