### PR TITLE
Fix invalid 'seconds behind the master' value for mysql slave

### DIFF
--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -117,7 +117,7 @@ GLOBAL_STATS = [
  'Connection_errors_tcpwrap']
 
 def slave_seconds(value):
-    return value if value else -1
+    return value if value >= 0 else -1
 
 def slave_running(value):
     return 1 if value == 'Yes' else -1

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -117,7 +117,7 @@ GLOBAL_STATS = [
  'Connection_errors_tcpwrap']
 
 def slave_seconds(value):
-    return value if value >= 0 else -1
+    return value if value is not '' else -1
 
 def slave_running(value):
     return 1 if value == 'Yes' else -1


### PR DESCRIPTION
This PR fixes an invalid `seconds behind the master` value when the actual value is 0 but it shows -1. 