### PR TITLE
Web log improvements

### DIFF
--- a/conf.d/python.d/web_log.conf
+++ b/conf.d/python.d/web_log.conf
@@ -67,6 +67,10 @@
 #          cacti: 'cacti.*'               # name(dimension): REGEX to match
 #          observium: 'observium.*'       # name(dimension): REGEX to match
 #          stub_status: 'stub_status'     # name(dimension): REGEX to match
+#     user_defined:                       # requests per pattern in <user_defined> field (custom_log_format)
+#          cacti: 'cacti.*'               # name(dimension): REGEX to match
+#          observium: 'observium.*'       # name(dimension): REGEX to match
+#          stub_status: 'stub_status'     # name(dimension): REGEX to match
 #     custom_log_format:                  # define a custom log format
 #          pattern: '(?P<address>[\da-f.:]+) -.*?"(?P<method>[A-Z]+) (?P<url>.*?)" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d\.\d+) '
 #          time_multiplier: 1000000       # type <int> - convert time to microseconds

--- a/python.d/fail2ban.chart.py
+++ b/python.d/fail2ban.chart.py
@@ -12,7 +12,7 @@ from base import LogService
 priority = 60000
 retries = 60
 REGEX_JAILS = r_compile(r'\[([A-Za-z-_0-9]+)][^\[\]]*?(?<!# )enabled = (?:(true|false))')
-REGEX_DATA = r_compile(r'\[(?P<jail>[A-Za-z-_0-9]+)\] (?P<action>[A-Z])[a-z]+ (?P<ipaddr>\d{1,3}(?:\.\d{1,3}){3})')
+REGEX_DATA = r_compile(r'\[(?P<jail>[A-Za-z-_0-9]+)\] (?P<action>(?:(U|B)))[a-z]+ (?P<ipaddr>\d{1,3}(?:\.\d{1,3}){3})')
 ORDER = ['jails_bans', 'jails_in_jail']
 
 


### PR DESCRIPTION
https://github.com/firehol/netdata/issues/2196

Example: <user_defined> is $host

```
log_format netdata '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '$request_length $request_time "$host" '
                    '"$http_referer" "$http_user_agent"';
```


`10.4.12.41 - - [18/May/2017:15:23:54 +0900] "GET /api/v1/alarms?active&_=1494921766863 HTTP/1.1" 200 142 471 0.096 "health.somedomain.lan" "http://health.somedomain.lan/" "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"`

`pattern: '(?P<address>[\da-f.:]+) -.*?"(?P<method>[A-Z]+) (?P<url>[^ ]+) [A-Z]+/(?P<http_version>\d\.\d)" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d\.\d+) "(?P<user_defined>[^"]+)'`
```yaml
nginx_log:
  name: 'nginx'
  path: '/var/log/nginx/access.log'
  user_defined:
    tech: 'tech'
    health: 'health'
  categories:
    cacti: 'cacti'
    observium: 'observium'
  custom_log_format:
    pattern: '(?P<address>[\da-f.:]+) -.*?"(?P<method>[A-Z]+) (?P<url>[^ ]+) [A-Z]+/(?P<http_version>\d\.\d)" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d\.\d+) "(?P<user_defined>[^"]+)'
```
![screenshot_20170518_145324](https://cloud.githubusercontent.com/assets/22274335/26188950/261540e6-3bdd-11e7-86b6-216cb7f6fe9c.png)

