### PR TITLE
Reduce notification e-mail spam score.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -105,6 +105,13 @@ SEND_EMAIL="YES"
 DEFAULT_RECIPIENT_EMAIL="root"
 # to receive only critical alarms, set it to "root|critical"
 
+# Optionally specify the encoding to list in the Content-Type header.
+# This doesn't change what encoding the e-mail is sent with, just what
+# the headers say it was encoded as.
+# This shouldn't need to be changed as it will almost always be
+# autodetected from the environment.
+#EMAIL_CHARSET="UTF-8"
+
 
 #------------------------------------------------------------------------------
 # pushover (pushover.net) global notification options

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1402,6 +1402,8 @@ This is a MIME-encoded multipart message
 
 --multipart-boundary
 Content-Type: text/plain
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
 
 ${host} ${status_message}
 
@@ -1418,6 +1420,8 @@ Notification generated on ${this_host}
 
 --multipart-boundary
 Content-Type: text/html
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; padding: 0;">

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -290,6 +290,7 @@ declare -A role_recipients_custom=()
 # email configs
 EMAIL_SENDER=""
 DEFAULT_RECIPIENT_EMAIL="root"
+EMAIL_CHARSET=$(locale charmap 2>/dev/null)
 declare -A role_recipients_email=()
 
 # load the user configuration
@@ -299,6 +300,14 @@ if [ -f "${NETDATA_CONFIG_DIR}/health_alarm_notify.conf" ]
     source "${NETDATA_CONFIG_DIR}/health_alarm_notify.conf"
 else
     error "Cannot find file ${NETDATA_CONFIG_DIR}/health_alarm_notify.conf. Using internal defaults."
+fi
+
+# If we didn't autodetect the character set for e-mail and it wasn't
+# set by the user, we need to set it to a reasonable default.  UTF-8
+# should be correct for almost all modern UNIX systems.
+if [ -z ${EMAIL_CHARSET} ]
+    then
+    EMAIL_CHARSET="UTF-8"
 fi
 
 # -----------------------------------------------------------------------------
@@ -1401,7 +1410,7 @@ Content-Type: multipart/alternative; boundary="multipart-boundary"
 This is a MIME-encoded multipart message
 
 --multipart-boundary
-Content-Type: text/plain
+Content-Type: text/plain; encoding=${EMAIL_CHARSET}
 Content-Disposition: inline
 Content-Transfer-Encoding: 8bit
 
@@ -1419,7 +1428,7 @@ Date    : ${date}
 Notification generated on ${this_host}
 
 --multipart-boundary
-Content-Type: text/html
+Content-Type: text/html; encoding=${EMAIL_CHARSET}
 Content-Disposition: inline
 Content-Transfer-Encoding: 8bit
 


### PR DESCRIPTION
This adds Content-Disposition and Content-Transfer-Encoding headers to the HTML and text/plain e-mail bodies, thus eliminating one of the issues that tools like Spamassassin check for.

The value `inline` for the Content-Disposition is largely ignored by most e-mail clients these days, but may cause some older clients to display both parts of the message.  It's usage here is consistent with what most e-mail clients set when sending both HTML and text/plain components.

The value `8bit` for the Content-Type-Encoding clarifies that there is unescaped binary data in the text, but that it is limited to 998 character lines and only uses CR and LF at the end of the lines.  `7bit` would work also when dealing with sending the messages in English, and technically be more widely compatible, but we can't assume that the message content will not contain 8-bit characters because certain components (specifically, at least the host name and chart name) may contain Unicode codepoints above 127.

Ideally, we also need to add `charset=` parameters to the Content-Type header for both components, but that requires a bit more work because it's non-trivial to translate the locale's character set to an IANA character set.

Partially fixes #2587