### PR TITLE
Fix smartd_log attributes in Python 2 and allow custom order

### DIFF
--- a/conf.d/python.d/smartd_log.conf
+++ b/conf.d/python.d/smartd_log.conf
@@ -58,11 +58,11 @@
 #
 #    log_path: '/path/to/smartdlogs'   # path to smartd log files. Default is /var/log/smartd
 #    raw_values: no                    # raw or normalized values on charts. Default is normalized.
-#    smart_attributes: '1 2 3 4 44'    # add additional smart attributes charts. Default are ['1', '4', '5', '7', '9', '12', '193', '194', '197', '198', '200'].
+#    smart_attributes: '1 2 3 4 44'    # smart attributes charts. Default are ['1', '4', '5', '7', '9', '12', '193', '194', '197', '198', '200'].
 #
 # ----------------------------------------------------------------------
 # Additional information
-#  Plugin reads smartd log files (-A option). 
+#  Plugin reads smartd log files (-A option).
 #  You need to add (man smartd) to /etc/default/smartmontools '-i 600 -A /var/log/smartd/' to pass additional options to smartd on startup
 #  Then restart smartd service and check /path/log/smartdlogs
 #  ls /var/log/smartd/
@@ -74,12 +74,12 @@
 # RAW vs NORMALIZED values
 # "Normalized value", commonly referred to as just "value". This is a most universal measurement, on the scale from 0 (bad) to some maximum (good) value.
 # Maximum values are typically 100, 200 or 253. Rule of thumb is: high values are good, low values are bad.
-# 
+#
 # "Raw value" - the value of the attribute as it is tracked by the device, before any normalization takes place.
 # Some raw numbers provide valuable insight when properly interpreted. These cases will be discussed later on.
 # Raw values are typically listed in hexadecimal numbers. The raw value has different structure for different vendors and is often not meaningful as a decimal number.
 #
 #
 # JOB configuration
-# 
+#
 log_path: '/var/log/smartd'

--- a/python.d/smartd_log.chart.py
+++ b/python.d/smartd_log.chart.py
@@ -198,11 +198,12 @@ class Service(SimpleService):
             return result
 
         # Use configured attributes, if present. If something goes wrong we don't care.
+        order = ORDER
         try:
-            ORDER = [attr for attr in self.attr.split() if attr in SMART_ATTR.keys()] or ORDER
+            order = [attr for attr in self.attr.split() if attr in SMART_ATTR.keys()] or ORDER
         except Exception:
             pass
-        self.order = [''.join(['attrid', i]) for i in ORDER]
+        self.order = [''.join(['attrid', i]) for i in order]
         self.definitions = dict()
         units = 'raw' if self.raw_values else 'normalized'
 

--- a/python.d/smartd_log.chart.py
+++ b/python.d/smartd_log.chart.py
@@ -198,11 +198,10 @@ class Service(SimpleService):
             return result
 
         # Use configured attributes, if present. If something goes wrong we don't care.
-        if self.attr:
-            try:
-                ORDER = [attr for attr in self.attr.split() if attr in SMART_ATTR.keys()]
-            except Exception:
-                pass
+        try:
+            ORDER = [attr for attr in self.attr.split() if attr in SMART_ATTR.keys()] or ORDER
+        except Exception:
+            pass
         self.order = [''.join(['attrid', i]) for i in ORDER]
         self.definitions = dict()
         units = 'raw' if self.raw_values else 'normalized'

--- a/python.d/smartd_log.chart.py
+++ b/python.d/smartd_log.chart.py
@@ -197,11 +197,12 @@ class Service(SimpleService):
                 result.append(['_'.join([name, attrid]), name[:name.index('.')], 'absolute'])
             return result
 
-        # Add additional smart attributes to the ORDER. If something goes wrong we don't care.
-        try:
-            ORDER.extend(list(set(self.attr.split()) & SMART_ATTR.keys() - set(ORDER)))
-        except Exception:
-            pass
+        # Use configured attributes, if present. If something goes wrong we don't care.
+        if self.attr:
+            try:
+                ORDER = [attr for attr in self.attr.split() if attr in SMART_ATTR.keys()]
+            except Exception:
+                pass
         self.order = [''.join(['attrid', i]) for i in ORDER]
         self.definitions = dict()
         units = 'raw' if self.raw_values else 'normalized'


### PR DESCRIPTION
The current check fails when using Python 2 because `dict.keys()` returns a list in Python 2 and `&` is not a valid operation with operands `set` and `list`.

In addition the previous implementation only allowed extending the default attributes (even though the comment at the top of this file suggests otherwise).  This changes the behavior to allow for overriding the default attributes.