### PR TITLE
support domain name sockets

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -80,6 +80,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/un.h>
 #include <time.h>
 #include <unistd.h>
 #include <uuid/uuid.h>

--- a/src/main.c
+++ b/src/main.c
@@ -172,7 +172,7 @@ void kill_childs()
         // it is detached
         // pthread_join(w->thread, NULL);
 
-        w->obsolete = 1;
+        WEB_CLIENT_IS_OBSOLETE(w);
     }
 
     int i;

--- a/src/socket.h
+++ b/src/socket.h
@@ -15,7 +15,8 @@ typedef struct listen_sockets {
     size_t failed;                      // the number of sockets attempted to open, but failed
     int fds[MAX_LISTEN_FDS];            // the open sockets
     char *fds_names[MAX_LISTEN_FDS];    // descriptions for the open sockets
-    int fds_types[MAX_LISTEN_FDS];      // the socktype for the open sockets
+    int fds_types[MAX_LISTEN_FDS];      // the socktype for the open sockets (SOCK_STREAM, SOCK_DGRAM)
+    int fds_families[MAX_LISTEN_FDS];   // the family of the open sockets (AF_UNIX, AF_INET, AF_INET6)
 } LISTEN_SOCKETS;
 
 extern int listen_sockets_setup(LISTEN_SOCKETS *sockets);

--- a/src/socket.h
+++ b/src/socket.h
@@ -21,7 +21,7 @@ typedef struct listen_sockets {
 extern int listen_sockets_setup(LISTEN_SOCKETS *sockets);
 extern void listen_sockets_close(LISTEN_SOCKETS *sockets);
 
-extern int connect_to(const char *definition, int default_port, struct timeval *timeout);
+extern int connect_to_this(const char *definition, int default_port, struct timeval *timeout);
 extern int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
 
 extern ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -816,7 +816,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 #endif /* NETDATA_INTERNAL_CHECKS */
     }
 
-    if(respect_web_browser_do_not_track_policy && w->donottrack) {
+    if(respect_web_browser_do_not_track_policy && web_client_has_donottrack(w)) {
         buffer_flush(w->response.data);
         buffer_sprintf(w->response.data, "Your web browser is sending 'DNT: 1' (Do Not Track). The registry requires persistent cookies on your browser to work.");
         return 400;
@@ -853,19 +853,19 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
     switch(action) {
         case 'A':
-            w->tracking_required = 1;
+            web_client_enable_tracking_required(w);
             return registry_request_access_json(host, w, person_guid, machine_guid, machine_url, url_name, now_realtime_sec());
 
         case 'D':
-            w->tracking_required = 1;
+            web_client_enable_tracking_required(w);
             return registry_request_delete_json(host, w, person_guid, machine_guid, machine_url, delete_url, now_realtime_sec());
 
         case 'S':
-            w->tracking_required = 1;
+            web_client_enable_tracking_required(w);
             return registry_request_search_json(host, w, person_guid, machine_guid, machine_url, search_machine_guid, now_realtime_sec());
 
         case 'W':
-            w->tracking_required = 1;
+            web_client_enable_tracking_required(w);
             return registry_request_switch_json(host, w, person_guid, machine_guid, machine_url, to_person_guid, now_realtime_sec());
 
         case 'H':

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -20,6 +20,66 @@ typedef enum web_client_mode {
     WEB_CLIENT_MODE_STREAM      = 3
 } WEB_CLIENT_MODE;
 
+typedef enum web_client_flags {
+    WEB_CLIENT_FLAG_OBSOLETE          = 1 << 0, // if set, the listener will remove this client
+    // after setting this, you should not touch
+    // this web_client
+
+    WEB_CLIENT_FLAG_DEAD              = 1 << 1, // if set, this client is dead
+
+    WEB_CLIENT_FLAG_KEEPALIVE         = 1 << 2, // if set, the web client will be re-used
+
+    WEB_CLIENT_FLAG_WAIT_RECEIVE      = 1 << 3, // if set, we are waiting more input data
+    WEB_CLIENT_FLAG_WAIT_SEND         = 1 << 4, // if set, we have data to send to the client
+
+    WEB_CLIENT_FLAG_DO_NOT_TRACK      = 1 << 5, // if set, we should not set cookies on this client
+    WEB_CLIENT_FLAG_TRACKING_REQUIRED = 1 << 6, // if set, we need to send cookies
+
+    WEB_CLIENT_FLAG_TCP_CLIENT        = 1 << 7, // if set, the client is using a TCP socket
+    WEB_CLIENT_FLAG_UNIX_CLIENT       = 1 << 8  // if set, the client is using a UNIX socket
+} WEB_CLIENT_FLAGS;
+
+//#ifdef HAVE_C___ATOMIC
+//#define web_client_flag_check(w, flag) (__atomic_load_n(&((w)->flags), __ATOMIC_SEQ_CST) & flag)
+//#define web_client_flag_set(w, flag)   __atomic_or_fetch(&((w)->flags), flag, __ATOMIC_SEQ_CST)
+//#define web_client_flag_clear(w, flag) __atomic_and_fetch(&((w)->flags), ~flag, __ATOMIC_SEQ_CST)
+//#else
+#define web_client_flag_check(w, flag) ((w)->flags & flag)
+#define web_client_flag_set(w, flag)   (w)->flags |= flag
+#define web_client_flag_clear(w, flag) (w)->flags &= ~flag
+//#endif
+
+#define WEB_CLIENT_IS_OBSOLETE(w) web_client_flag_set(w, WEB_CLIENT_FLAG_OBSOLETE)
+#define web_client_check_obsolete(w) web_client_flag_check(w, WEB_CLIENT_FLAG_OBSOLETE)
+
+#define WEB_CLIENT_IS_DEAD(w) web_client_flag_set(w, WEB_CLIENT_FLAG_DEAD)
+#define web_client_check_dead(w) web_client_flag_check(w, WEB_CLIENT_FLAG_DEAD)
+
+#define web_client_has_keepalive(w) web_client_flag_check(w, WEB_CLIENT_FLAG_KEEPALIVE)
+#define web_client_enable_keepalive(w) web_client_flag_set(w, WEB_CLIENT_FLAG_KEEPALIVE)
+#define web_client_disable_keepalive(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_KEEPALIVE)
+
+#define web_client_has_donottrack(w) web_client_flag_check(w, WEB_CLIENT_FLAG_DO_NOT_TRACK)
+#define web_client_enable_donottrack(w) web_client_flag_set(w, WEB_CLIENT_FLAG_DO_NOT_TRACK)
+#define web_client_disable_donottrack(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_DO_NOT_TRACK)
+
+#define web_client_has_tracking_required(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TRACKING_REQUIRED)
+#define web_client_enable_tracking_required(w) web_client_flag_set(w, WEB_CLIENT_FLAG_TRACKING_REQUIRED)
+#define web_client_disable_tracking_required(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_TRACKING_REQUIRED)
+
+#define web_client_has_wait_receive(w) web_client_flag_check(w, WEB_CLIENT_FLAG_WAIT_RECEIVE)
+#define web_client_enable_wait_receive(w) web_client_flag_set(w, WEB_CLIENT_FLAG_WAIT_RECEIVE)
+#define web_client_disable_wait_receive(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_WAIT_RECEIVE)
+
+#define web_client_has_wait_send(w) web_client_flag_check(w, WEB_CLIENT_FLAG_WAIT_SEND)
+#define web_client_enable_wait_send(w) web_client_flag_set(w, WEB_CLIENT_FLAG_WAIT_SEND)
+#define web_client_disable_wait_send(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_WAIT_SEND)
+
+#define web_client_set_tcp(w) web_client_flag_set(w, WEB_CLIENT_FLAG_TCP_CLIENT)
+#define web_client_set_unix(w) web_client_flag_set(w, WEB_CLIENT_FLAG_UNIX_CLIENT)
+
+#define web_client_is_corkable(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TCP_CLIENT)
+
 #define URL_MAX 8192
 #define ZLIB_CHUNK  16384
 #define HTTP_RESPONSE_HEADER_SIZE 4096
@@ -50,20 +110,7 @@ struct response {
 struct web_client {
     unsigned long long id;
 
-    uint8_t obsolete:1;                 // if set to 1, the listener will remove this client
-                                        // after setting this to 1, you should not touch
-                                        // this web_client
-
-    uint8_t dead:1;                     // if set to 1, this client is dead
-
-    uint8_t keepalive:1;                // if set to 1, the web client will be re-used
-
-    uint8_t wait_receive:1;             // 1 = we are waiting more input data
-    uint8_t wait_send:1;                // 1 = we have data to send to the client
-
-    uint8_t donottrack:1;               // 1 = we should not set cookies on this client
-    uint8_t tracking_required:1;        // 1 = if the request requires cookies
-
+    WEB_CLIENT_FLAGS flags;             // status flags for the client
     WEB_CLIENT_MODE mode;               // the operational mode of the client
 
     int tcp_cork;                       // 1 = we have a cork on the socket
@@ -93,8 +140,6 @@ struct web_client {
     struct web_client *prev;
     struct web_client *next;
 };
-
-#define WEB_CLIENT_IS_DEAD(w) (w)->dead=1
 
 extern struct web_client *web_clients;
 

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -6,13 +6,9 @@ After=network.target httpd.service squid.service nfs-server.service mysqld.servi
 Type=simple
 User=netdata
 Group=netdata
-ExecStart=@sbindir_POST@/netdata -D
-
-# The minimum netdata Out-Of-Memory (OOM) score.
-# netdata (via [global].OOM score in netdata.conf) can only increase the value set here.
-# To decrease it, set the minimum here and set the same or a higher value in netdata.conf.
-# Valid values: -1000 (never kill netdata) to 1000 (always kill netdata).
-OOMScoreAdjust=0
+RuntimeDirectory=netdata
+RuntimeDirectoryMode=0775
+ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=60
@@ -20,6 +16,26 @@ TimeoutStopSec=60
 # restart netdata if it crashes
 Restart=on-failure
 RestartSec=30
+
+# The minimum netdata Out-Of-Memory (OOM) score.
+# netdata (via [global].OOM score in netdata.conf) can only increase the value set here.
+# To decrease it, set the minimum here and set the same or a higher value in netdata.conf.
+# Valid values: -1000 (never kill netdata) to 1000 (always kill netdata).
+#OOMScoreAdjust=0
+
+# By default netdata switches to scheduling policy idle, which makes it use CPU, only
+# when there is spare available.
+# Valid policies: other (the system default) | batch | idle | fifo | rr
+#CPUSchedulingPolicy=other
+
+# This sets the maximum scheduling priority netdata can set (for policies: rr and fifo).
+# netdata (via [global].process scheduling priority in netdata.conf) can only lower this value.
+# Priority gets values 1 (lowest) to 99 (highest).
+#CPUSchedulingPriority=1
+
+# For scheduling policy 'other' and 'batch', this sets the lowest niceness of netdata.
+# netdata (via [global].process nice level in netdata.conf) can only increase the value set here.
+#Nice=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
netdata now supports unix domain sockets:

1. for the web API (use `bind to = unix:/path/to/netdata.sock`). This allows web servers in front of netdata to use a socket file while proxying netdata.

2. for statsd

3. for sending and receiving metrics between netdata netdata servers (if they are on the same host)

4. for pushing metrics to backends


Fixes #2656 