### PR TITLE
allow custom alarm notifications; more bugfixes

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -303,6 +303,68 @@ SEND_PD="YES"
 DEFAULT_RECIPIENT_PD=""
 
 
+#------------------------------------------------------------------------------
+# custom notifications
+#
+
+# enable/disable sending pagerduty notifications
+SEND_CUSTOM="YES"
+
+# if a role's recipients are not configured, use the following.
+# (empty = do not send a notification for unconfigured roles)
+DEFAULT_RECIPIENT_CUSTOM=""
+
+# The custom_sender() is a custom function to do whatever you need to do
+custom_sender() {
+    # variables you can use:
+    # ${host}               the host generated this event
+    # ${url_host}           same as ${host} but URL encoded
+    # ${unique_id}          the unique id of this event
+    # ${alarm_id}           the unique id of the alarm that generated this event
+    # ${event_id}           the incremental id of the event, for this alarm id
+    # ${when}               the timestamp this event occurred
+    # ${name}               the name of the alarm, as given in netdata health.d entries
+    # ${url_name}           same as ${name} but URL encoded
+    # ${chart}              the name of the chart (type.id)
+    # ${url_chart}          same as ${chart} but URL encoded
+    # ${family}             the family of the chart
+    # ${url_family}         same as ${family} but URL encoded
+    # ${status}             the current status : REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
+    # ${old_status}         the previous status: REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
+    # ${value}              the current value of the alarm
+    # ${old_value}          the previous value of the alarm
+    # ${src}                the line number and file the alarm has been configured
+    # ${duration}           the duration in seconds of the previous alarm state
+    # ${duration_txt}       same as ${duration} for humans
+    # ${non_clear_duration} the total duration in seconds this is/was non-clear
+    # ${non_clear_duration_txt} same as ${non_clear_duration} for humans
+    # ${units}              the units of the value
+    # ${info}               a short description of the alarm
+    # ${value_string}       friendly value (with units)
+    # ${old_value_string}   friendly old value (with units)
+    # ${image}              the URL of an image to represent the status of the alarm
+    # ${color}              a color in #AABBCC format for the alarm
+    # ${goto_url}           the URL the user can click to see the netdata dashboard
+
+    # these are more human friendly:
+    # ${alarm}              like "name = value units"
+    # ${status_message}     like "needs attention", "recovered", "is critical"
+    # ${severity}           like "Escalated to CRITICAL", "Recovered from WARNING"
+    # ${raised_for}         like "(alarm was raised for 10 minutes)"
+
+    # example human readable SMS
+    local msg="${host} ${status_message}: ${alarm} ${raised_for}"
+
+    # limit it to 160 characters and encode it for use in a URL
+    urlencode "${msg:0:160}" >/dev/null; msg="${REPLY}"
+
+    # a space separated list of the recipients to send alarms to
+    to="${1}"
+
+    info "not sending custom notification to ${to}, for ${status} of '${host}.${chart}.${name}' - custom_sender() is not configured."
+}
+
+
 ###############################################################################
 # RECIPIENTS PER ROLE
 
@@ -330,6 +392,8 @@ role_recipients_messagebird[sysadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
+
 # -----------------------------------------------------------------------------
 # DNS related alarms
 
@@ -352,6 +416,8 @@ role_recipients_twilio[domainadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 role_recipients_messagebird[domainadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_custom[domainadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
 # -----------------------------------------------------------------------------
 # database servers alarms
@@ -377,6 +443,8 @@ role_recipients_messagebird[dba]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
+
 # -----------------------------------------------------------------------------
 # web servers alarms
 # apache, nginx, lighttpd, etc
@@ -401,6 +469,8 @@ role_recipients_messagebird[webmaster]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_custom[webmaster]="${DEFAULT_RECIPIENT_CUSTOM}"
+
 # -----------------------------------------------------------------------------
 # proxy servers alarms
 # squid, etc
@@ -424,3 +494,5 @@ role_recipients_twilio[proxyadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 role_recipients_messagebird[proxyadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
 role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"

--- a/configs.signatures
+++ b/configs.signatures
@@ -354,6 +354,7 @@ declare -A configs_signatures=(
   ['c080e006f544c949baca33cc24a9c126']='health_alarm_notify.conf'
   ['c1a7e634b5b8aad523a0d115a93379cd']='health.d/memcached.conf'
   ['c3296c08260bcd556e74711c820817be']='health.d/cpu.conf'
+  ['c3661b68232e06de90bb5e63e725b8b6']='health_alarm_notify.conf'
   ['c61948101e0e6846679682794ee48c5b']='python.d/nginx.conf'
   ['c6403d8b1bcfa52d3abb941be155fc03']='python.d.conf'
   ['c88fb430f35b7d8f08775d84debffbd2']='python.d/phpfpm.conf'

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -2,7 +2,7 @@
 
 # netdata
 # real-time performance and health monitoring, done right!
-# (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+# (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 # GPL v3+
 #
 # Script to send alarm notifications for netdata
@@ -18,13 +18,14 @@
 #  - slack.com notifications by @ktsaou
 #  - discordapp.com notifications by @lowfive
 #  - pushover.net notifications by @ktsaou
-#  - pushbullet.com push notifications by Tiago Peralta @tperalta82 PR #1070
-#  - telegram.org notifications by @hashworks PR #1002
-#  - twilio.com notifications by Levi Blaney @shadycuz PR #1211
+#  - pushbullet.com push notifications by Tiago Peralta @tperalta82 #1070
+#  - telegram.org notifications by @hashworks #1002
+#  - twilio.com notifications by Levi Blaney @shadycuz #1211
 #  - kafka notifications by @ktsaou #1342
-#  - pagerduty.com notifications by Jim Cooley @jimcooley PR #1373
+#  - pagerduty.com notifications by Jim Cooley @jimcooley #1373
 #  - messagebird.com notifications by @tech_no_logical #1453
 #  - hipchat notifications by @ktsaou #1561
+#  - custom notifications by @ktsaou
 
 # -----------------------------------------------------------------------------
 # testing notifications
@@ -103,6 +104,15 @@ debug() {
     [ ${debug} -eq 1 ] && log DEBUG "${@}"
 }
 
+
+# -----------------------------------------------------------------------------
+# this is to be overwritten by the config file
+
+custom_sender() {
+    info "not sending custom notification for ${status} of '${host}.${chart}.${name}'"
+}
+
+
 # -----------------------------------------------------------------------------
 
 # check for BASH v4+ (required for associative arrays)
@@ -128,8 +138,8 @@ when="${6}"        # the timestamp this event occurred
 name="${7}"        # the name of the alarm, as given in netdata health.d entries
 chart="${8}"       # the name of the chart (type.id)
 family="${9}"      # the family of the chart
-status="${10}"     # the current status : REMOVED, UNITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
-old_status="${11}" # the previous status: REMOVED, UNITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
+status="${10}"     # the current status : REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
+old_status="${11}" # the previous status: REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
 value="${12}"      # the current value of the alarm
 old_value="${13}"  # the previous value of the alarm
 src="${14}"        # the line number and file the alarm has been configured
@@ -189,6 +199,7 @@ SEND_EMAIL="YES"
 SEND_PUSHBULLET="YES"
 SEND_KAFKA="YES"
 SEND_PD="YES"
+SEND_CUSTOM="YES"
 
 # slack configs
 SLACK_WEBHOOK_URL=
@@ -241,6 +252,10 @@ KAFKA_SENDER_IP=
 # pagerduty.com configs
 PD_SERVICE_KEY=
 declare -A role_recipients_pd=()
+
+# custom configs
+DEFAULT_RECIPIENT_CUSTOM=
+declare -A role_recipients_custom=()
 
 # email configs
 DEFAULT_RECIPIENT_EMAIL="root"
@@ -305,6 +320,7 @@ declare -A arr_hipchat=()
 declare -A arr_telegram=()
 declare -A arr_pd=()
 declare -A arr_email=()
+declare -A arr_custom=()
 
 # netdata may call us with multiple roles, and roles may have multiple but
 # overlapping recipients - so, here we find the unique recipients.
@@ -393,6 +409,15 @@ do
     do
         [ "${r}" != "disabled" ] && filter_recipient_by_criticality pd "${r}" && arr_pd[${r/|*/}]="1"
     done
+
+    # custom
+    a="${role_recipients_custom[${x}]}"
+    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_CUSTOM}"
+    for r in ${a//,/ }
+    do
+        [ "${r}" != "disabled" ] && filter_recipient_by_criticality custom "${r}" && arr_custom[${r/|*/}]="1"
+    done
+
 done
 
 # build the list of slack recipients (channels)
@@ -430,6 +455,10 @@ to_telegram="${!arr_telegram[*]}"
 # build the list of pagerduty recipients (service keys)
 to_pd="${!arr_pd[*]}"
 [ -z "${to_pd}" ] && SEND_PD="NO"
+
+# build the list of custom recipients
+to_custom="${!arr_custom[*]}"
+[ -z "${to_custom}" ] && SEND_CUSTOM="NO"
 
 # build the list of email recipients (email addresses)
 to_email=
@@ -489,7 +518,7 @@ fi
 if [ \( \
            "${SEND_PUSHOVER}"    = "YES" \
         -o "${SEND_SLACK}"       = "YES" \
-        -o "${SEND_DISCORD}"       = "YES" \
+        -o "${SEND_DISCORD}"     = "YES" \
         -o "${SEND_HIPCHAT}"     = "YES" \
         -o "${SEND_TWILIO}"      = "YES" \
         -o "${SEND_MESSAGEBIRD}" = "YES" \
@@ -527,13 +556,14 @@ if [   "${SEND_EMAIL}"          != "YES" \
     -a "${SEND_PUSHOVER}"       != "YES" \
     -a "${SEND_TELEGRAM}"       != "YES" \
     -a "${SEND_SLACK}"          != "YES" \
-    -a "${SEND_DISCORD}"          != "YES" \
+    -a "${SEND_DISCORD}"        != "YES" \
     -a "${SEND_TWILIO}"         != "YES" \
     -a "${SEND_HIPCHAT}"        != "YES" \
     -a "${SEND_MESSAGEBIRD}"    != "YES" \
     -a "${SEND_PUSHBULLET}"     != "YES" \
     -a "${SEND_KAFKA}"          != "YES" \
     -a "${SEND_PD}"             != "YES" \
+    -a "${SEND_CUSTOM}"         != "YES" \
     ]
     then
     fatal "All notification methods are disabled. Not sending notification for host '${host}', chart '${chart}' to '${roles}' for '${name}' = '${value}' for status '${status}'."
@@ -1286,6 +1316,24 @@ SENT_PD=$?
 
 
 # -----------------------------------------------------------------------------
+# send the custom message
+
+send_custom() {
+    # is it enabled?
+    [ "${SEND_CUSTOM}" != "YES" ] && return 1
+
+    # do we have any sender?
+    [ -z "${1}" ] && return 1
+
+    # call the custom_sender function
+    custom_sender "${@}"
+}
+
+send_custom "${to_custom}"
+SENT_CUSTOM=$?
+
+
+# -----------------------------------------------------------------------------
 # send hipchat message
 
 send_hipchat "${HIPCHAT_AUTH_TOKEN}" "${to_hipchat}" " \
@@ -1298,6 +1346,7 @@ ${host} ${status_message}<br/> \
 "
 
 SENT_HIPCHAT=$?
+
 
 # -----------------------------------------------------------------------------
 # send the email
@@ -1430,6 +1479,7 @@ if [   ${SENT_EMAIL}        -eq 0 \
     -o ${SENT_PUSHBULLET}   -eq 0 \
     -o ${SENT_KAFKA}        -eq 0 \
     -o ${SENT_PD}           -eq 0 \
+    -o ${SENT_CUSTOM}       -eq 0 \
     ]
     then
     # we did send something

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -122,8 +122,8 @@ custom_sender() {
 # -----------------------------------------------------------------------------
 # defaults to allow running this script by hand
 
-NETDATA_CONFIG_DIR="${NETDATA_CONFIG_DIR-/etc/netdata}"
-NETDATA_CACHE_DIR="${NETDATA_CACHE_DIR-/var/cache/netdata}"
+[ -z "${NETDATA_CONFIG_DIR}" ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
+[ -z "${NETDATA_CACHE_DIR}" ] && NETDATA_CACHE_DIR="$(dirname "${0}")/../../../../var/cache/netdata"
 [ -z "${NETDATA_REGISTRY_URL}" ] && NETDATA_REGISTRY_URL="https://registry.my-netdata.io"
 
 # -----------------------------------------------------------------------------

--- a/plugins.d/alarm-test.sh
+++ b/plugins.d/alarm-test.sh
@@ -2,7 +2,7 @@
 
 # netdata
 # real-time performance and health monitoring, done right!
-# (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+# (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 # GPL v3+
 #
 # Script to test alarm notifications for netdata

--- a/plugins.d/cgroup-name.sh
+++ b/plugins.d/cgroup-name.sh
@@ -51,7 +51,7 @@ debug() {
 
 # -----------------------------------------------------------------------------
 
-NETDATA_CONFIG_DIR="${NETDATA_CONFIG_DIR-/etc/netdata}"
+[ -z "${NETDATA_CONFIG_DIR}" ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
 CONFIG="${NETDATA_CONFIG_DIR}/cgroups-names.conf"
 CGROUP="${1}"
 NAME=

--- a/plugins.d/charts.d.plugin
+++ b/plugins.d/charts.d.plugin
@@ -2,7 +2,7 @@
 
 # netdata
 # real-time performance and health monitoring, done right!
-# (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+# (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 # GPL v3+
 #
 # charts.d.plugin allows easy development of BASH plugins
@@ -115,10 +115,11 @@ info "started from '$PROGRAM_FILE' with options: $*"
 # internal defaults
 # netdata exposes a few environment variables for us
 
-pluginsd="${NETDATA_PLUGINS_DIR}"
-[ -z "$pluginsd" ] && pluginsd="$( dirname $PROGRAM_FILE )"
+[ -z "${NETDATA_PLUGINS_DIR}" ] && NETDATA_PLUGINS_DIR="$(dirname "${0}")"
+[ -z "${NETDATA_CONFIG_DIR}" ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
 
-confd="${NETDATA_CONFIG_DIR-/etc/netdata}"
+pluginsd="${NETDATA_PLUGINS_DIR}"
+confd="${NETDATA_CONFIG_DIR}"
 chartsd="$pluginsd/../charts.d"
 
 myconfig="$confd/$PROGRAM_NAME.conf"

--- a/plugins.d/fping.plugin
+++ b/plugins.d/fping.plugin
@@ -2,7 +2,7 @@
 
 # netdata
 # real-time performance and health monitoring, done right!
-# (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+# (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 # GPL v3+
 #
 # This plugin requires a latest version of fping.
@@ -129,7 +129,7 @@ update_every="${1-1}"
 
 # the netdata configuration directory
 # passed by netdata as an environment variable
-NETDATA_CONFIG_DIR="${NETDATA_CONFIG_DIR-/etc/netdata}"
+[ -z "${NETDATA_CONFIG_DIR}" ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
 
 # -----------------------------------------------------------------------------
 # configuration options

--- a/plugins.d/node.d.plugin
+++ b/plugins.d/node.d.plugin
@@ -4,13 +4,13 @@
 // shebang hack from:
 // http://unix.stackexchange.com/questions/65235/universal-node-js-shebang
 
-// Initially this is run as a shell script (#!/bin/sh).
+// Initially this is run as a shell script.
 // Then, the second line, finds nodejs or node or js in the system path
 // and executes it with the shell parameters.
 
 // netdata
 // real-time performance and health monitoring, done right!
-// (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+// (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 // GPL v3+
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -21,7 +21,7 @@
 // get NETDATA environment variables
 
 var NETDATA_PLUGINS_DIR = process.env.NETDATA_PLUGINS_DIR || __dirname;
-var NETDATA_CONFIG_DIR = process.env.NETDATA_CONFIG_DIR || '/etc/netdata';
+var NETDATA_CONFIG_DIR = process.env.NETDATA_CONFIG_DIR || __dirname + '/../../../../etc/netdata';
 var NETDATA_UPDATE_EVERY = process.env.NETDATA_UPDATE_EVERY || 1;
 var NODE_D_DIR = NETDATA_PLUGINS_DIR + '/../node.d';
 

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -20,8 +20,11 @@ BASE_CONFIG = {'update_every': os.getenv('NETDATA_UPDATE_EVERY', 1),
                'retries': 10}
 
 MODULES_DIR = os.path.abspath(os.getenv('NETDATA_PLUGINS_DIR',
-                                        os.path.dirname(__file__)) + "/../python.d") + "/"
-CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', "/etc/netdata/")
+                        os.path.dirname(__file__)) + "/../python.d") + "/"
+
+CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR',
+                       os.path.dirname(__file__)) + "/../../../../etc/netdata")
+
 # directories should end with '/'
 if CONFIG_DIR[-1] != "/":
     CONFIG_DIR += "/"

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -23,7 +23,7 @@ MODULES_DIR = os.path.abspath(os.getenv('NETDATA_PLUGINS_DIR',
                         os.path.dirname(__file__)) + "/../python.d") + "/"
 
 CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR',
-                       os.path.dirname(__file__)) + "/../../../../etc/netdata")
+                       os.path.dirname(__file__) + "/../../../../etc/netdata")
 
 # directories should end with '/'
 if CONFIG_DIR[-1] != "/":

--- a/plugins.d/tc-qos-helper.sh
+++ b/plugins.d/tc-qos-helper.sh
@@ -2,7 +2,7 @@
 
 # netdata
 # real-time performance and health monitoring, done right!
-# (C) 2016 Costa Tsaousis <costa@tsaousis.gr>
+# (C) 2017 Costa Tsaousis <costa@tsaousis.gr>
 # GPL v3+
 #
 # This script is a helper to allow netdata collect tc data.
@@ -101,10 +101,11 @@ debug() {
 
 # -----------------------------------------------------------------------------
 
-plugins_dir="${NETDATA_PLUGINS_DIR}"
-[ -z "$plugins_dir" ] && plugins_dir="$( dirname $PROGRAM_FILE )"
+[ -z "${NETDATA_PLUGINS_DIR}" ] && NETDATA_PLUGINS_DIR="$(dirname "${0}")"
+[ -z "${NETDATA_CONFIG_DIR}" ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
 
-config_dir=${NETDATA_CONFIG_DIR-/etc/netdata}
+plugins_dir="${NETDATA_PLUGINS_DIR}"
+config_dir="${NETDATA_CONFIG_DIR}"
 tc="$(which tc 2>/dev/null || command -v tc 2>/dev/null)"
 
 

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -352,7 +352,7 @@ typedef struct rrdset RRDSET;
 // and may lead to missing information.
 
 typedef enum rrdhost_flags {
-    RRDHOST_ORPHAN                 = 1 << 0, // this host is orphan
+    RRDHOST_ORPHAN                 = 1 << 0, // this host is orphan (not receiving data)
     RRDHOST_DELETE_OBSOLETE_FILES  = 1 << 1, // delete files of obsolete charts
     RRDHOST_DELETE_ORPHAN_FILES    = 1 << 2  // delete the entire host when orphan
 } RRDHOST_FLAGS;


### PR DESCRIPTION
This PR allows calling a custom bash function `custom_sender()` defined at `health_alarm_notify.conf` to be called, just like all the other notification methods.

This allows custom notification hooks to be used for automating reactions to alarms.

---

cleanup of obsolete host files worked only for proxies. Now it also works for masters. fixes #2329 

---

remove all static references to `/etc/netdata` from netdata plugins and use `/../../../../etc/netdata` relative to plugin `dirname`. fixes #2264 