### PR TITLE
properly calculate the first data collection of statsd metrics when charts are loaded from disk

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -381,6 +381,14 @@ typedef enum rrdhost_flags {
 #define rrdhost_flag_clear(host, flag) (host)->flags &= ~flag
 #endif
 
+#ifdef NETDATA_INTERNAL_CHECKS
+#define rrdset_debug(st, fmt, args...) do { if(unlikely(debug_flags & D_RRD_STATS && rrdset_flag_check(st, RRDSET_FLAG_DEBUG))) \
+            debug_int(__FILE__, __FUNCTION__, __LINE__, "%s: " fmt, st->name, ##args); } while(0)
+#else
+#define rrdset_debug(st, fmt, args...) debug_dummy()
+#endif
+
+
 // ----------------------------------------------------------------------------
 // RRD HOST
 

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -226,7 +226,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rd->collected_volume = 0;
     rd->stored_volume = 0;
     rd->last_stored_value = 0;
-    rd->values[st->current_entry] = pack_storage_number(0, SN_NOT_EXISTS);
+    rd->values[st->current_entry] = SN_EMPTY_SLOT; // pack_storage_number(0, SN_NOT_EXISTS);
     rd->last_collected_time.tv_sec = 0;
     rd->last_collected_time.tv_usec = 0;
     rd->rrdset = st;

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1262,6 +1262,7 @@ static inline RRDSET *statsd_private_rrdset_create(
             , history
     );
     rrdset_flag_set(st, RRDSET_FLAG_STORE_FIRST);
+    // rrdset_flag_set(st, RRDSET_FLAG_DEBUG);
     return st;
 }
 
@@ -1658,6 +1659,7 @@ static inline void statsd_update_app_chart(STATSD_APP *app, STATSD_APP_CHART *ch
         );
 
         rrdset_flag_set(chart->st, RRDSET_FLAG_STORE_FIRST);
+        // rrdset_flag_set(chart->st, RRDSET_FLAG_DEBUG);
     }
     else rrdset_next(chart->st);
 


### PR DESCRIPTION
Also, charts are now initialised a lot faster when big gaps should be shown.