### PR TITLE
added the ability to define the value type on synthetic charts of statsd

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -126,3 +126,8 @@ dist_chartsconfig_DATA = \
     charts.d/postfix.conf \
     charts.d/squid.conf \
     $(NULL)
+
+statsdconfigdir=$(configdir)/statsd.d
+dist_statsdconfig_DATA = \
+    statsd.d/example.conf \
+    $(NULL)

--- a/conf.d/statsd.d/example.conf
+++ b/conf.d/statsd.d/example.conf
@@ -1,0 +1,63 @@
+# statsd synthetic charts configuration
+
+# You can add many .conf files, one for each of your apps
+
+# start a new app - you can add many apps in the same file
+[app]
+    # give a name for this app
+    # this controls the main menu on the dashboard
+    # and will be the prefix for all charts of the app
+	name = myapp
+
+	# match all the metrics of the app
+	metrics = myapp.*
+
+	# shall private charts of these metrics be created?
+	private charts = no
+
+	# shall gaps be shown when metrics are not collected?
+	gaps when not collected = no
+
+	# the memory mode for the charts of this app: none|map|save
+	memory mode = ram
+
+	# the history size for the charts of this app, in seconds
+	history = 60
+
+
+
+# create a chart
+# this is its id - the chart will be named myapp.mychart
+[mychart]
+    # a name for the chart, similar to the id (2 names for each chart)
+	name = mychart
+
+	# the chart title
+	title = my chart title
+
+	# the submenu of the dashboard
+	family = my family
+
+	# the context for alarm templates
+	context = chart.context
+
+	# the units of the chart
+	units = tests/s
+
+	# the sorting priority of the chart on the dashboard
+	priority = 91000
+
+	# the type of chart to create: line | area | stacked
+	type = area
+
+	# one or more dimensions for the chart
+	# type = events | last | min | max | sum | average | percentile | median | stddev
+	#        events = the number of events for this metric
+	#        last = the last value collected
+	#        all the others are only valid for histograms and timers
+	dimension = myapp.metric1 avg   average 1 1
+	dimension = myapp.metric1 lower min     1 1
+	dimension = myapp.metric1 upper max     1 1
+	dimension = myapp.metric2 other last    1 1
+
+# You can add as many charts as needed


### PR DESCRIPTION
fixes #2181 

1. statsd synthetic charts now support a `type`, with the type of value to use
2. statsd parsing is somewhat faster and strictier now (the single threaded statsd server in netdata can parse 200Mbps of sustained statsd traffic, 1.2mil events/s, on modern hardware ... haha it is fast!)
3. fixed a few issues here and there (in statsd)

