### PR TITLE
Fix build with latest travis images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
     - libcap2-bin
     - zlib1g-dev
     - uuid-dev
+    - fakeroot
 #
 # Setup environment
 before_install:


### PR DESCRIPTION
We use the garnet image, which got updated as described here:
  https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch

One of the updates removed the fakeroot package from the base, so this
update re-adds it explicitly.