### PR TITLE
Add puma ruby webserver to apps_group.conf

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -95,6 +95,7 @@ php: php*
 ftpd: proftpd in.tftpd vsftpd
 uwsgi: uwsgi
 unicorn: *unicorn*
+puma: *puma*
 
 # -----------------------------------------------------------------------------
 # database servers


### PR DESCRIPTION
Hi, this is a tiny PR just adding the missing **puma** ruby webserver from the monitored apps.

I was thinking about creating a **ruby** group for puma and unicorn processes (as they are both ruby webservers), but thought that it would be too unclear. Tell me if you want me to change this.

Thank you!