### PR TITLE
support RHEL in installer

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -411,9 +411,9 @@ install_non_systemd_init() {
         source /etc/os-release || return 1
         key="${ID}-${VERSION_ID}"
 
-    elif [ -f /etc/centos-release ]
+    elif [ -f /etc/redhat-release ]
         then
-        key=$(</etc/centos-release)
+        key=$(</etc/redhat-release)
     fi
 
     if [ -d /etc/init.d -a ! -f /etc/init.d/netdata ]
@@ -437,7 +437,7 @@ install_non_systemd_init() {
             run update-rc.d netdata defaults && \
             run update-rc.d netdata enable && \
             return 0
-        elif [[ "${key}" =~ ^(amzn-201[567]|CentOS release 6).* ]]
+        elif [[ "${key}" =~ ^(amzn-201[567]|CentOS release 6|Red Hat Enterprise Linux Server release 6).* ]]
             then
             echo >&2 "Installing init.d file..."
             run cp system/netdata-init-d /etc/init.d/netdata && \


### PR DESCRIPTION
support RHEL6 script installation. 
since Centos|RHEL both have /etc/redhat-release, just replaced centos-release with redhat-release

