### PR TITLE
allow HTTP/2 for custom_log_format in web_log

### DIFF
--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -697,7 +697,7 @@ class Web(Mixin):
         optional_dict = {'resp_length': r'\d+',
                          'resp_time': r'[\d.]+',
                          'resp_time_upstream': r'[\d.-]+',
-                         'http_version': r'\d\.\d'}
+                         'http_version': r'\d(\.\d)?'}
 
         mandatory_values = set(mandatory_dict) - set(match_dict)
         if mandatory_values:


### PR DESCRIPTION
some web servers log HTTP2 requests as `HTTP/2` instead of `HTTP/2.0`. When using a custom log
format, requests with HTTP/2 can't be matched using the default dictionary.

This commit makes the `.0` part optional for custom logs