### PR TITLE
fix alarm notification URLs sent by master for a slave

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,9 @@
-netdata
-(C) Copyright 2017, Costa Tsaousis
+**netdata**<br/>
+(C) Copyright 2017<br/>
+Costa Tsaousis &lt;costa@tsaousis.gr&gt;
 
-Please read the following files:
+For license details refer to the following files:
 
-- [LICENSE](LICENSE) (GPL v3+)
-- [LICENSE-REDISTRIBUTED.md](LICENSE-REDISTRIBUTED.md) for third party packages re-distributed with netdata
+- [netdata license](LICENSE) (GPL v3+)
+- [third party licenses](LICENSE-REDISTRIBUTED.md), for packages re-distributed with netdata
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# netdata [![Build Status](https://travis-ci.org/firehol/netdata.svg?branch=master)](https://travis-ci.org/firehol/netdata) [![Coverity Scan Build Status](https://scan.coverity.com/projects/9140/badge.svg)](https://scan.coverity.com/projects/firehol-netdata) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a994873f30d045b9b4b83606c3eb3498)](https://www.codacy.com/app/netdata/netdata?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=firehol/netdata&amp;utm_campaign=Badge_Grade) [![Code Climate](https://codeclimate.com/github/firehol/netdata/badges/gpa.svg)](https://codeclimate.com/github/firehol/netdata) [![license](https://img.shields.io/github/license/firehol/netdata.svg)](LICENSE.md)
+# netdata [![Build Status](https://travis-ci.org/firehol/netdata.svg?branch=master)](https://travis-ci.org/firehol/netdata) [![Coverity Scan Build Status](https://scan.coverity.com/projects/9140/badge.svg)](https://scan.coverity.com/projects/firehol-netdata) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a994873f30d045b9b4b83606c3eb3498)](https://www.codacy.com/app/netdata/netdata?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=firehol/netdata&amp;utm_campaign=Badge_Grade) [![Code Climate](https://codeclimate.com/github/firehol/netdata/badges/gpa.svg)](https://codeclimate.com/github/firehol/netdata) [![license](https://img.shields.io/github/license/firehol/netdata.svg)](LICENSE)
 > *New to netdata? Here is a live demo: [http://my-netdata.io](http://my-netdata.io)*
 
 **netdata** is a system for **distributed real-time performance and health monitoring**.
@@ -273,13 +273,17 @@ This is a list of what it currently monitors:
 - **SNMP devices**<br/>
   can be monitored too (although you will need to configure these)
 
+- **statsd**<br/>
+  [netdata is a fully featured statsd server](https://github.com/firehol/netdata/wiki/statsd)
+
 And you can extend it, by writing plugins that collect data from any source, using any computer language.
 
 ---
 
 ## netdata infographic
 
-This is a high level overview of netdata feature set and architecture. Click it to to interact with it.
+This is a high level overview of netdata feature set and architecture.
+Click it to to interact with it (it has direct links to documentation).
 
 [![netdata-overview](https://cloud.githubusercontent.com/assets/2662304/25580009/bf7016a4-2e85-11e7-9a7a-b36c57db7b91.png)](https://my-netdata.io/infographic.html)
 
@@ -311,6 +315,6 @@ Check the **[netdata wiki](https://github.com/firehol/netdata/wiki)**.
 
 ## License
 
-netdata is GPLv3+.
+netdata is [GPLv3+](LICENSE).
 
-It re-distributes other open-source tools and libraries. Please check its [License Statement](https://github.com/firehol/netdata/blob/master/LICENSE.md).
+It re-distributes other open-source tools and libraries. Please check the [third party licenses](https://github.com/firehol/netdata/blob/master/LICENSE-REDISTRIBUTED.md).

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -115,8 +115,6 @@ debug() {
 NETDATA_CONFIG_DIR="${NETDATA_CONFIG_DIR-/etc/netdata}"
 NETDATA_CACHE_DIR="${NETDATA_CACHE_DIR-/var/cache/netdata}"
 [ -z "${NETDATA_REGISTRY_URL}" ] && NETDATA_REGISTRY_URL="https://registry.my-netdata.io"
-[ -z "${NETDATA_HOSTNAME}" ] && NETDATA_HOSTNAME="$(hostname)"
-[ -z "${NETDATA_REGISTRY_HOSTNAME}" ] && NETDATA_REGISTRY_HOSTNAME="${NETDATA_HOSTNAME}"
 
 # -----------------------------------------------------------------------------
 # parse command line parameters
@@ -145,8 +143,6 @@ old_value_string="${20}"    # friendly old value (with units)
 # -----------------------------------------------------------------------------
 # find a suitable hostname to use, if netdata did not supply a hostname
 
-[ -z "${host}" ] && host="${NETDATA_HOSTNAME}"
-[ -z "${host}" ] && host="${NETDATA_REGISTRY_HOSTNAME}"
 [ -z "${host}" ] && host="$(hostname 2>/dev/null)"
 
 # -----------------------------------------------------------------------------
@@ -1108,7 +1104,7 @@ EOF
 # prepare the content of the notification
 
 # the url to send the user on click
-urlencode "${NETDATA_REGISTRY_HOSTNAME}" >/dev/null; url_host="${REPLY}"
+urlencode "${host}" >/dev/null; url_host="${REPLY}"
 urlencode "${chart}" >/dev/null; url_chart="${REPLY}"
 urlencode "${family}" >/dev/null; url_family="${REPLY}"
 urlencode "${name}" >/dev/null; url_name="${REPLY}"

--- a/src/health.c
+++ b/src/health.c
@@ -148,7 +148,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '%0.0Lf' '%0.0Lf' '%s' '%u' '%u' '%s' '%s' '%s' '%s'",
               exec,
               recipient,
-              host->hostname,
+              host->registry_hostname,
               ae->unique_id,
               ae->alarm_id,
               ae->alarm_event_id,

--- a/src/main.c
+++ b/src/main.c
@@ -425,8 +425,6 @@ static void get_netdata_configured_variables() {
     netdata_configured_hostname = config_get(CONFIG_SECTION_GLOBAL, "hostname", buf);
     debug(D_OPTIONS, "hostname set to '%s'", netdata_configured_hostname);
 
-    netdata_configured_hostname    = config_get(CONFIG_SECTION_GLOBAL, "hostname",    CONFIG_DIR);
-
     // ------------------------------------------------------------------------
     // get default database size
 

--- a/src/registry.c
+++ b/src/registry.c
@@ -45,7 +45,7 @@ static inline void registry_json_header(RRDHOST *host, struct web_client *w, con
     buffer_flush(w->response.data);
     w->response.data->contenttype = CT_APPLICATION_JSON;
     buffer_sprintf(w->response.data, "{\n\t\"action\": \"%s\",\n\t\"status\": \"%s\",\n\t\"hostname\": \"%s\",\n\t\"machine_guid\": \"%s\"",
-            action, status, (host == localhost)?registry.hostname:host->hostname, host->machine_guid);
+            action, status, host->registry_hostname, host->machine_guid);
 }
 
 static inline void registry_json_footer(struct web_client *w) {

--- a/src/registry.h
+++ b/src/registry.h
@@ -70,6 +70,8 @@ extern int registry_request_hello_json(RRDHOST *host, struct web_client *w);
 extern void registry_statistics(void);
 
 extern char *registry_get_this_machine_guid(void);
+extern char *registry_get_this_machine_hostname(void);
+
 extern int regenerate_guid(const char *guid, char *result);
 
 #endif /* NETDATA_REGISTRY_H */

--- a/src/registry_init.c
+++ b/src/registry_init.c
@@ -34,7 +34,7 @@ int registry_init(void) {
     registry.persons_expiration = config_get_number(CONFIG_SECTION_REGISTRY, "registry expire idle persons days", 365) * 86400;
     registry.registry_domain = config_get(CONFIG_SECTION_REGISTRY, "registry domain", "");
     registry.registry_to_announce = config_get(CONFIG_SECTION_REGISTRY, "registry to announce", "https://registry.my-netdata.io");
-    registry.hostname = config_get(CONFIG_SECTION_REGISTRY, "registry hostname", config_get(CONFIG_SECTION_GLOBAL, "hostname", "localhost"));
+    registry.hostname = config_get(CONFIG_SECTION_REGISTRY, "registry hostname", netdata_configured_hostname);
     registry.verify_cookies_redirects = config_get_boolean(CONFIG_SECTION_REGISTRY, "verify browser cookies support", 1);
 
     setenv("NETDATA_REGISTRY_HOSTNAME", registry.hostname, 1);

--- a/src/registry_internals.c
+++ b/src/registry_internals.c
@@ -274,6 +274,10 @@ static inline int is_machine_guid_blacklisted(const char *guid) {
     return 0;
 }
 
+char *registry_get_this_machine_hostname(void) {
+    return registry.hostname;
+}
+
 char *registry_get_this_machine_guid(void) {
     static char guid[GUID_LEN + 1] = "";
 

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -368,6 +368,8 @@ struct rrdhost {
     char *hostname;                                 // the hostname of this host
     uint32_t hash_hostname;                         // the hostname hash
 
+    char *registry_hostname;                        // the registry hostname for this host
+
     char machine_guid[GUID_LEN + 1];                // the unique ID of this host
     uint32_t hash_machine_guid;                     // the hash of the unique ID
 
@@ -488,6 +490,7 @@ extern RRDHOST *rrdhost_find_by_guid(const char *guid, uint32_t hash);
 
 extern RRDHOST *rrdhost_find_or_create(
         const char *hostname
+        , const char *registry_hostname
         , const char *guid
         , const char *os
         , int update_every

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -6472,7 +6472,7 @@ var NETDATA = window.NETDATA || {};
 
     NETDATA.alarms = {
         onclick: null,                  // the callback to handle the click - it will be called with the alarm log entry
-        chart_div_offset: 100,          // give that space above the chart when scrolling to it
+        chart_div_offset: -50,          // give that space above the chart when scrolling to it
         chart_div_id_prefix: 'chart_',  // the chart DIV IDs have this prefix (they should be NETDATA.name2id(chart.id))
         chart_div_animation_duration: 0,// the duration of the animation while scrolling to a chart
 

--- a/web/index.html
+++ b/web/index.html
@@ -2349,7 +2349,7 @@
                 netdata_url = NETDATA.serverDefault;
 
             // initialize clickable alarms
-            NETDATA.alarms.chart_div_offset = 100;
+            NETDATA.alarms.chart_div_offset = -50;
             NETDATA.alarms.chart_div_id_prefix = 'chart_';
             NETDATA.alarms.chart_div_animation_duration = 0;
 

--- a/web/index.html
+++ b/web/index.html
@@ -3545,4 +3545,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170503-3"></script>
+<script type="text/javascript" src="dashboard.js?v20170514-1"></script>


### PR DESCRIPTION
alarm notification URLs use the hostname to find the URL of the netdata dashboard.

This hostname is the `[registry].hostname`, not the `[global].hostname`, since the registry is not aware of the global one.

Before this PR, there were 3 issues:

1. `alarm-notify.sh` was called with a hostname, but not the registry one.
2. `alarm-notify.sh` was using `${NETDATA_REGISTRY_HOSTNAME}`, which of course is wrong if the alarm is for a slave netdata.
3. slaves did not send to master their `[registry].hostname`.

This PR fixes them all. That is:

1. slaves send their `[registry].hostname` to the master.
2. the master calls alarm notification programs with the registry hostname of the host.
