### PR TITLE
Powerdns plugin init

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -53,6 +53,7 @@ dist_pythonconfig_DATA = \
     python.d/phpfpm.conf \
     python.d/postfix.conf \
     python.d/postgres.conf \
+    python.d/powerdns.conf \
     python.d/rabbitmq.conf \
     python.d/redis.conf \
     python.d/retroshare.conf \

--- a/conf.d/python.d/powerdns.conf
+++ b/conf.d/python.d/powerdns.conf
@@ -1,0 +1,71 @@
+# netdata python.d.plugin configuration for powerdns
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 5
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname     # the JOB's name as it will appear at the
+#                      # dashboard (by default is the job_name)
+#                      # JOBs sharing a name are mutually exclusive
+#     update_every: 1  # the JOB's data collection frequency
+#     priority: 60000  # the JOB's order on the dashboard
+#     retries: 5       # the JOB's number of restoration attempts
+#
+# Additionally to the above, apache also supports the following:
+#
+#     url: 'URL'             # the URL to fetch powerdns performance statistics
+#     header:
+#          X-API-Key: 'Key'  # API key
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+
+localhost:
+  name : 'local'
+  url  : 'http://127.0.0.1:8081/api/v1/servers/localhost/statistics'
+  header:
+    X-API-Key: 'changeme'

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -41,6 +41,7 @@ dist_python_DATA = \
     phpfpm.chart.py \
     postfix.chart.py \
     postgres.chart.py \
+    powerdns.chart.py \
     rabbitmq.chart.py \
     redis.chart.py \
     retroshare.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -1278,6 +1278,45 @@ When no configuration file is found, module tries to connect to TCP/IP socket: `
 
 ---
 
+# powerdns
+
+Module monitor powerdns performance and health metrics.
+
+Following charts are drawn:
+
+1. **Queries and Answers**
+ * udp-queries
+ * udp-answers
+ * tcp-queries
+ * tcp-answers
+
+2. **Cache Usage**
+ * query-cache-hit
+ * query-cache-miss
+ * packetcache-hit
+ * packetcache-miss
+
+3. **Cache Size**
+ * query-cache-size
+ * packetcache-size
+ * key-cache-size
+ * meta-cache-size
+
+4. **Latency**
+ * latency
+
+### configuration
+
+```yaml
+local:
+  name     : 'local'
+  url     : 'http://127.0.0.1:8081/api/v1/servers/localhost/statistics'
+  header   :
+    X-API-Key: 'change_me'
+```
+
+---
+
 # rabbitmq
 
 Module monitor rabbitmq performance and health metrics.
@@ -1321,10 +1360,10 @@ Following charts are drawn:
 ```yaml
 socket:
   name     : 'local'
-    host     : '127.0.0.1'
-    port     :  15672
-    user     : 'guest'
-    pass     : 'guest'
+  host     : '127.0.0.1'
+  port     :  15672
+  user     : 'guest'
+  pass     : 'guest'
 
 ```
 

--- a/python.d/powerdns.chart.py
+++ b/python.d/powerdns.chart.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Description: powerdns netdata python.d module
+# Author: l2isbad
+
+from base import UrlService
+from json import loads
+
+priority = 60000
+retries = 60
+# update_every = 3
+
+ORDER = ['questions', 'cache_usage', 'cache_size', 'latency']
+CHARTS = {
+    'questions': {
+        'options': [None, 'PowerDNS Queries and Answers', 'count', 'questions', 'powerdns.questions', 'line'],
+        'lines': [
+            ['udp-queries', None, 'incremental'],
+            ['udp-answers', None, 'incremental'],
+            ['tcp-queries', None, 'incremental'],
+            ['tcp-answers', None, 'incremental']
+        ]},
+    'cache_usage': {
+        'options': [None, 'PowerDNS Cache Usage', 'count', 'cache', 'powerdns.cache_usage', 'line'],
+        'lines': [
+            ['query-cache-hit', None, 'incremental'],
+            ['query-cache-miss', None, 'incremental'],
+            ['packetcache-hit', 'packet-cache-hit', 'incremental'],
+            ['packetcache-miss', 'packet-cache-miss', 'incremental']
+        ]},
+    'cache_size': {
+        'options': [None, 'PowerDNS Cache Size', 'count', 'cache', 'powerdns.cache_size', 'line'],
+        'lines': [
+            ['query-cache-size', None, 'absolute'],
+            ['packetcache-size', 'packet-cache-size', 'absolute'],
+            ['key-cache-size', None, 'absolute'],
+            ['meta-cache-size', None, 'absolute']
+        ]},
+    'latency': {
+        'options': [None, 'PowerDNS Latency', 'microseconds', 'latency', 'powerdns.latency', 'line'],
+        'lines': [
+            ['latency', None, 'absolute']
+        ]}
+
+}
+
+
+class Service(UrlService):
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+
+    def _get_data(self):
+        data = self._get_raw_data()
+        if not data:
+            return None
+        return dict([(d['name'], d['value']) for d in loads(data)])
+


### PR DESCRIPTION
Works only for powerdns version 4.x . Version 3.x is [unsupported according official documentation](https://doc.powerdns.com).
closes https://github.com/firehol/netdata/issues/2666

@pschiffe
I did https://github.com/firehol/netdata/issues/2666#issuecomment-326816450

Please check it.

Not sure about:
1. cache_size units (count)
2. chart types (all of them - `line`)