### PR TITLE
UrlService http proxy support, _get_raw_data support for different openers 

### DIFF
--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -313,10 +313,10 @@ class Service(UrlService):
             self.error(str(error))
             return False
 
-        scheme = 'http' if self.scheme else 'https'
+        scheme = 'http' if self.scheme == 'http' else 'https'
         # Add handlers (auth, self signed cert accept)
         self.url = '%s://%s:%s' % (scheme, self.host, self.port)
-        self._UrlService__add_openers()
+        self.opener = self._build_opener()
         # Create URL for every Elasticsearch API
         url_node_stats = '%s://%s:%s/_nodes/_local/stats' % (scheme, self.host, self.port)
         url_cluster_health = '%s://%s:%s/_cluster/health' % (scheme, self.host, self.port)


### PR DESCRIPTION
HTTP proxy support:

```yaml
localhost:
  name : 'local'
  url  : 'http://100.100.0.1/stub_status'
  proxy : 'http://127.0.0.1:3128'
# proxy : 'http://username:password@127.0.0.1:3128'
```

And initial support for https://github.com/firehol/netdata/issues/2115


If we need to get data from different URLs we may need to build different openers:

Example:
1. URL's w/o auth, http proxy, self signed cert ignore
2. URL's w/ http proxy
3. URL's w/ auth and self signed cert ignore


```python
self.opener = self._build_opener() # self.opener used in _get_raw_data() if opener is not passed
opener_via_proxy = self._build_opener(proxy='http://127.0.0.1:3128')
opener_ss_ignore_auth = self._build_opener(user='user', password='password', ss_cert=True, url='URL')


data_1 = self._get_raw_data() # uses default self.opener and self.url
data_2 = self._get_raw_data(url='URL_2', opener=opener_via_proxy)
data_3 = self._get_raw_data(url='URL_3', opener=opener_ss_ignore_auth)
```

ready @ktsaou 