### PR TITLE
Add systemd BuildRequires for EL distributions

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -27,7 +27,8 @@ BuildRequires: systemd-rpm-macros \
 %global netdata_init_preun %service_del_preun netdata.service
 %global netdata_init_postun %service_del_postun netdata.service
 %else
-%global netdata_initd_buildrequires %{nil}
+%global netdata_initd_buildrequires \
+BuildRequires: systemd
 %global netdata_initd_requires \
 Requires(preun):  systemd-units \
 Requires(postun): systemd-units \


### PR DESCRIPTION
When building on RedHat/CentOS systems with the default buildsys-build chroot group, macros are not expanded as they comes with the systemd package which is not part of this group of packages by default.
Your package ends up with this scripts:

```
# rpm -qp --scripts netdata-1.6.0-1.el7.x86_64.rpm
preinstall scriptlet (using /bin/sh):
getent group netdata >/dev/null || groupadd -r netdata
getent group docker >/dev/null || groupadd -r docker
getent passwd netdata >/dev/null || \
  useradd -r -g netdata -G docker -s /sbin/nologin \
    -d /usr/share/netdata -c "netdata" netdata
postinstall scriptlet (using /bin/sh):
%systemd_post netdata.service
preuninstall scriptlet (using /bin/sh):
%systemd_preun netdata.service
postuninstall scriptlet (using /bin/sh):
%systemd_postun_with_restart netdata.service
```

To expand the %systemd_* macros, you need to install the systemd package at build.