### PR TITLE
fixed alarms severity filtering bug; more minor fixes and improvements

### DIFF
--- a/src/inlined.h
+++ b/src/inlined.h
@@ -244,25 +244,47 @@ static inline char *strncpyz(char *dst, const char *src, size_t n) {
     return p;
 }
 
-static inline int read_single_number_file(const char *filename, unsigned long long *result) {
-    char buffer[30 + 1];
-
+static inline int read_file(const char *filename, char *buffer, size_t size) {
     int fd = open(filename, O_RDONLY, 0666);
-    if(unlikely(fd == -1)) {
-        *result = 0;
+    if(unlikely(fd == -1))
         return 1;
-    }
 
-    ssize_t r = read(fd, buffer, 30);
+    ssize_t r = read(fd, buffer, size);
     if(unlikely(r == -1)) {
-        *result = 0;
         close(fd);
         return 2;
     }
+    buffer[r] = '\0';
 
     close(fd);
+    return 0;
+}
+
+static inline int read_single_number_file(const char *filename, unsigned long long *result) {
+    char buffer[30 + 1];
+
+    int ret = read_file(filename, buffer, 30);
+    if(unlikely(ret)) {
+        *result = 0;
+        return ret;
+    }
+
     buffer[30] = '\0';
     *result = str2ull(buffer);
+    return 0;
+}
+
+static inline int read_single_signed_number_file(const char *filename, long long *result) {
+    char buffer[30 + 1];
+
+    int ret = read_file(filename, buffer, 30);
+    if(unlikely(ret)) {
+        *result = 0;
+        return ret;
+    }
+
+    buffer[30] = '\0';
+    *result = atoll(buffer);
     return 0;
 }
 

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -167,11 +167,11 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
                     }
 
                     if(rd->multiplier != multiplier) {
-                        info("File %s does not have the expected multiplier (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT ". Previous values may be wrong.", fullfilename, multiplier, rd->multiplier);
+                        info("File %s does not have the expected multiplier (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", fullfilename, multiplier, rd->multiplier);
                     }
 
                     if(rd->divisor != divisor) {
-                        info("File %s does not have the expected divisor (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT ". Previous values may be wrong.", fullfilename, divisor, rd->divisor);
+                        info("File %s does not have the expected divisor (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", fullfilename, divisor, rd->divisor);
                     }
                 }
             }

--- a/system/netdata-init-d.in
+++ b/system/netdata-init-d.in
@@ -15,7 +15,7 @@ DAEMON="netdata"
 DAEMON_PATH=@sbindir_POST@
 PIDFILE=@localstatedir_POST@/run/$DAEMON.pid
 DAEMONOPTS="-P $PIDFILE"
-STOP_TIMEOUT="10"
+STOP_TIMEOUT="60"
 
 [ -e /etc/sysconfig/$DAEMON ] && . /etc/sysconfig/$DAEMON
 

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -10,7 +10,7 @@
 
 # The timeout in seconds to wait for netdata
 # to save its database on disk and exit.
-: ${NETDATA_WAIT_EXIT_TIMEOUT:=15}
+: ${NETDATA_WAIT_EXIT_TIMEOUT:=60}
 
 # When set to 1, if netdata does not exit in
 # NETDATA_WAIT_EXIT_TIMEOUT, we will force it

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -11,5 +11,9 @@ ExecStart=@sbindir_POST@/netdata -D
 # saving a big db on slow disks may need some time
 TimeoutStopSec=60
 
+# restart netdata if it crashes
+Restart=on-failure
+RestartSec=30
+
 [Install]
 WantedBy=multi-user.target

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -8,6 +8,12 @@ User=netdata
 Group=netdata
 ExecStart=@sbindir_POST@/netdata -D
 
+# The minimum netdata Out-Of-Memory (OOM) score.
+# netdata (via [global].OOM score in netdata.conf) can only increase the value set here.
+# To decrease it, set the minimum here and set the same or a higher value in netdata.conf.
+# Valid values: -1000 (never kill netdata) to 1000 (always kill netdata).
+OOMScoreAdjust=0
+
 # saving a big db on slow disks may need some time
 TimeoutStopSec=60
 


### PR DESCRIPTION
1. netdata service stop now has a timeout of 60 seconds (as a good default for cases netdata has big databases to save).

   :point_right: _do you know how to do this with LSB init style, like old ubuntu and centos? help me, I can't find out._

2. systemd will now restart netdata in cases it stops with an error (i.e. out-of-memory conditions, or fatal bugs); fixes #2617 

3. alarm notifications severity filtering did not cleanup properly. Once you received a `CRITICAL` notification for an alarm, it kept sending all notifications for this alarm. fixes #2618 

   :exclamation: _to cleanup the dirty status of your notifications, check this: https://github.com/firehol/netdata/issues/2618#issuecomment-324078665_

4. properly handle negative OOM scores #2549 . This was buggy in netdata. Fixed it.