### PR TITLE
Fix minor typo in fping plugin

### DIFF
--- a/plugins.d/fping.plugin
+++ b/plugins.d/fping.plugin
@@ -163,7 +163,7 @@ source "${NETDATA_CONFIG_DIR}/${plugin}.conf"
 
 if [ -z "${hosts}" ]
 then
-	fatal "no hosts configued in '${NETDATA_CONFIG_DIR}/${plugin}.conf' - nothing to do."
+	fatal "no hosts configured in '${NETDATA_CONFIG_DIR}/${plugin}.conf' - nothing to do."
 fi
 
 if [ -z "${fping}" -o ! -x "${fping}" ]


### PR DESCRIPTION
Fix minor typo in fping plugin ("configued" -> "configured")