### PR TITLE
include stiebeleltron.node.js in dist

### DIFF
--- a/node.d/Makefile.am
+++ b/node.d/Makefile.am
@@ -6,6 +6,7 @@ dist_node_DATA = \
 	fronius.node.js \
 	sma_webbox.node.js \
 	snmp.node.js \
+	stiebeleltron.node.js \
 	$(NULL)
 
 nodemodulesdir=$(nodedir)/node_modules


### PR DESCRIPTION
when installing netdata, this file was missing.