### PR TITLE
Log service: support for log file with pattern match

### DIFF
--- a/conf.d/python.d/web_log.conf
+++ b/conf.d/python.d/web_log.conf
@@ -60,6 +60,7 @@
 # Additionally to the above, web_log also supports the following:
 #
 #     path: 'PATH'                        # the path to web server log file
+#     path: 'PATH[0-9]*[0-9]'             # log files with date suffix are also supported
 #     detailed_response_codes: yes/no     # default: yes. Additional chart where response codes are not grouped
 #     detailed_response_aggregate: yes/no # default: yes. Not aggregated detailed response codes charts
 #     all_time : yes/no                   # default: yes. All time unique client IPs chart (50000 addresses ~ 400KB)

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -848,6 +848,7 @@ class LogService(SimpleService):
         """
         self.__re_find['run'] = self.__re_find['maximum']
         self.__re_find['current'] = 0
+        self.__glob_path = self.__glob_path or self.log_path  # workaround for modules w/o config files
         path_list = glob(self.__glob_path)
         if path_list:
             self.log_path = max(path_list)

--- a/python.d/python_modules/base.py
+++ b/python.d/python_modules/base.py
@@ -20,12 +20,12 @@
 import time
 import os
 import socket
-import select
 import threading
 import msg
 import ssl
 from subprocess import Popen, PIPE
 from sys import exc_info
+from glob import glob
 
 try:
     from urlparse import urlparse
@@ -807,57 +807,68 @@ class SocketService(SimpleService):
 
 class LogService(SimpleService):
     def __init__(self, configuration=None, name=None):
-        self.log_path = ""
-        self._last_position = 0
-        # self._log_reader = None
         SimpleService.__init__(self, configuration=configuration, name=name)
+        self.log_path = self.configuration.get('path')
+        self.__glob_path = self.log_path
+        self._last_position = 0
         self.retries = 100000  # basically always retry
+        self.__re_find = dict(current=0, run=0, maximum=60)
 
     def _get_raw_data(self):
         """
         Get log lines since last poll
         :return: list
         """
-        lines = []
+        lines = list()
         try:
-            if os.path.getsize(self.log_path) < self._last_position:
+            if self.__re_find['current'] == self.__re_find['run']:
+                self._find_recent_log_file()
+            size = os.path.getsize(self.log_path)
+            if size == self._last_position:
+                self.__re_find['current'] += 1
+                return list()  # return empty list if nothing has changed
+            elif size < self._last_position:
                 self._last_position = 0  # read from beginning if file has shrunk
-            elif os.path.getsize(self.log_path) == self._last_position:
-                self.debug("Log file hasn't changed. No new data.")
-                return []  # return empty list if nothing has changed
-            with open(self.log_path, "r") as fp:
+
+            with open(self.log_path) as fp:
                 fp.seek(self._last_position)
-                for i, line in enumerate(fp):
+                for line in fp:
                     lines.append(line)
                 self._last_position = fp.tell()
-        except Exception as e:
-            self.error(str(e))
+                self.__re_find['current'] = 0
+        except (OSError, IOError) as error:
+            self.__re_find['current'] += 1
+            self.error(str(error))
 
-        if len(lines) != 0:
-            return lines
-        else:
-            self.error("No data collected.")
-            return None
+        return lines or None
+
+    def _find_recent_log_file(self):
+        """
+        :return:
+        """
+        self.__re_find['run'] = self.__re_find['maximum']
+        self.__re_find['current'] = 0
+        path_list = glob(self.__glob_path)
+        if path_list:
+            self.log_path = max(path_list)
+            return True
+        return False
 
     def check(self):
         """
         Parse basic configuration and check if log file exists
         :return: boolean
         """
-        if self.name is not None or self.name != str(None):
-            self.name = ""
-        else:
-            self.name = str(self.name)
-        try:
-            self.log_path = str(self.configuration['path'])
-        except (KeyError, TypeError):
-            self.info("No path to log specified. Using: '" + self.log_path + "'")
+        if not self.log_path:
+            self.error("No path to log specified")
+            return None
 
-        if os.access(self.log_path, os.R_OK):
+        if all([self._find_recent_log_file(),
+                os.access(self.log_path, os.R_OK),
+                os.path.isfile(self.log_path)]):
             return True
-        else:
-            self.error("Cannot access file: '" + self.log_path + "'")
-            return False
+        self.error("Cannot access %s" % self.log_path)
+        return False
 
     def create(self):
         # set cursor at last byte of log file

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -264,19 +264,21 @@ class Service(LogService):
         if not self.log_path:
             self.error('log path is not specified')
             return False
+        self._find_recent_log_file()
 
         if not access(self.log_path, R_OK):
-            self.error('%s not readable or not exist' % self.configuration['path'])
+            self.error('%s not readable or not exist' % self.log_path)
             return False
 
         if not getsize(self.log_path):
-            self.error('%s is empty' % self.configuration['path'])
+            self.error('%s is empty' % self.log_path)
             return False
 
         self.configuration['update_every'] = self.update_every
         self.configuration['name'] = self.name
         self.configuration['override_name'] = self.override_name
         self.configuration['_dimensions'] = self._dimensions
+        self.configuration['path'] = self.log_path
 
         cls = log_types[self.log_type]
         self.Job = cls(configuration=self.configuration)

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -264,9 +264,8 @@ class Service(LogService):
         if not self.log_path:
             self.error('log path is not specified')
             return False
-        self._find_recent_log_file()
 
-        if not access(self.log_path, R_OK):
+        if not (self._find_recent_log_file() and access(self.log_path, R_OK)):
             self.error('%s not readable or not exist' % self.log_path)
             return False
 
@@ -285,6 +284,7 @@ class Service(LogService):
         if self.Job.check():
             self.order = self.Job.order
             self.definitions = self.Job.definitions
+            self.info('Current log file: %s' % self.log_path)
             return True
         return False
 


### PR DESCRIPTION
fixes https://github.com/firehol/netdata/issues/2282
fixes https://github.com/firehol/netdata/pull/2283

initial support. Should be improved in the future (get rid of N hard coded iterations, add  `backoff` algorithm).

How it works.
```max(glob(LOG_FILE_PATTERN))``` is used to find the most recent log file.

```bash
[~/logs]ls -l
total 4
-rw-r--r-- 1 lgz lgz  0 Jun  5 16:23 access_log.20170605
-rw-r--r-- 1 lgz lgz  0 Jun  5 16:23 access_log.20170606
-rw-r--r-- 1 lgz lgz  0 Jun  5 16:23 access_log.20170607
-rw-r--r-- 1 lgz lgz  0 Jun  5 18:16 access_log.20170701
```

```python
In [2]: max(glob('access_log.[0-9]*[0-9]'))
Out[2]: 'access_log.20170701'
```

```max(glob(LOG_FILE_PATTERN))``` runs only if:
1. Current log file is not updated for 60 iterations in a row
2. Current log file is missing (rotated). Again 60 iterations.

60 iterations is hard coded. So it will be 1 minute gap after the service starts to write to the new file.

 
