### PR TITLE
adapted prometheus formatting

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -227,7 +227,8 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_BACKEND_IGNORE   = 1 << 5, // if set, this chart should not be sent to backends
     RRDSET_FLAG_EXPOSED_UPSTREAM = 1 << 6, // if set, we have sent this chart to netdata master (streaming)
     RRDSET_FLAG_STORE_FIRST      = 1 << 7, // if set, do not eliminate the first collection during interpolation
-    RRDSET_FLAG_HETEROGENEOUS    = 1 << 8  // if set, the chart is not homogeneus (dimensions in it have multiple algorithms, multipliers or dividers)
+    RRDSET_FLAG_HETEROGENEOUS    = 1 << 8, // if set, the chart is not homogeneous (dimensions in it have multiple algorithms, multipliers or dividers)
+    RRDSET_FLAG_HOMEGENEOUS_CHECK= 1 << 9  // if set, the chart should be checked to determine if the dimensions as homogeneous
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -595,6 +596,8 @@ extern void rrdhost_cleanup_orphan_hosts(RRDHOST *protected);
 extern void rrdhost_free(RRDHOST *host);
 extern void rrdhost_save(RRDHOST *host);
 extern void rrdhost_delete(RRDHOST *host);
+
+extern void rrdset_update_heterogeneous_flag(RRDSET *st);
 
 extern RRDSET *rrdset_find(RRDHOST *host, const char *id);
 #define rrdset_find_localhost(id) rrdset_find(localhost, id)

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -57,6 +57,7 @@ inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm)
     debug(D_RRD_CALLS, "Updating algorithm of dimension '%s/%s' from %s to %s", st->id, rd->name, rrd_algorithm_name(rd->algorithm), rrd_algorithm_name(algorithm));
     rd->algorithm = algorithm;
     rd->exposed = 0;
+    rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
     return 1;
 }
 
@@ -67,6 +68,7 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multip
     debug(D_RRD_CALLS, "Updating multiplier of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, st->id, rd->name, rd->multiplier, multiplier);
     rd->multiplier = multiplier;
     rd->exposed = 0;
+    rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
     return 1;
 }
 
@@ -77,6 +79,7 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     debug(D_RRD_CALLS, "Updating divisor of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, st->id, rd->name, rd->divisor, divisor);
     rd->divisor = divisor;
     rd->exposed = 0;
+    rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
     return 1;
 }
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -190,6 +190,37 @@ inline void rrdset_isnot_obsolete(RRDSET *st) {
     }
 }
 
+inline void rrdset_update_heterogeneous_flag(RRDSET *st) {
+    RRDDIM *rd;
+
+    rrdset_flag_clear(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
+
+    RRD_ALGORITHM algorithm = st->dimensions->algorithm;
+    collected_number multiplier = abs(st->dimensions->multiplier);
+    collected_number divisor = abs(st->dimensions->divisor);
+
+    rrddim_foreach_read(rd, st) {
+        if(algorithm != rd->algorithm || multiplier != abs(rd->multiplier) || divisor != abs(rd->divisor)) {
+            if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
+                #ifdef NETDATA_INTERNAL_CHECKS
+                info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already present (algorithm is '%s' vs '%s', multiplier is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ", divisor is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ").",
+                        rd->name,
+                        st->name,
+                        st->rrdhost->hostname,
+                        rrd_algorithm_name(rd->algorithm), rrd_algorithm_name(algorithm),
+                        rd->multiplier, multiplier,
+                        rd->divisor, divisor
+                );
+                #endif
+                rrdset_flag_set(st, RRDSET_FLAG_HETEROGENEOUS);
+            }
+            return;
+        }
+    }
+
+    rrdset_flag_clear(st, RRDSET_FLAG_HETEROGENEOUS);
+}
+
 // ----------------------------------------------------------------------------
 // RRDSET - reset a chart
 


### PR DESCRIPTION
https://github.com/firehol/netdata/pull/2436#issuecomment-315002915

I did some research to check if `as collected` could possibly use the format of `average`. I found out that for most of the cases, even if we collect metrics from multiple sources, the metrics that are added to the same chart happen to have exactly the same algorithm, multiplier and divider.

I found only 3 charts that this is not true. A redis one, and 2 netdata internal ones (for monitoring netdata itself).

Also, I checked if netdata autodetection incrementally adds dimensions to charts (so that adding an incompatible dimension will suddenly make the chart dimensions heterogeneous). I found that most dynamic additions to a chart, are controlled by the exact same source, which is totally unlikely to change the algorithm, multiplier or divider.

The key problem remains statsd synthetic charts, that are user controlled.

So, I added some code that formats homogeneous charts in `as collected` mode with the format `average` uses. This is still dynamic, meaning that netdata will automatically switch format if the chart becomes heterogeneous, but I think the probability of this happening is close to zero.

Also, metrics are named `*_total` for counters, `*_average` for averages and `*_sum` for sums.

Finally, for `average` mode, the units are in the metrics name.
