### PR TITLE
plugins API supports options per chart; streamed charts now auto-cleanup; statsd charts do not loose the first collected value due to interpolation

### DIFF
--- a/m4/ax_c___atomic.m4
+++ b/m4/ax_c___atomic.m4
@@ -10,13 +10,19 @@ AC_DEFUN([AC_C___ATOMIC],
         main (int argc, char **argv)
         {
           volatile unsigned long ul1 = 1, ul2 = 0, ul3 = 2;
+          __atomic_load_n(&ul1, __ATOMIC_SEQ_CST);
           __atomic_compare_exchange(&ul1, &ul2, &ul3, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
           __atomic_fetch_add(&ul1, 1, __ATOMIC_SEQ_CST);
           __atomic_fetch_sub(&ul3, 1, __ATOMIC_SEQ_CST);
+          __atomic_or_fetch(&ul1, ul2, __ATOMIC_SEQ_CST);
+          __atomic_and_fetch(&ul1, ul2, __ATOMIC_SEQ_CST);
           volatile unsigned long long ull1 = 1, ull2 = 0, ull3 = 2;
+          __atomic_load_n(&ull1, __ATOMIC_SEQ_CST);
           __atomic_compare_exchange(&ull1, &ull2, &ull3, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
           __atomic_fetch_add(&ull1, 1, __ATOMIC_SEQ_CST);
           __atomic_fetch_sub(&ull3, 1, __ATOMIC_SEQ_CST);
+          __atomic_or_fetch(&ull1, ull2, __ATOMIC_SEQ_CST);
+          __atomic_and_fetch(&ull1, ull2, __ATOMIC_SEQ_CST);
           return 0;
         }
       ]])],

--- a/plugins.d/cgroup-name.sh
+++ b/plugins.d/cgroup-name.sh
@@ -133,7 +133,7 @@ if [ -z "${NAME}" ]
         FILENAME="/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
         if [[ -f $FILENAME && -r $FILENAME ]]
             then
-            NAME=$(grep -e '^name: ' /etc/pve/qemu-server/${BASH_REMATCH[1]}.conf | head -1 | sed -rn 's|\s*name\s*:\s*(.*)?$|\1|p')
+            NAME="qemu_$(grep -e '^name: ' "/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf" | head -1 | sed -rn 's|\s*name\s*:\s*(.*)?$|\1|p')"
         else
             error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
         fi

--- a/plugins.d/cgroup-name.sh
+++ b/plugins.d/cgroup-name.sh
@@ -74,22 +74,22 @@ if [ -f "${CONFIG}" ]
 #   info "configuration file '${CONFIG}' is not available."
 fi
 
-function get_name_classic {
-    local DOCKERID="$1"
-    info "Running command: docker ps --filter=id=\"${DOCKERID}\" --format=\"{{.Names}}\""
-    NAME="$( docker ps --filter=id="${DOCKERID}" --format="{{.Names}}" )"
+function docker_get_name_classic {
+    local id="${1}"
+    info "Running command: docker ps --filter=id=\"${id}\" --format=\"{{.Names}}\""
+    NAME="$( docker ps --filter=id="${id}" --format="{{.Names}}" )"
     return 0
 }
 
-function get_name_api {
-    local DOCKERID="$1"
+function docker_get_name_api {
+    local id="${1}"
     if [ ! -S "/var/run/docker.sock" ]
         then
         warning "Can't find /var/run/docker.sock"
         return 1
     fi
-    info "Running API command: /containers/${DOCKERID}/json"
-    JSON=$(echo -e "GET /containers/${DOCKERID}/json HTTP/1.0\r\n" | nc -U /var/run/docker.sock | grep '^{.*')
+    info "Running API command: /containers/${id}/json"
+    JSON=$(echo -e "GET /containers/${id}/json HTTP/1.0\r\n" | nc -U /var/run/docker.sock | grep '^{.*')
     NAME=$(echo $JSON | jq -r .Name,.Config.Hostname | grep -v null | head -n1 | sed 's|^/||')
     return 0
 }
@@ -107,9 +107,9 @@ if [ -z "${NAME}" ]
             then
             if hash docker 2>/dev/null
                 then
-                get_name_classic $DOCKERID
+                docker_get_name_classic ${DOCKERID}
             else
-                get_name_api $DOCKERID || get_name_classic $DOCKERID
+                docker_get_name_api ${DOCKERID} || docker_get_name_classic ${DOCKERID}
             fi
             if [ -z "${NAME}" ]
                 then
@@ -123,28 +123,30 @@ if [ -z "${NAME}" ]
         then
         # libvirtd / qemu virtual machines
 
-        NAME="$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d//; s/\/x2d/\-/g; s/\.scope//g')"
+        # NAME="$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d//; s/\/x2d/\-/g; s/\.scope//g')"
+        NAME="qemu_$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
+
     elif [[ "${CGROUP}" =~ qemu.slice_([0-9]+).scope && -d /etc/pve ]]
         then
-        
-	# Proxmox VMs
-	FILENAME="/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
-	if [[ -f $FILENAME && -r $FILENAME ]]
-	    then
+        # Proxmox VMs
+
+        FILENAME="/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
+        if [[ -f $FILENAME && -r $FILENAME ]]
+            then
             NAME=$(grep -e '^name: ' /etc/pve/qemu-server/${BASH_REMATCH[1]}.conf | head -1 | sed -rn 's|\s*name\s*:\s*(.*)?$|\1|p')
-	else	
-            error "proxmox config file missing $FILENAME or netdata does not have read access.  Please ensure netdata is a member of www-data group."
-	fi
+        else
+            error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
+        fi
     elif [[ "${CGROUP}" =~ lxc_([0-9]+) && -d /etc/pve ]]
         then
+        # Proxmox Containers (LXC)
 
-        # Proxmox Container (LXC)
-	FILENAME="/etc/pve/lxc/${BASH_REMATCH[1]}.conf"
-	if [[ -f $FILENAME && -r $FILENAME ]]
+        FILENAME="/etc/pve/lxc/${BASH_REMATCH[1]}.conf"
+        if [[ -f ${FILENAME} && -r ${FILENAME} ]]
             then
-	    NAME=$(grep -e '^hostname: ' /etc/pve/lxc/${BASH_REMATCH[1]}.conf | head -1 | sed -rn 's|\s*hostname\s*:\s*(.*)?$|\1|p')
-	else
-            error "proxmox config file missing $FILENAME or netdata does not have read access.  Please ensure netdata is a member of www-data group."
+            NAME=$(grep -e '^hostname: ' /etc/pve/lxc/${BASH_REMATCH[1]}.conf | head -1 | sed -rn 's|\s*hostname\s*:\s*(.*)?$|\1|p')
+        else
+            error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
         fi
     fi
 

--- a/src/freebsd_devstat.c
+++ b/src/freebsd_devstat.c
@@ -74,21 +74,21 @@ static size_t disks_added = 0, disks_found = 0;
 
 static void disk_free(struct disk *dm) {
     if (likely(dm->st_io))
-        rrdset_flag_set(dm->st_io,     RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_io);
     if (likely(dm->st_ops))
-        rrdset_flag_set(dm->st_ops,    RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_ops);
     if (likely(dm->st_qops))
-        rrdset_flag_set(dm->st_qops,   RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_qops);
     if (likely(dm->st_util))
-        rrdset_flag_set(dm->st_util,   RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_util);
     if (likely(dm->st_iotime))
-        rrdset_flag_set(dm->st_iotime, RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_iotime);
     if (likely(dm->st_await))
-        rrdset_flag_set(dm->st_await,  RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_await);
     if (likely(dm->st_avagsz))
-        rrdset_flag_set(dm->st_avagsz, RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_avagsz);
     if (likely(dm->st_svctm))
-        rrdset_flag_set(dm->st_svctm,  RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(dm->st_svctm);
 
     disks_added--;
     freez(dm->name);

--- a/src/freebsd_getifaddrs.c
+++ b/src/freebsd_getifaddrs.c
@@ -50,15 +50,15 @@ static size_t network_interfaces_added = 0, network_interfaces_found = 0;
 
 static void network_interface_free(struct network_interface *ifm) {
     if (likely(ifm->st_bandwidth))
-        rrdset_flag_set(ifm->st_bandwidth, RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(ifm->st_bandwidth);
     if (likely(ifm->st_packets))
-        rrdset_flag_set(ifm->st_packets,   RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(ifm->st_packets);
     if (likely(ifm->st_errors))
-        rrdset_flag_set(ifm->st_errors,    RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(ifm->st_errors);
     if (likely(ifm->st_drops))
-        rrdset_flag_set(ifm->st_drops,     RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(ifm->st_drops);
     if (likely(ifm->st_events))
-        rrdset_flag_set(ifm->st_events,    RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(ifm->st_events);
 
     network_interfaces_added--;
     freez(ifm->name);

--- a/src/freebsd_getmntinfo.c
+++ b/src/freebsd_getmntinfo.c
@@ -37,9 +37,9 @@ static size_t mount_points_added = 0, mount_points_found = 0;
 
 static void mount_point_free(struct mount_point *m) {
     if (likely(m->st_space))
-        rrdset_flag_set(m->st_space,  RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(m->st_space);
     if (likely(m->st_inodes))
-        rrdset_flag_set(m->st_inodes, RRDSET_FLAG_OBSOLETE);
+        rrdset_is_obsolete(m->st_inodes);
 
     mount_points_added--;
     freez(m->name);

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -45,7 +45,7 @@ struct mount_point_metadata {
 
 static DICTIONARY *dict_mountpoints = NULL;
 
-#define rrdset_obsolete_and_pointer_null(st) do { if(st) { rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE); st = NULL; } } while(st)
+#define rrdset_obsolete_and_pointer_null(st) do { if(st) { rrdset_is_obsolete(st); st = NULL; } } while(st)
 
 int mount_point_cleanup(void *entry, void *data) {
     (void)data;

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -286,6 +286,11 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
                     rrdset_flag_set(st, RRDSET_FLAG_DETAIL);
                 else
                     rrdset_flag_clear(st, RRDSET_FLAG_DETAIL);
+
+                if(strstr(options, "store_first"))
+                    rrdset_flag_set(st, RRDSET_FLAG_STORE_FIRST);
+                else
+                    rrdset_flag_clear(st, RRDSET_FLAG_STORE_FIRST);
             }
         }
         else if(likely(hash == DIMENSION_HASH && !strcmp(s, PLUGINSD_KEYWORD_DIMENSION))) {

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -237,6 +237,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             char *chart = words[7];
             char *priority_s = words[8];
             char *update_every_s = words[9];
+            char *options = words[10];
 
             if(unlikely(!type || !*type || !id || !*id)) {
                 error("PLUGINSD: '%s' is requesting a CHART, without a type.id, on host '%s'. Disabling it.", cd->fullfilename, host->hostname);
@@ -274,6 +275,18 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
                 cd->update_every = update_every;
             }
             else debug(D_PLUGINSD, "PLUGINSD: Chart '%s' already exists. Not adding it again.", st->id);
+
+            if(options && *options) {
+                if(strstr(options, "obsolete"))
+                    rrdset_is_obsolete(st);
+                else
+                    rrdset_isnot_obsolete(st);
+
+                if(strstr(options, "detail"))
+                    rrdset_flag_set(st, RRDSET_FLAG_DETAIL);
+                else
+                    rrdset_flag_clear(st, RRDSET_FLAG_DETAIL);
+            }
         }
         else if(likely(hash == DIMENSION_HASH && !strcmp(s, PLUGINSD_KEYWORD_DIMENSION))) {
             char *id = words[1];

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -44,7 +44,7 @@ static struct disk {
     struct disk *next;
 } *disk_root = NULL;
 
-#define rrdset_obsolete_and_pointer_null(st) do { if(st) { rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE); st = NULL; } } while(st)
+#define rrdset_obsolete_and_pointer_null(st) do { if(st) { rrdset_is_obsolete(st); st = NULL; } } while(st)
 
 static struct disk *get_disk(unsigned long major, unsigned long minor, char *disk) {
     static char path_to_get_hw_sector_size[FILENAME_MAX + 1] = "";

--- a/src/proc_net_dev.c
+++ b/src/proc_net_dev.c
@@ -73,13 +73,13 @@ static struct netdev *netdev_root = NULL, *netdev_last_used = NULL;
 static size_t netdev_added = 0, netdev_found = 0;
 
 static void netdev_free(struct netdev *d) {
-    if(d->st_bandwidth)  rrdset_flag_set(d->st_bandwidth,  RRDSET_FLAG_OBSOLETE);
-    if(d->st_packets)    rrdset_flag_set(d->st_packets,    RRDSET_FLAG_OBSOLETE);
-    if(d->st_errors)     rrdset_flag_set(d->st_errors,     RRDSET_FLAG_OBSOLETE);
-    if(d->st_drops)      rrdset_flag_set(d->st_drops,      RRDSET_FLAG_OBSOLETE);
-    if(d->st_fifo)       rrdset_flag_set(d->st_fifo,       RRDSET_FLAG_OBSOLETE);
-    if(d->st_compressed) rrdset_flag_set(d->st_compressed, RRDSET_FLAG_OBSOLETE);
-    if(d->st_events)     rrdset_flag_set(d->st_events,     RRDSET_FLAG_OBSOLETE);
+    if(d->st_bandwidth)  rrdset_is_obsolete(d->st_bandwidth);
+    if(d->st_packets)    rrdset_is_obsolete(d->st_packets);
+    if(d->st_errors)     rrdset_is_obsolete(d->st_errors);
+    if(d->st_drops)      rrdset_is_obsolete(d->st_drops);
+    if(d->st_fifo)       rrdset_is_obsolete(d->st_fifo);
+    if(d->st_compressed) rrdset_is_obsolete(d->st_compressed);
+    if(d->st_events)     rrdset_is_obsolete(d->st_events);
 
     netdev_added--;
     freez(d->name);

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -225,7 +225,8 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_OBSOLETE         = 1 << 3, // this is marked by the collector/module as obsolete
     RRDSET_FLAG_BACKEND_SEND     = 1 << 4, // if set, this chart should be sent to backends
     RRDSET_FLAG_BACKEND_IGNORE   = 1 << 5, // if set, this chart should not be sent to backends
-    RRDSET_FLAG_EXPOSED_UPSTREAM = 1 << 6  // if set, we have sent this chart to netdata master (streaming)
+    RRDSET_FLAG_EXPOSED_UPSTREAM = 1 << 6, // if set, we have sent this chart to netdata master (streaming)
+    RRDSET_FLAG_STORE_FIRST      = 1 << 7  // if set, do not eliminate the first collection during interpolation
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -103,9 +103,15 @@ typedef enum rrddim_flags {
     RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS = 1 << 1   // do not offer RESET or OVERFLOW info to callers
 } RRDDIM_FLAGS;
 
+#ifdef HAVE_C___ATOMIC
+#define rrddim_flag_check(rd, flag) (__atomic_load_n(&((rd)->flags), __ATOMIC_SEQ_CST) & flag)
+#define rrddim_flag_set(rd, flag)   __atomic_or_fetch(&((rd)->flags), flag, __ATOMIC_SEQ_CST)
+#define rrddim_flag_clear(rd, flag) __atomic_and_fetch(&((rd)->flags), ~flag, __ATOMIC_SEQ_CST)
+#else
 #define rrddim_flag_check(rd, flag) ((rd)->flags & flag)
 #define rrddim_flag_set(rd, flag)   (rd)->flags |= flag
 #define rrddim_flag_clear(rd, flag) (rd)->flags &= ~flag
+#endif
 
 
 // ----------------------------------------------------------------------------
@@ -221,9 +227,15 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_BACKEND_IGNORE = 1 << 5
 } RRDSET_FLAGS;
 
+#ifdef HAVE_C___ATOMIC
+#define rrdset_flag_check(st, flag) (__atomic_load_n(&((st)->flags), __ATOMIC_SEQ_CST) & flag)
+#define rrdset_flag_set(st, flag)   __atomic_or_fetch(&((st)->flags), flag, __ATOMIC_SEQ_CST)
+#define rrdset_flag_clear(st, flag) __atomic_and_fetch(&((st)->flags), ~flag, __ATOMIC_SEQ_CST)
+#else
 #define rrdset_flag_check(st, flag) ((st)->flags & flag)
 #define rrdset_flag_set(st, flag)   (st)->flags |= flag
 #define rrdset_flag_clear(st, flag) (st)->flags &= ~flag
+#endif
 
 struct rrdset {
     // ------------------------------------------------------------------------
@@ -357,9 +369,15 @@ typedef enum rrdhost_flags {
     RRDHOST_DELETE_ORPHAN_HOST     = 1 << 2  // delete the entire host when orphan
 } RRDHOST_FLAGS;
 
+#ifdef HAVE_C___ATOMIC
+#define rrdhost_flag_check(host, flag) (__atomic_load_n(&((host)->flags), __ATOMIC_SEQ_CST) & flag)
+#define rrdhost_flag_set(host, flag)   __atomic_or_fetch(&((host)->flags), flag, __ATOMIC_SEQ_CST)
+#define rrdhost_flag_clear(host, flag) __atomic_and_fetch(&((host)->flags), ~flag, __ATOMIC_SEQ_CST)
+#else
 #define rrdhost_flag_check(host, flag) ((host)->flags & flag)
 #define rrdhost_flag_set(host, flag)   (host)->flags |= flag
 #define rrdhost_flag_clear(host, flag) (host)->flags &= ~flag
+#endif
 
 // ----------------------------------------------------------------------------
 // RRD HOST

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -218,13 +218,14 @@ typedef struct rrddim RRDDIM;
 // and may lead to missing information.
 
 typedef enum rrdset_flags {
-    RRDSET_FLAG_ENABLED        = 1 << 0, // enables or disables a chart
-    RRDSET_FLAG_DETAIL         = 1 << 1, // if set, the data set should be considered as a detail of another
+    RRDSET_FLAG_ENABLED          = 1 << 0, // enables or disables a chart
+    RRDSET_FLAG_DETAIL           = 1 << 1, // if set, the data set should be considered as a detail of another
                                          // (the master data set should be the one that has the same family and is not detail)
-    RRDSET_FLAG_DEBUG          = 1 << 2, // enables or disables debugging for a chart
-    RRDSET_FLAG_OBSOLETE       = 1 << 3, // this is marked by the collector/module as obsolete
-    RRDSET_FLAG_BACKEND_SEND   = 1 << 4,
-    RRDSET_FLAG_BACKEND_IGNORE = 1 << 5
+    RRDSET_FLAG_DEBUG            = 1 << 2, // enables or disables debugging for a chart
+    RRDSET_FLAG_OBSOLETE         = 1 << 3, // this is marked by the collector/module as obsolete
+    RRDSET_FLAG_BACKEND_SEND     = 1 << 4, // if set, this chart should be sent to backends
+    RRDSET_FLAG_BACKEND_IGNORE   = 1 << 5, // if set, this chart should not be sent to backends
+    RRDSET_FLAG_EXPOSED_UPSTREAM = 1 << 6  // if set, we have sent this chart to netdata master (streaming)
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -599,6 +600,9 @@ extern void rrdset_next_usec(RRDSET *st, usec_t microseconds);
 #define rrdset_next(st) rrdset_next_usec(st, 0ULL)
 
 extern void rrdset_done(RRDSET *st);
+
+extern void rrdset_is_obsolete(RRDSET *st);
+extern void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
 #define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -211,8 +211,11 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rd->entries = st->entries;
     rd->update_every = st->update_every;
 
-    // prevent incremental calculation spikes
-    rd->collections_counter = 0;
+    if(rrdset_flag_check(st, RRDSET_FLAG_STORE_FIRST))
+        rd->collections_counter = 1;
+    else
+        rd->collections_counter = 0;
+
     rd->updated = 0;
     rd->flags = 0x00000000;
 

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -79,7 +79,7 @@ static inline int need_to_send_chart_definition(RRDSET *st) {
 static inline void send_chart_definition(RRDSET *st) {
     rrdset_flag_set(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
 
-    buffer_sprintf(st->rrdhost->rrdpush_buffer, "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d \"%s %s\"\n"
+    buffer_sprintf(st->rrdhost->rrdpush_buffer, "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d \"%s %s %s\"\n"
                 , st->id
                 , st->name
                 , st->title
@@ -91,6 +91,7 @@ static inline void send_chart_definition(RRDSET *st) {
                 , st->update_every
                 , rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)?"obsolete":""
                 , rrdset_flag_check(st, RRDSET_FLAG_DETAIL)?"detail":""
+                , rrdset_flag_check(st, RRDSET_FLAG_STORE_FIRST)?"store_first":""
     );
 
     RRDDIM *rd;

--- a/src/rrdpush.h
+++ b/src/rrdpush.h
@@ -8,6 +8,7 @@ extern unsigned int remote_clock_resync_iterations;
 
 extern int rrdpush_init();
 extern void rrdset_done_push(RRDSET *st);
+extern void rrdset_push_chart_definition(RRDSET *st);
 extern void *rrdpush_sender_thread(void *ptr);
 
 extern int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url);

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -175,7 +175,7 @@ inline void rrdset_is_obsolete(RRDSET *st) {
 
         // the chart will not get more updates (data collection)
         // so, we have to push its definition now
-        if(unlikely(host->rrdpush_enabled))
+        if(unlikely(st->rrdhost->rrdpush_enabled))
             rrdset_push_chart_definition(st);
     }
 }

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -172,6 +172,11 @@ inline void rrdset_is_obsolete(RRDSET *st) {
     if(unlikely(!(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)))) {
         rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE);
         rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+
+        // the chart will not get more updates (data collection)
+        // so, we have to push its definition now
+        if(unlikely(host->rrdpush_enabled))
+            rrdset_push_chart_definition(st);
     }
 }
 
@@ -179,6 +184,9 @@ inline void rrdset_isnot_obsolete(RRDSET *st) {
     if(unlikely((rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)))) {
         rrdset_flag_clear(st, RRDSET_FLAG_OBSOLETE);
         rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+
+        // the chart will be pushed upstream automatically
+        // due to data collection
     }
 }
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1246,7 +1246,7 @@ static inline RRDSET *statsd_private_rrdset_create(
     }
 
     statsd.private_charts++;
-    return rrdset_create_custom(
+    RRDSET *st = rrdset_create_custom(
             localhost
             , type
             , id
@@ -1261,6 +1261,8 @@ static inline RRDSET *statsd_private_rrdset_create(
             , memory_mode
             , history
     );
+    rrdset_flag_set(st, RRDSET_FLAG_STORE_FIRST);
+    return st;
 }
 
 static inline void statsd_private_chart_gauge(STATSD_METRIC *m) {
@@ -1654,6 +1656,8 @@ static inline void statsd_update_app_chart(STATSD_APP *app, STATSD_APP_CHART *ch
                 , app->rrd_memory_mode
                 , app->rrd_history_entries
         );
+
+        rrdset_flag_set(chart->st, RRDSET_FLAG_STORE_FIRST);
     }
     else rrdset_next(chart->st);
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -901,20 +901,20 @@ static inline struct cgroup *cgroup_add(const char *id) {
 static inline void cgroup_free(struct cgroup *cg) {
     debug(D_CGROUP, "Removing cgroup '%s' with chart id '%s' (was %s and %s)", cg->id, cg->chart_id, (cg->enabled)?"enabled":"disabled", (cg->available)?"available":"not available");
 
-    if(cg->st_cpu)                   rrdset_flag_set(cg->st_cpu,                   RRDSET_FLAG_OBSOLETE);
-    if(cg->st_cpu_per_core)          rrdset_flag_set(cg->st_cpu_per_core,          RRDSET_FLAG_OBSOLETE);
-    if(cg->st_mem)                   rrdset_flag_set(cg->st_mem,                   RRDSET_FLAG_OBSOLETE);
-    if(cg->st_writeback)             rrdset_flag_set(cg->st_writeback,             RRDSET_FLAG_OBSOLETE);
-    if(cg->st_mem_activity)          rrdset_flag_set(cg->st_mem_activity,          RRDSET_FLAG_OBSOLETE);
-    if(cg->st_pgfaults)              rrdset_flag_set(cg->st_pgfaults,              RRDSET_FLAG_OBSOLETE);
-    if(cg->st_mem_usage)             rrdset_flag_set(cg->st_mem_usage,             RRDSET_FLAG_OBSOLETE);
-    if(cg->st_mem_failcnt)           rrdset_flag_set(cg->st_mem_failcnt,           RRDSET_FLAG_OBSOLETE);
-    if(cg->st_io)                    rrdset_flag_set(cg->st_io,                    RRDSET_FLAG_OBSOLETE);
-    if(cg->st_serviced_ops)          rrdset_flag_set(cg->st_serviced_ops,          RRDSET_FLAG_OBSOLETE);
-    if(cg->st_throttle_io)           rrdset_flag_set(cg->st_throttle_io,           RRDSET_FLAG_OBSOLETE);
-    if(cg->st_throttle_serviced_ops) rrdset_flag_set(cg->st_throttle_serviced_ops, RRDSET_FLAG_OBSOLETE);
-    if(cg->st_queued_ops)            rrdset_flag_set(cg->st_queued_ops,            RRDSET_FLAG_OBSOLETE);
-    if(cg->st_merged_ops)            rrdset_flag_set(cg->st_merged_ops,            RRDSET_FLAG_OBSOLETE);
+    if(cg->st_cpu)                   rrdset_is_obsolete(cg->st_cpu);
+    if(cg->st_cpu_per_core)          rrdset_is_obsolete(cg->st_cpu_per_core);
+    if(cg->st_mem)                   rrdset_is_obsolete(cg->st_mem);
+    if(cg->st_writeback)             rrdset_is_obsolete(cg->st_writeback);
+    if(cg->st_mem_activity)          rrdset_is_obsolete(cg->st_mem_activity);
+    if(cg->st_pgfaults)              rrdset_is_obsolete(cg->st_pgfaults);
+    if(cg->st_mem_usage)             rrdset_is_obsolete(cg->st_mem_usage);
+    if(cg->st_mem_failcnt)           rrdset_is_obsolete(cg->st_mem_failcnt);
+    if(cg->st_io)                    rrdset_is_obsolete(cg->st_io);
+    if(cg->st_serviced_ops)          rrdset_is_obsolete(cg->st_serviced_ops);
+    if(cg->st_throttle_io)           rrdset_is_obsolete(cg->st_throttle_io);
+    if(cg->st_throttle_serviced_ops) rrdset_is_obsolete(cg->st_throttle_serviced_ops);
+    if(cg->st_queued_ops)            rrdset_is_obsolete(cg->st_queued_ops);
+    if(cg->st_merged_ops)            rrdset_is_obsolete(cg->st_merged_ops);
 
     freez(cg->cpuacct_usage.cpu_percpu);
 


### PR DESCRIPTION
Fixes #2222 
Fixes #2161 
Fixes #2334 

This PR extends the plugins API to support options per `CHART`. The options are appended to the `CHART` line (to be backwards compatible - older versions of netdata will silently ignore the options - to use the new functionality both masters and slaves have  to be updated).

With this PR, ephemeral charts (cgroups, disks, network interfaces) are now automatically cleaned up on netdata masters and proxies.

statsd charts no longer loose the first collected value.

metrics sent to backends were randomly loosing points if the data collection frequency was above 1 and the backends frequency was also the same. This PR detects this case and properly reports all the points.