### PR TITLE
changed get_latest_commit_id() to use git-rev-parse HEAD

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1212,10 +1212,7 @@ failed() {
 }
 
 get_latest_commit_id() {
-    git log -1           2>&3 |\\
-        grep ^commit     2>&3 |\\
-        head -n 1        2>&3 |\\
-        cut -d ' ' -f 2  2>&3
+	git rev-parse HEAD 2>&3
 }
 
 update() {


### PR DESCRIPTION
On my system my ~/.gitconfig had a section like this:
```git
[format]
  pretty = format:%C(blue)%ad%Creset %C(yellow)%h%C(green)%d%Creset %C(blue)%s %C(magenta) [%an]%Creset
```
This prevented the `get_latest_commit_id()` function from working properly. Anyway, `git log`  is intended for human viewers. `git rev-parse HEAD` is a more reliable alternative.

source: https://stackoverflow.com/questions/949314/how-to-retrieve-the-hash-for-the-current-commit-in-git