### PR TITLE
Web log: allow filtering with regex

### DIFF
--- a/conf.d/python.d/web_log.conf
+++ b/conf.d/python.d/web_log.conf
@@ -60,9 +60,12 @@
 # Additionally to the above, web_log also supports the following:
 #
 #     path: 'PATH'                        # the path to web server log file
-#     detailed_response_codes: yes/no     # Default: yes. Additional chart where response codes are not grouped
-#     detailed_response_aggregate: yes/no # Default: yes. Not aggregated detailed response codes charts
-#     all_time : yes/no                   # Default: yes. All time unique client IPs chart (50000 addresses ~ 400KB)
+#     detailed_response_codes: yes/no     # default: yes. Additional chart where response codes are not grouped
+#     detailed_response_aggregate: yes/no # default: yes. Not aggregated detailed response codes charts
+#     all_time : yes/no                   # default: yes. All time unique client IPs chart (50000 addresses ~ 400KB)
+#     filter:                             # filter with regex
+#          inclue: 'REGEX'                # only those rows that matches the regex
+#          exclude: 'REGEX'               # all rows except those that matches the regex
 #     categories:                         # requests per url chart configuration
 #          cacti: 'cacti.*'               # name(dimension): REGEX to match
 #          observium: 'observium.*'       # name(dimension): REGEX to match

--- a/conf.d/python.d/web_log.conf
+++ b/conf.d/python.d/web_log.conf
@@ -64,7 +64,7 @@
 #     detailed_response_aggregate: yes/no # default: yes. Not aggregated detailed response codes charts
 #     all_time : yes/no                   # default: yes. All time unique client IPs chart (50000 addresses ~ 400KB)
 #     filter:                             # filter with regex
-#          inclue: 'REGEX'                # only those rows that matches the regex
+#          include: 'REGEX'               # only those rows that matches the regex
 #          exclude: 'REGEX'               # all rows except those that matches the regex
 #     categories:                         # requests per url chart configuration
 #          cacti: 'cacti.*'               # name(dimension): REGEX to match

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -881,7 +881,7 @@ class ExecutableService(SimpleService):
         try:
             p = Popen(self.command, stdout=PIPE, stderr=PIPE)
         except Exception as error:
-            self.error("Executing command", self.command, "resulted in error:", str(error))
+            self.error("Executing command", " ".join(self.command), "resulted in error:", str(error))
             return None
         data = list()
         std = p.stderr if stderr else p.stdout

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -11,7 +11,6 @@ from base import LogService
 try:
     from itertools import filterfalse
 except ImportError:
-    from itertools import ifilter as filter
     from itertools import ifilterfalse as filterfalse
 import msg
 
@@ -299,13 +298,13 @@ class Mixin:
         """
         if not self.pre_filter:
             return raw_data
-        parsed = raw_data
+        filtered = raw_data
         for elem in self.pre_filter:
             if elem.description == 'filter_include':
-                parsed = filter(elem.func, parsed)
+                filtered = filter(elem.func, filtered)
             elif elem.description == 'filter_exclude':
-                parsed = filterfalse(elem.func, parsed)
-        return parsed
+                filtered = filterfalse(elem.func, filtered)
+        return filtered
 
     def add_new_dimension(self, dimension_id, chart_key, dimension=None,
                           algorithm='incremental', multiplier=1, divisor=1):
@@ -959,12 +958,14 @@ def check_patterns(string, dimension_regex_dict):
             return False
 
     def func_search(pattern):
-        return lambda v: pattern.search(v)
+        def closure(v):
+            return pattern.search(v)
+        return closure
 
     for dimension, regex in dimension_regex_dict.items():
         valid = valid_pattern(regex)
-        func = func_search(valid)
         if isinstance(dimension, str) and valid_pattern:
+            func = func_search(valid)
             result.append(NAMED_PATTERN(description='_'.join([string, dimension]),
                                         func=func))
     return result or None

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -8,6 +8,11 @@ from os.path import getsize
 from collections import namedtuple
 from copy import deepcopy
 from base import LogService
+try:
+    from itertools import filterfalse
+except ImportError:
+    from itertools import ifilter as filter
+    from itertools import ifilterfalse as filterfalse
 import msg
 
 priority = 60000
@@ -216,7 +221,7 @@ CHARTS_SQUID = {
         ]}
 }
 
-NAMED_PATTERN = namedtuple('PATTERN', ['description', 'pattern'])
+NAMED_PATTERN = namedtuple('PATTERN', ['description', 'func'])
 
 DET_RESP_AGGR = ['', '_1xx', '_2xx', '_3xx', '_4xx', '_5xx', '_Other']
 
@@ -287,6 +292,21 @@ class Service(LogService):
 
 
 class Mixin:
+    def filter_data(self, raw_data):
+        """
+        :param raw_data: list
+        :return:
+        """
+        if not self.pre_filter:
+            return raw_data
+        parsed = raw_data
+        for elem in self.pre_filter:
+            if elem.description == 'filter_include':
+                parsed = filter(elem.func, parsed)
+            elif elem.description == 'filter_exclude':
+                parsed = filterfalse(elem.func, parsed)
+        return parsed
+
     def add_new_dimension(self, dimension_id, chart_key, dimension=None,
                           algorithm='incremental', multiplier=1, divisor=1):
         """
@@ -350,6 +370,7 @@ class Mixin:
 class Web(Mixin):
     def __init__(self, configuration):
         self.conf = configuration
+        self.pre_filter = check_patterns('filter', self.conf.get('filter'))
         self.storage = dict()
         self.data = {'bytes_sent': 0, 'resp_length': 0, 'resp_time_min': 0, 'resp_time_max': 0,
                      'resp_time_avg': 0, 'unique_cur_ipv4': 0, 'unique_cur_ipv6': 0, '2xx': 0,
@@ -432,13 +453,15 @@ class Web(Mixin):
         None if _get_raw_data method fails.
         In all other cases - dict.
         """
-        if raw_data is None:
-            return None
+        if not raw_data:
+            return None if raw_data is None else self.data
+
+        filtered_data = self.filter_data(raw_data=raw_data)
 
         request_time, unique_current = list(), list()
         request_counter = {'count': 0, 'sum': 0}
         ip_address_counter = {'unique_cur_ip': 0}
-        for line in raw_data:
+        for line in filtered_data:
             match = self.storage['regex'].search(line)
             if match:
                 match_dict = match.groupdict()
@@ -702,7 +725,7 @@ class Web(Mixin):
         """
         match = None
         for elem in pattern:
-            if elem.pattern.search(row):
+            if elem.func(row):
                 self.data[elem.description] += 1
                 match = True
                 break
@@ -758,6 +781,7 @@ class Squid(Mixin):
         self.conf = configuration
         self.order = ORDER_SQUID
         self.definitions = CHARTS_SQUID
+        self.pre_filter = check_patterns('filter', self.conf.get('filter'))
         self.storage = dict()
         self.data = {'duration_max': 0, 'duration_avg': 0, 'duration_min': 0, 'bytes': 0,
                      '0xx': 0, '1xx': 0, '2xx': 0, '3xx': 0, '4xx': 0, '5xx': 0,
@@ -799,12 +823,14 @@ class Squid(Mixin):
         return True
 
     def get_data(self, raw_data=None):
-        if raw_data is None:
-            return None
+        if not raw_data:
+            return None if raw_data is None else self.data
+
+        filtered_data = self.filter_data(raw_data=raw_data)
 
         unique_ip, duration = set(), list()
 
-        for row in raw_data:
+        for row in filtered_data:
             match = self.storage['regex'].search(row)
             if match:
                 match = match.groupdict()
@@ -932,11 +958,15 @@ def check_patterns(string, dimension_regex_dict):
         except re.error:
             return False
 
+    def func_search(pattern):
+        return lambda v: pattern.search(v)
+
     for dimension, regex in dimension_regex_dict.items():
         valid = valid_pattern(regex)
+        func = func_search(valid)
         if isinstance(dimension, str) and valid_pattern:
-            result.append(NAMED_PATTERN(description='_'.join([string, dimension]), pattern=valid))
-
+            result.append(NAMED_PATTERN(description='_'.join([string, dimension]),
+                                        func=func))
     return result or None
 
 


### PR DESCRIPTION
https://github.com/firehol/netdata/issues/2278
https://github.com/firehol/netdata/issues/2192
> An easy way to do it, is to add a filter regex configuration option. So, we could add the same log file many times, with different filters.

^