### PR TITLE
Follow symlinks when listing conf files in updater

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -555,7 +555,7 @@ config_signature_matches() {
 
 # backup user configurations
 installer_backup_suffix="${PID}.${RANDOM}"
-for x in $(find "${NETDATA_PREFIX}/etc/netdata/" -name '*.conf' -type f)
+for x in $(find -L "${NETDATA_PREFIX}/etc/netdata/" -name '*.conf' -type f)
 do
     if [ -f "${x}" ]
         then
@@ -607,7 +607,7 @@ run make install || exit 1
 # -----------------------------------------------------------------------------
 progress "Restore user edited netdata configuration files"
 
-for x in $(find "${NETDATA_PREFIX}/etc/netdata/" -name '*.conf' -type f)
+for x in $(find -L "${NETDATA_PREFIX}/etc/netdata/" -name '*.conf' -type f)
 do
     if [ -f "${x}.installer_backup.${installer_backup_suffix}" ]
         then


### PR DESCRIPTION
Follow symlinks when backing up configuration files. This enables the use and preservation of symlinks for configuration files.

The changes in #2330 turned out to be insufficient, as `find` does not list symlinks when filtering on `-type f`. This can be fixed by removing the filter, or adding either the `-L` or `-H` flags to the find command. I opted for the `-L` option.

Manual listing for `-L`:

```
When find examines or prints information about files, the information used shall be taken from the properties of the file to which the link points, not from the link itself
``` 