### PR TITLE
various bugfixes; allow memory mode ram to use KSM; propagate dimension changes to masters

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -943,105 +943,125 @@ inline char *trim_all(char *buffer) {
     return buffer;
 }
 
-void *mymmap(const char *filename, size_t size, int flags, int ksm) {
-#ifndef MADV_MERGEABLE
-    (void)ksm;
-#endif
-    static int log_madvise_1 = 1;
-#ifdef MADV_MERGEABLE
-    static int log_madvise_2 = 1, log_madvise_3 = 1;
-#endif
-    void *mem = NULL;
-
-    errno = 0;
+static int memory_file_open(const char *filename, size_t size) {
     int fd = open(filename, O_RDWR | O_CREAT | O_NOATIME, 0664);
     if (fd != -1) {
         if (lseek(fd, size, SEEK_SET) == (off_t) size) {
             if (write(fd, "", 1) == 1) {
                 if (ftruncate(fd, size))
                     error("Cannot truncate file '%s' to size %zu. Will use the larger file.", filename, size);
-
-#ifdef MADV_MERGEABLE
-                if (flags & MAP_SHARED || !enable_ksm || !ksm) {
-#endif
-                    mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, fd, 0);
-                    if (mem == MAP_FAILED) {
-                        error("Cannot allocate SHARED memory for file '%s'.", filename);
-                        mem = NULL;
-                    }
-                    else {
-#ifdef NETDATA_LOG_ALLOCATIONS
-                        mmap_accounting(size);
-#endif
-                        int advise = MADV_SEQUENTIAL | MADV_DONTFORK;
-                        if (flags & MAP_SHARED) advise |= MADV_WILLNEED;
-
-                        if (madvise(mem, size, advise) != 0 && log_madvise_1) {
-                            error("Cannot advise the kernel about the memory usage of file '%s'.", filename);
-                            log_madvise_1--;
-                        }
-                    }
-#ifdef MADV_MERGEABLE
-                }
-                else {
-/*
-                    // test - load the file into memory
-                    mem = calloc(1, size);
-                    if(mem) {
-                        if(lseek(fd, 0, SEEK_SET) == 0) {
-                            if(read(fd, mem, size) != (ssize_t)size)
-                                error("Cannot read from file '%s'", filename);
-                        }
-                        else
-                            error("Cannot seek to beginning of file '%s'.", filename);
-                    }
-*/
-                    mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags | MAP_ANONYMOUS, -1, 0);
-                    if (mem == MAP_FAILED) {
-                        error("Cannot allocate PRIVATE ANONYMOUS memory for KSM for file '%s'.", filename);
-                        mem = NULL;
-                    }
-                    else {
-#ifdef NETDATA_LOG_ALLOCATIONS
-                        mmap_accounting(size);
-#endif
-                        if (lseek(fd, 0, SEEK_SET) == 0) {
-                            if (read(fd, mem, size) != (ssize_t) size)
-                                error("Cannot read from file '%s'", filename);
-                        } else
-                            error("Cannot seek to beginning of file '%s'.", filename);
-
-                        // don't use MADV_SEQUENTIAL|MADV_DONTFORK, they disable MADV_MERGEABLE
-                        if (madvise(mem, size, MADV_SEQUENTIAL | MADV_DONTFORK) != 0 && log_madvise_2) {
-                            error("Cannot advise the kernel about the memory usage (MADV_SEQUENTIAL|MADV_DONTFORK) of file '%s'.",
-                                  filename);
-                            log_madvise_2--;
-                        }
-
-                        if (madvise(mem, size, MADV_MERGEABLE) != 0 && log_madvise_3) {
-                            error("Cannot advise the kernel about the memory usage (MADV_MERGEABLE) of file '%s'.",
-                                  filename);
-                            log_madvise_3--;
-                        }
-                    }
-                }
-#endif
             }
-            else
-                error("Cannot write to file '%s' at position %zu.", filename, size);
+            else error("Cannot write to file '%s' at position %zu.", filename, size);
         }
-        else
-            error("Cannot seek file '%s' to size %zu.", filename, size);
-
-        close(fd);
+        else error("Cannot seek file '%s' to size %zu.", filename, size);
     }
-    else
-        error("Cannot create/open file '%s'.", filename);
+    else error("Cannot create/open file '%s'.", filename);
+
+    return fd;
+}
+
+// mmap_shared is used for memory mode = map
+static void *memory_file_mmap(const char *filename, size_t size, int flags) {
+    static int log_madvise = 1;
+
+    int fd = -1;
+    if(filename) {
+        fd = memory_file_open(filename, size);
+        if(fd == -1) return MAP_FAILED;
+    }
+
+    void *mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, fd, 0);
+    if (mem != MAP_FAILED) {
+#ifdef NETDATA_LOG_ALLOCATIONS
+        mmap_accounting(size);
+#endif
+        int advise = MADV_SEQUENTIAL | MADV_DONTFORK;
+        if (flags & MAP_SHARED) advise |= MADV_WILLNEED;
+
+        if (madvise(mem, size, advise) != 0 && log_madvise) {
+            error("Cannot advise the kernel about shared memory usage.");
+            log_madvise--;
+        }
+    }
+
+    if(fd != -1)
+        close(fd);
 
     return mem;
 }
 
-int savememory(const char *filename, void *mem, size_t size) {
+#ifdef MADV_MERGEABLE
+static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
+    static int log_madvise_2 = 1, log_madvise_3 = 1;
+
+    int fd = -1;
+    if(filename) {
+        fd = memory_file_open(filename, size);
+        if(fd == -1) return MAP_FAILED;
+    }
+
+    void *mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags | MAP_ANONYMOUS, -1, 0);
+    if (mem != MAP_FAILED) {
+#ifdef NETDATA_LOG_ALLOCATIONS
+        mmap_accounting(size);
+#endif
+        if(fd != -1) {
+            if (lseek(fd, 0, SEEK_SET) == 0) {
+                if (read(fd, mem, size) != (ssize_t) size)
+                    error("Cannot read from file '%s'", filename);
+            }
+            else error("Cannot seek to beginning of file '%s'.", filename);
+
+            // don't use MADV_SEQUENTIAL|MADV_DONTFORK, they disable MADV_MERGEABLE
+            if (madvise(mem, size, MADV_SEQUENTIAL | MADV_DONTFORK) != 0 && log_madvise_2) {
+                error("Cannot advise the kernel about the memory usage (MADV_SEQUENTIAL|MADV_DONTFORK) of file '%s'.", filename);
+                log_madvise_2--;
+            }
+
+            if (madvise(mem, size, MADV_MERGEABLE) != 0 && log_madvise_3) {
+                error("Cannot advise the kernel about the memory usage (MADV_MERGEABLE) of file '%s'.", filename);
+                log_madvise_3--;
+            }
+        }
+    }
+
+    if(fd != -1)
+        close(fd);
+
+    return mem;
+}
+#else
+static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
+
+    if(filename)
+        return memory_file_mmap(filename, size, flags);
+
+    // when KSM is not available and no filename is given (memory mode = ram),
+    // we just report failure
+    return MAP_FAILED;
+}
+#endif
+
+void *mymmap(const char *filename, size_t size, int flags, int ksm) {
+    void *mem = NULL;
+
+    if (filename && (flags & MAP_SHARED || !enable_ksm || !ksm))
+        // memory mode = map | save
+        // when KSM is not enabled
+        // MAP_SHARED is used for memory mode = map (no KSM possible)
+        mem = memory_file_mmap(filename, size, flags);
+
+    else
+        // memory mode = save | ram
+        // when KSM is enabled
+        // for memory mode = ram, the filename is NULL
+        mem = memory_file_mmap_ksm(filename, size, flags);
+
+    if(mem == MAP_FAILED) return NULL;
+    return mem;
+}
+
+int memory_file_save(const char *filename, void *mem, size_t size) {
     char tmpfilename[FILENAME_MAX + 1];
 
     snprintfz(tmpfilename, FILENAME_MAX, "%s.%ld.tmp", filename, (long) getpid());

--- a/src/common.c
+++ b/src/common.c
@@ -944,6 +944,8 @@ inline char *trim_all(char *buffer) {
 }
 
 static int memory_file_open(const char *filename, size_t size) {
+    // info("memory_file_open('%s', %zu", filename, size);
+
     int fd = open(filename, O_RDWR | O_CREAT | O_NOATIME, 0664);
     if (fd != -1) {
         if (lseek(fd, size, SEEK_SET) == (off_t) size) {
@@ -962,6 +964,7 @@ static int memory_file_open(const char *filename, size_t size) {
 
 // mmap_shared is used for memory mode = map
 static void *memory_file_mmap(const char *filename, size_t size, int flags) {
+    // info("memory_file_mmap('%s', %zu", filename, size);
     static int log_madvise = 1;
 
     int fd = -1;
@@ -992,6 +995,7 @@ static void *memory_file_mmap(const char *filename, size_t size, int flags) {
 
 #ifdef MADV_MERGEABLE
 static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
+    // info("memory_file_mmap_ksm('%s', %zu", filename, size);
     static int log_madvise_2 = 1, log_madvise_3 = 1;
 
     int fd = -1;
@@ -1011,17 +1015,17 @@ static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) 
                     error("Cannot read from file '%s'", filename);
             }
             else error("Cannot seek to beginning of file '%s'.", filename);
+        }
 
-            // don't use MADV_SEQUENTIAL|MADV_DONTFORK, they disable MADV_MERGEABLE
-            if (madvise(mem, size, MADV_SEQUENTIAL | MADV_DONTFORK) != 0 && log_madvise_2) {
-                error("Cannot advise the kernel about the memory usage (MADV_SEQUENTIAL|MADV_DONTFORK) of file '%s'.", filename);
-                log_madvise_2--;
-            }
+        // don't use MADV_SEQUENTIAL|MADV_DONTFORK, they disable MADV_MERGEABLE
+        if (madvise(mem, size, MADV_SEQUENTIAL | MADV_DONTFORK) != 0 && log_madvise_2) {
+            error("Cannot advise the kernel about the memory usage (MADV_SEQUENTIAL|MADV_DONTFORK) of file '%s'.", filename);
+            log_madvise_2--;
+        }
 
-            if (madvise(mem, size, MADV_MERGEABLE) != 0 && log_madvise_3) {
-                error("Cannot advise the kernel about the memory usage (MADV_MERGEABLE) of file '%s'.", filename);
-                log_madvise_3--;
-            }
+        if (madvise(mem, size, MADV_MERGEABLE) != 0 && log_madvise_3) {
+            error("Cannot advise the kernel about the memory usage (MADV_MERGEABLE) of file '%s'.", filename);
+            log_madvise_3--;
         }
     }
 
@@ -1032,6 +1036,7 @@ static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) 
 }
 #else
 static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
+    // info("memory_file_mmap_ksm FALLBACK ('%s', %zu", filename, size);
 
     if(filename)
         return memory_file_mmap(filename, size, flags);

--- a/src/common.c
+++ b/src/common.c
@@ -226,6 +226,13 @@ void json_escape_string(char *dst, const char *src, size_t size) {
     *d = '\0';
 }
 
+void json_fix_string(char *s) {
+    for( ; *s ;s++) {
+        if(unlikely(*s == '\\')) *s = '/';
+        else if(unlikely(*s == '"')) *s = '\'';
+    }
+}
+
 int sleep_usec(usec_t usec) {
 
 #ifndef NETDATA_WITH_USLEEP

--- a/src/common.h
+++ b/src/common.h
@@ -271,7 +271,7 @@ extern void freez(void *ptr);
 extern void json_escape_string(char *dst, const char *src, size_t size);
 
 extern void *mymmap(const char *filename, size_t size, int flags, int ksm);
-extern int savememory(const char *filename, void *mem, size_t size);
+extern int memory_file_save(const char *filename, void *mem, size_t size);
 
 extern int fd_is_valid(int fd);
 

--- a/src/common.h
+++ b/src/common.h
@@ -269,6 +269,7 @@ extern void freez(void *ptr);
 #endif
 
 extern void json_escape_string(char *dst, const char *src, size_t size);
+extern void json_fix_string(char *s);
 
 extern void *mymmap(const char *filename, size_t size, int flags, int ksm);
 extern int memory_file_save(const char *filename, void *mem, size_t size);

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -316,19 +316,14 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
                       , options?options:""
                 );
 
-            RRDDIM *rd = rrddim_find(st, id);
-            if(unlikely(!rd)) {
-                rd = rrddim_add(st, id, name, multiplier, divisor, rrd_algorithm_id(algorithm));
-                rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
-                rrddim_flag_clear(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
-                if(options && *options) {
-                    if(strstr(options, "hidden") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
-                    if(strstr(options, "noreset") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
-                    if(strstr(options, "nooverflow") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
-                }
+            RRDDIM *rd = rrddim_add(st, id, name, multiplier, divisor, rrd_algorithm_id(algorithm));
+            rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
+            rrddim_flag_clear(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
+            if(options && *options) {
+                if(strstr(options, "hidden") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
+                if(strstr(options, "noreset") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
+                if(strstr(options, "nooverflow") != NULL) rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
             }
-            else if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
-                debug(D_PLUGINSD, "PLUGINSD: dimension %s/%s already exists. Not adding it again.", st->id, id);
         }
         else if(unlikely(hash == DISABLE_HASH && !strcmp(s, PLUGINSD_KEYWORD_DISABLE))) {
             info("PLUGINSD: '%s' called DISABLE. Disabling it.", cd->fullfilename);

--- a/src/rrd.c
+++ b/src/rrd.c
@@ -31,18 +31,27 @@ inline const char *rrd_memory_mode_name(RRD_MEMORY_MODE id) {
             return RRD_MEMORY_MODE_NONE_NAME;
 
         case RRD_MEMORY_MODE_SAVE:
-        default:
             return RRD_MEMORY_MODE_SAVE_NAME;
+
+        case RRD_MEMORY_MODE_ALLOC:
+            return RRD_MEMORY_MODE_ALLOC_NAME;
     }
+
+    return RRD_MEMORY_MODE_SAVE_NAME;
 }
 
 RRD_MEMORY_MODE rrd_memory_mode_id(const char *name) {
     if(unlikely(!strcmp(name, RRD_MEMORY_MODE_RAM_NAME)))
         return RRD_MEMORY_MODE_RAM;
+
     else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_MAP_NAME)))
         return RRD_MEMORY_MODE_MAP;
+
     else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_NONE_NAME)))
         return RRD_MEMORY_MODE_NONE;
+
+    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_ALLOC_NAME)))
+        return RRD_MEMORY_MODE_ALLOC;
 
     return RRD_MEMORY_MODE_SAVE;
 }

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -5,7 +5,7 @@
 #define UPDATE_EVERY_MAX 3600
 
 #define RRD_DEFAULT_HISTORY_ENTRIES 3600
-#define RRD_HISTORY_ENTRIES_MAX (86400*10)
+#define RRD_HISTORY_ENTRIES_MAX (86400*365)
 
 extern int default_rrd_update_every;
 extern int default_rrd_history_entries;

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -212,11 +212,13 @@ typedef struct rrddim RRDDIM;
 // and may lead to missing information.
 
 typedef enum rrdset_flags {
-    RRDSET_FLAG_ENABLED  = 1 << 0, // enables or disables a chart
-    RRDSET_FLAG_DETAIL   = 1 << 1, // if set, the data set should be considered as a detail of another
-                                   // (the master data set should be the one that has the same family and is not detail)
-    RRDSET_FLAG_DEBUG    = 1 << 2, // enables or disables debugging for a chart
-    RRDSET_FLAG_OBSOLETE = 1 << 3  // this is marked by the collector/module as obsolete
+    RRDSET_FLAG_ENABLED        = 1 << 0, // enables or disables a chart
+    RRDSET_FLAG_DETAIL         = 1 << 1, // if set, the data set should be considered as a detail of another
+                                         // (the master data set should be the one that has the same family and is not detail)
+    RRDSET_FLAG_DEBUG          = 1 << 2, // enables or disables debugging for a chart
+    RRDSET_FLAG_OBSOLETE       = 1 << 3, // this is marked by the collector/module as obsolete
+    RRDSET_FLAG_BACKEND_SEND   = 1 << 4,
+    RRDSET_FLAG_BACKEND_IGNORE = 1 << 5
 } RRDSET_FLAGS;
 
 #define rrdset_flag_check(st, flag) ((st)->flags & flag)

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -281,7 +281,8 @@ struct rrdset {
     size_t counter_done;                            // the number of times rrdset_done() has been called
 
     time_t last_accessed_time;                      // the last time this RRDSET has been accessed
-    size_t unused[9];
+    time_t upstream_resync_time;                    // the timestamp up to which we should resync clock upstream
+    size_t unused[8];
 
     uint32_t hash;                                  // a simple hash on the id, to speed up searching
                                                     // we first compare hashes, and only if the hashes are equal we do string comparisons

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -617,7 +617,11 @@ extern void rrdset_done(RRDSET *st);
 extern RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm, RRD_MEMORY_MODE memory_mode);
 #define rrddim_add(st, id, name, multiplier, divisor, algorithm) rrddim_add_custom(st, id, name, multiplier, divisor, algorithm, (st)->rrd_memory_mode)
 
-extern void rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name);
+extern int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name);
+extern int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm);
+extern int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multiplier);
+extern int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor);
+
 extern RRDDIM *rrddim_find(RRDSET *st, const char *id);
 
 extern int rrddim_hide(RRDSET *st, const char *id);

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -42,13 +42,15 @@ typedef enum rrd_memory_mode {
     RRD_MEMORY_MODE_NONE = 0,
     RRD_MEMORY_MODE_RAM  = 1,
     RRD_MEMORY_MODE_MAP  = 2,
-    RRD_MEMORY_MODE_SAVE = 3
+    RRD_MEMORY_MODE_SAVE = 3,
+    RRD_MEMORY_MODE_ALLOC = 4
 } RRD_MEMORY_MODE;
 
 #define RRD_MEMORY_MODE_NONE_NAME "none"
 #define RRD_MEMORY_MODE_RAM_NAME "ram"
 #define RRD_MEMORY_MODE_MAP_NAME "map"
 #define RRD_MEMORY_MODE_SAVE_NAME "save"
+#define RRD_MEMORY_MODE_ALLOC_NAME "alloc"
 
 extern RRD_MEMORY_MODE default_rrd_memory_mode;
 

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -11,7 +11,7 @@ void rrd_stats_api_v1_chart_with_data(RRDSET *st, BUFFER *wb, size_t *dimensions
         "\t\t\t\"type\": \"%s\",\n"
         "\t\t\t\"family\": \"%s\",\n"
         "\t\t\t\"context\": \"%s\",\n"
-        "\t\t\t\"title\": \"%s\",\n"
+        "\t\t\t\"title\": \"%s (%s)\",\n"
         "\t\t\t\"priority\": %ld,\n"
         "\t\t\t\"enabled\": %s,\n"
         "\t\t\t\"units\": \"%s\",\n"
@@ -27,7 +27,7 @@ void rrd_stats_api_v1_chart_with_data(RRDSET *st, BUFFER *wb, size_t *dimensions
         , st->type
         , st->family
         , st->context
-        , st->title
+        , st->title, st->name
         , st->priority
         , rrdset_flag_check(st, RRDSET_FLAG_ENABLED)?"true":"false"
         , st->units

--- a/src/rrd2json_api_old.c
+++ b/src/rrd2json_api_old.c
@@ -14,7 +14,7 @@ unsigned long rrdset_info2json_api_old(RRDSET *st, char *options, BUFFER *wb) {
             "\t\t\t\"type\": \"%s\",\n"
             "\t\t\t\"family\": \"%s\",\n"
             "\t\t\t\"context\": \"%s\",\n"
-            "\t\t\t\"title\": \"%s\",\n"
+            "\t\t\t\"title\": \"%s (%s)\",\n"
             "\t\t\t\"priority\": %ld,\n"
             "\t\t\t\"enabled\": %d,\n"
             "\t\t\t\"units\": \"%s\",\n"
@@ -37,7 +37,7 @@ unsigned long rrdset_info2json_api_old(RRDSET *st, char *options, BUFFER *wb) {
             , st->type
             , st->family
             , st->context
-            , st->title
+            , st->title, st->name
             , st->priority
             , rrdset_flag_check(st, RRDSET_FLAG_ENABLED)?1:0
             , st->units

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -71,8 +71,14 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rrdset_strncpyz_name(filename, id, FILENAME_MAX);
     snprintfz(fullfilename, FILENAME_MAX, "%s/%s.db", st->cache_dir, filename);
 
-    if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP) {
-        rd = (RRDDIM *)mymmap(fullfilename, size, ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE), 1);
+    if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP || memory_mode == RRD_MEMORY_MODE_RAM) {
+        rd = (RRDDIM *)mymmap(
+                  (memory_mode == RRD_MEMORY_MODE_RAM)?NULL:fullfilename
+                , size
+                , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
+                , 1
+        );
+
         if(likely(rd)) {
             // we have a file mapped for rd
 

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -276,6 +276,7 @@ void rrddim_free(RRDSET *st, RRDDIM *rd)
     switch(rd->rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
         case RRD_MEMORY_MODE_MAP:
+        case RRD_MEMORY_MODE_RAM:
             debug(D_RRD_CALLS, "Unmapping dimension '%s'.", rd->name);
             freez((void *)rd->id);
             freez(rd->cache_filename);
@@ -283,7 +284,6 @@ void rrddim_free(RRDSET *st, RRDDIM *rd)
             break;
 
         case RRD_MEMORY_MODE_NONE:
-        case RRD_MEMORY_MODE_RAM:
             debug(D_RRD_CALLS, "Removing dimension '%s'.", rd->name);
             freez((void *)rd->id);
             freez(rd->cache_filename);

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -36,7 +36,7 @@ inline RRDDIM *rrddim_find(RRDSET *st, const char *id) {
 // RRDDIM rename a dimension
 
 inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
-    if(unlikely(!strcmp(rd->name, name)))
+    if(unlikely(!name || !*name || !strcmp(rd->name, name)))
         return 0;
 
     debug(D_RRD_CALLS, "rrddim_set_name() from %s.%s to %s.%s", st->name, rd->name, st->name, name);

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -51,7 +51,7 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
 }
 
 inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm) {
-    if(unlikely(rd->algorithm != algorithm))
+    if(unlikely(rd->algorithm == algorithm))
         return 0;
 
     debug(D_RRD_CALLS, "Updating algorithm of dimension '%s/%s' from %s to %s", st->id, rd->name, rrd_algorithm_name(rd->algorithm), rrd_algorithm_name(algorithm));
@@ -61,7 +61,7 @@ inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm)
 }
 
 inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multiplier) {
-    if(unlikely(rd->multiplier != multiplier))
+    if(unlikely(rd->multiplier == multiplier))
         return 0;
 
     debug(D_RRD_CALLS, "Updating multiplier of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, st->id, rd->name, rd->multiplier, multiplier);
@@ -71,7 +71,7 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multip
 }
 
 inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) {
-    if(unlikely(rd->divisor != divisor))
+    if(unlikely(rd->divisor == divisor))
         return 0;
 
     debug(D_RRD_CALLS, "Updating divisor of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, st->id, rd->name, rd->divisor, divisor);

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -74,7 +74,7 @@ static inline int need_to_send_chart_definition(RRDSET *st) {
 
 // sends the current chart definition
 static inline void send_chart_definition(RRDSET *st) {
-    buffer_sprintf(st->rrdhost->rrdpush_buffer, "CHART '%s' '%s' '%s' '%s' '%s' '%s' '%s' %ld %d\n"
+    buffer_sprintf(st->rrdhost->rrdpush_buffer, "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d\n"
                 , st->id
                 , st->name
                 , st->title
@@ -88,7 +88,7 @@ static inline void send_chart_definition(RRDSET *st) {
 
     RRDDIM *rd;
     rrddim_foreach_read(rd, st) {
-        buffer_sprintf(st->rrdhost->rrdpush_buffer, "DIMENSION '%s' '%s' '%s' " COLLECTED_NUMBER_FORMAT " " COLLECTED_NUMBER_FORMAT " '%s %s'\n"
+        buffer_sprintf(st->rrdhost->rrdpush_buffer, "DIMENSION \"%s\" \"%s\" \"%s\" " COLLECTED_NUMBER_FORMAT " " COLLECTED_NUMBER_FORMAT " \"%s %s\"\n"
                        , rd->id
                        , rd->name
                        , rrd_algorithm_name(rd->algorithm)

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -569,13 +569,8 @@ RRDSET *rrdset_create_custom(
     if(name && *name) rrdset_set_name(st, name);
     else rrdset_set_name(st, id);
 
-    {
-        char varvalue[CONFIG_MAX_VALUE + 1];
-        char varvalue2[CONFIG_MAX_VALUE + 1];
-        snprintfz(varvalue, CONFIG_MAX_VALUE, "%s", title?title:"");
-        json_escape_string(varvalue2, varvalue, sizeof(varvalue2));
-        st->title = config_get(st->config_section, "title", varvalue2);
-    }
+    st->title = config_get(st->config_section, "title", title);
+    json_fix_string(st->title);
 
     st->rrdfamily = rrdfamily_create(host, st->family);
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -558,6 +558,9 @@ RRDSET *rrdset_create_custom(
     st->gap_when_lost_iterations_above = (int) (
             config_get_number(st->config_section, "gap when lost iterations above", RRD_DEFAULT_GAP_INTERPOLATIONS) + 2);
 
+    st->last_accessed_time = 0;
+    st->upstream_resync_time = 0;
+
     avl_init_lock(&st->dimensions_index, rrddim_compare);
     avl_init_lock(&st->variables_root_index, rrdvar_compare);
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -572,7 +572,7 @@ RRDSET *rrdset_create_custom(
     {
         char varvalue[CONFIG_MAX_VALUE + 1];
         char varvalue2[CONFIG_MAX_VALUE + 1];
-        snprintfz(varvalue, CONFIG_MAX_VALUE, "%s (%s)", title?title:"", st->name);
+        snprintfz(varvalue, CONFIG_MAX_VALUE, "%s", title?title:"");
         json_escape_string(varvalue2, varvalue, sizeof(varvalue2));
         st->title = config_get(st->config_section, "title", varvalue2);
     }

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -279,12 +279,18 @@ void rrdset_free(RRDSET *st) {
     // free directly allocated members
     freez(st->config_section);
 
-    if(st->rrd_memory_mode == RRD_MEMORY_MODE_SAVE || st->rrd_memory_mode == RRD_MEMORY_MODE_MAP) {
-        debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
-        munmap(st, st->memsize);
+    switch(st->rrd_memory_mode) {
+        case RRD_MEMORY_MODE_SAVE:
+        case RRD_MEMORY_MODE_MAP:
+        case RRD_MEMORY_MODE_RAM:
+            debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
+            munmap(st, st->memsize);
+            break;
+
+        case RRD_MEMORY_MODE_NONE:
+            freez(st);
+            break;
     }
-    else
-        freez(st);
 }
 
 void rrdset_save(RRDSET *st) {

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1608,6 +1608,12 @@ static inline void check_if_metric_is_for_app(STATSD_INDEX *index, STATSD_METRIC
                                 dim->divisor *= STATSD_DECIMAL_DETAIL;
                         }
 
+                        if(unlikely(chart->st && dim->rd)) {
+                            rrddim_set_algorithm(chart->st, dim->rd, dim->algorithm);
+                            rrddim_set_multiplier(chart->st, dim->rd, dim->multiplier);
+                            rrddim_set_divisor(chart->st, dim->rd, dim->divisor);
+                        }
+
                         chart->dimensions_linked_count++;
                         debug(D_STATSD, "metric '%s' of type %u linked with app '%s', chart '%s', dimension '%s', algorithm '%s'", m->name, m->type, app->name, chart->id, dim->name, rrd_algorithm_name(dim->algorithm));
                     }
@@ -1645,11 +1651,6 @@ static inline void statsd_update_app_chart(STATSD_APP *app, STATSD_APP_CHART *ch
             dim->rd = rrddim_add(chart->st, dim->name, NULL, dim->multiplier, dim->divisor, dim->algorithm);
 
         if(unlikely(dim->value_ptr)) {
-            // FIXME: this is anorthodox, we should an API call at RRDDIM to overwrite these settings
-            dim->rd->algorithm = dim->algorithm;
-            dim->rd->multiplier = dim->multiplier;
-            dim->rd->divisor = dim->divisor;
-
             debug(D_STATSD, "updating dimension '%s' (%s) of chart '%s' (%s) for app '%s' with value " COLLECTED_NUMBER_FORMAT, dim->name, dim->rd->id, chart->id, chart->st->id, app->name, *dim->value_ptr);
             rrddim_set_by_pointer(chart->st, dim->rd, *dim->value_ptr);
         }

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -923,7 +923,7 @@ int run_test(struct test *test)
 {
     fprintf(stderr, "\nRunning test '%s':\n%s\n", test->name, test->description);
 
-    default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
+    default_rrd_memory_mode = RRD_MEMORY_MODE_ALLOC;
     default_rrd_update_every = test->update_every;
 
     char name[101];
@@ -1132,7 +1132,7 @@ int unit_test(long delay, long shift)
     snprintfz(name, 100, "unittest-%d-%ld-%ld", repeat, delay, shift);
 
     //debug_flags = 0xffffffff;
-    default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
+    default_rrd_memory_mode = RRD_MEMORY_MODE_ALLOC;
     default_rrd_update_every = 1;
 
     int do_abs = 1;

--- a/web/infographic.html
+++ b/web/infographic.html
@@ -164,7 +164,7 @@
     }(document, 'script', 'facebook-jssdk'));
 </script>
 
-<script type="text/javascript" src="https://www.draw.io/embed2.js?s=arrows2;mscae/cloud;azure;office/users;office/servers&fetch=https%3A%2F%2Fraw.githubusercontent.com%2Fktsaou%2Fnetdata%2Fmaster%2Fdiagrams%2Fnetdata-overview.xml"></script>
+<script type="text/javascript" src="https://www.draw.io/embed2.js?s=arrows2;mscae/cloud;azure;office/users;office/servers&fetch=https%3A%2F%2Fraw.githubusercontent.com%2Ffirehol%2Fnetdata%2Fmaster%2Fdiagrams%2Fnetdata-overview.xml"></script>
 
 </html>
 


### PR DESCRIPTION
1. netdata master are now receiving dimension changes (name, algorithm, multiplier, divider). Also external plugins can now update these settings are runtime - fixes #2253 

2. memory mode `ram` can now use KSM. A new memory mode `alloc` is introduced, which is used as a fallback of `map`, `save`, `ram` (ie when `mmap()` fails) - fixes #2284

3. statsd now cleans up its memory properly when exiting (minor issue: the memory is always cleaned up by the system when a program exits - this fix removes warning messages when netdata runs under `valgrind`).

4. when metrics streaming is enabled and the master is not available, do not show gaps on the charts of the slave or proxy, on reconnect.

5. under streaming, the charts at the receiving end had duplicate chart name appended at their titles. Fixed it #2276 

6. streaming was escaping characters in an incompatible way with JSON which could lead to corrupted JSON output at the receiving end. Fixed it #2276 

7. metrics sent to backends (all except prometheus), can be filtered. A new setting has been added under the `[backends]` section: `send charts matching = *`. One or more space separated patterns can be given, using `*` as wildcard (any number of times within each pattern). A pattern starting with `!` gives a negative match. So to match all charts named `apps.*` except charts ending in `*reads`, use `send charts matching = !*reads apps.*`. fixes #2257 