### PR TITLE
Fix parsing of mdstat output

### DIFF
--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -20,7 +20,7 @@ class Service(SimpleService):
                                            r'(?P<total_disks>[0-9]+)/'
                                            r'(?P<inuse_disks>[0-9])\]'),
                           status=re_compile(r' (?P<array>[a-zA-Z_0-9]+) : active .+ '
-                                            r'(?P<operation>[a-z]+) = '
+                                            r'(?P<operation>[a-z]+) =[ ]{1,2}'
                                             r'(?P<operation_status>[0-9.]+).+finish='
                                             r'(?P<finish>([0-9.]+))min speed='
                                             r'(?P<speed>[0-9]+)'))


### PR DESCRIPTION
When an operation is in progress, there could be two spaces before the
percentage when it's less than 10%.