### PR TITLE
Fix None value for Seconds_Behind_Master

### DIFF
--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -117,7 +117,10 @@ GLOBAL_STATS = [
  'Connection_errors_tcpwrap']
 
 def slave_seconds(value):
-    return value if value is not '' else -1
+    try:
+        return int(value)
+    except ValueError:
+        return -1
 
 def slave_running(value):
     return 1 if value == 'Yes' else -1


### PR DESCRIPTION
The PR fixes `None` value for `Seconds_Behind_Master` by returning `-1` for non-numeric values.

See this comment for more information: https://github.com/firehol/netdata/pull/2184#issuecomment-318319662

@l2isbad