### PR TITLE
fixed corruption in charts JSON, when each chunk of data is above 1024 bytes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -635,6 +635,7 @@ int main(int argc, char **argv) {
                         char* debug_flags_string = "debug_flags=";
 
                         if(strcmp(optarg, "unittest") == 0) {
+                            if(unit_test_buffer()) exit(1);
                             if(unit_test_str2ld()) exit(1);
                             //default_rrd_update_every = 1;
                             //default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -6,6 +6,7 @@
 
 static struct mountinfo *disk_mountinfo_root = NULL;
 static int check_for_new_mountpoints_every = 15;
+static int cleanup_mount_points = 1;
 
 static inline void mountinfo_reload(int force) {
     static time_t last_loaded = 0;
@@ -58,7 +59,7 @@ int mount_point_cleanup(void *entry, void *data) {
         return 0;
     }
 
-    if(likely(mp->collected)) {
+    if(likely(cleanup_mount_points && mp->collected)) {
         mp->collected = 0;
         mp->updated = 0;
         mp->shown_error = 0;
@@ -327,6 +328,8 @@ void *proc_diskspace_main(void *ptr) {
         error("DISKSPACE: Cannot set pthread cancel state to ENABLE.");
 
     int vdo_cpu_netdata = config_get_boolean("plugin:proc", "netdata server resources", 1);
+
+    cleanup_mount_points = config_get_boolean(CONFIG_SECTION_DISKSPACE, "remove charts of unmounted disks" , cleanup_mount_points);
 
     int update_every = (int)config_get_number(CONFIG_SECTION_DISKSPACE, "update every", localhost->rrd_update_every);
     if(update_every < localhost->rrd_update_every)

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -269,6 +269,34 @@ int unit_test_str2ld() {
     return 0;
 }
 
+int unit_test_buffer() {
+    BUFFER *wb = buffer_create(1);
+    char string[2048 + 1];
+    char final[9000 + 1];
+    int i;
+
+    for(i = 0; i < 2048; i++)
+        string[i] = (char)((i % 24) + 'a');
+    string[2048] = '\0';
+
+    const char *fmt = "string1: %s\nstring2: %s\nstring3: %s\nstring4: %s";
+    buffer_sprintf(wb, fmt, string, string, string, string);
+    snprintfz(final, 9000, fmt, string, string, string, string);
+
+    const char *s = buffer_tostring(wb);
+
+    if(buffer_strlen(wb) != strlen(final) || strcmp(s, final) != 0) {
+        fprintf(stderr, "\nbuffer_sprintf() is faulty.\n");
+        fprintf(stderr, "\nstring  : %s (length %zu)\n", string, strlen(string));
+        fprintf(stderr, "\nbuffer  : %s (length %zu)\n", s, buffer_strlen(wb));
+        fprintf(stderr, "\nexpected: %s (length %zu)\n", final, strlen(final));
+        return -1;
+    }
+
+    fprintf(stderr, "buffer_sprintf() works as expected.\n");
+    return 0;
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 struct feed_values {

--- a/src/unit_test.h
+++ b/src/unit_test.h
@@ -5,5 +5,6 @@ extern int unit_test_storage(void);
 extern int unit_test(long delay, long shift);
 extern int run_all_mockup_tests(void);
 extern int unit_test_str2ld(void);
+extern int unit_test_buffer(void);
 
 #endif /* NETDATA_UNIT_TEST_H */

--- a/src/web_buffer.c
+++ b/src/web_buffer.c
@@ -201,29 +201,25 @@ void buffer_sprintf(BUFFER *wb, const char *fmt, ...)
 {
     if(unlikely(!fmt || !*fmt)) return;
 
-    buffer_need_bytes(wb, 2);
-
-    size_t len = wb->size - wb->len - 1;
-    size_t wrote;
-
     va_list args;
-    va_start(args, fmt);
-    wrote = (size_t) vsnprintfz(&wb->buffer[wb->len], len, fmt, args);
-    va_end(args);
+    size_t wrote = 0, need = 2, multiplier = 0, len;
 
-    if(unlikely(wrote >= len)) {
-        // truncated
-        buffer_overflow_check(wb);
+    do {
+        need += wrote + multiplier * WEB_DATA_LENGTH_INCREASE_STEP;
+        multiplier++;
 
-        debug(D_WEB_BUFFER, "web_buffer_sprintf(): increasing web_buffer at position %zu, size = %zu\n", wb->len, wb->size);
-        buffer_need_bytes(wb, len + WEB_DATA_LENGTH_INCREASE_STEP);
+        debug(D_WEB_BUFFER, "web_buffer_sprintf(): increasing web_buffer at position %zu, size = %zu, by %zu bytes (wrote = %zu)\n", wb->len, wb->size, need, wrote);
+        buffer_need_bytes(wb, need);
+
+        len = wb->size - wb->len - 1;
 
         va_start(args, fmt);
-        buffer_vsprintf(wb, fmt, args);
+        wrote = (size_t) vsnprintfz(&wb->buffer[wb->len], len, fmt, args);
         va_end(args);
-    }
-    else
-        wb->len += wrote;
+
+    } while(wrote >= len);
+
+    wb->len += wrote;
 
     // the buffer is \0 terminated by vsnprintf
 }


### PR DESCRIPTION
There was a faulty assumption that each chart in the JSON format will be at most 1024 bytes. Of course, this was not intended. It was a bug. Now it is dynamic. It does not care how long it will be.

fixes #2276 
fixes #2498 

---

Added netdata.conf options to disable cleaning up charts of removed disks.
https://stackoverflow.com/questions/45221639/add-alert-for-mount-point-in-netdata-monitoring
