### PR TITLE
added CPU core and package thermal throttling support

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -35,9 +35,11 @@ make clean || exit 1
 
 "${covbuild}" --dir cov-int make -j${cpus} || exit 1
 
+echo >&2 "Compressing data..."
 tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 
-curl --form token="${token}" \
+echo >&2 "Sending analysis..."
+curl --progress-bar --form token="${token}" \
   --form email=costa@tsaousis.gr \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \

--- a/src/proc_softirqs.c
+++ b/src/proc_softirqs.c
@@ -140,7 +140,8 @@ int do_proc_softirqs(int update_every, usec_t dt) {
                 , update_every
                 , RRDSET_TYPE_STACKED
         );
-    else rrdset_next(st_system_softirqs);
+    else
+        rrdset_next(st_system_softirqs);
 
     for(l = 0; l < lines ;l++) {
         struct interrupt *irr = irrindex(irrs, l, cpus);
@@ -167,6 +168,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
 
         rrddim_set_by_pointer(st_system_softirqs, irr->rd, irr->total);
     }
+
     rrdset_done(st_system_softirqs);
 
     // --------------------------------------------------------------------
@@ -215,7 +217,8 @@ int do_proc_softirqs(int update_every, usec_t dt) {
                         , RRDSET_TYPE_STACKED
                 );
             }
-            else rrdset_next(core_st[c]);
+            else
+                rrdset_next(core_st[c]);
 
             for(l = 0; l < lines ;l++) {
                 struct interrupt *irr = irrindex(irrs, l, cpus);

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -117,8 +117,8 @@ int do_proc_stat(int update_every, usec_t dt) {
         do_forks                  = config_get_boolean("plugin:proc:/proc/stat", "processes started", 1);
         do_processes              = config_get_boolean("plugin:proc:/proc/stat", "processes running", 1);
         do_core_throttle_count    = config_get_boolean_ondemand("plugin:proc:/proc/stat", "core_throttle_count", CONFIG_BOOLEAN_AUTO);
-        do_package_throttle_count = config_get_boolean_ondemand("plugin:proc:/proc/stat", "package_throttle_count", CONFIG_BOOLEAN_AUTO);
-        do_scaling_cur_freq       = config_get_boolean_ondemand("plugin:proc:/proc/stat", "scaling_cur_freq", CONFIG_BOOLEAN_AUTO);
+        do_package_throttle_count = config_get_boolean_ondemand("plugin:proc:/proc/stat", "package_throttle_count", CONFIG_BOOLEAN_NO);
+        do_scaling_cur_freq       = config_get_boolean_ondemand("plugin:proc:/proc/stat", "scaling_cur_freq", CONFIG_BOOLEAN_NO);
 
         hash_intr = simple_hash("intr");
         hash_ctxt = simple_hash("ctxt");

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -1,6 +1,21 @@
 #include "common.h"
 
+struct per_core_single_number_file {
+    char found:1;
+    const char *filename;
+    int fd;
+    collected_number value;
+    RRDDIM *rd;
+};
+
+#define CORE_THROTTLE_COUNT_INDEX    0
+#define PACKAGE_THROTTLE_COUNT_INDEX 1
+#define SCALING_CUR_FREQ_INDEX       2
+#define PER_CORE_FILES               3
+
 struct cpu_chart {
+    const char *id;
+
     RRDSET *st;
     RRDDIM *rd_user;
     RRDDIM *rd_nice;
@@ -13,7 +28,76 @@ struct cpu_chart {
     RRDDIM *rd_guest;
     RRDDIM *rd_guest_nice;
 
+    struct per_core_single_number_file files[PER_CORE_FILES];
 };
+
+
+static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, size_t index) {
+    char buf[50 + 1];
+    size_t x, files_read = 0, files_nonzero = 0;
+
+    for(x = 0; x < len ; x++) {
+        struct per_core_single_number_file *f = &all_cpu_charts[x].files[index];
+
+        f->found = 0;
+
+        if(unlikely(!f->filename))
+            continue;
+
+        if(unlikely(f->fd == -1)) {
+            f->fd = open(f->filename, O_RDONLY);
+            if (unlikely(f->fd == -1))
+                error("Cannot open file '%s'", f->filename);
+                continue;
+        }
+
+        ssize_t ret = read(f->fd, buf, 50);
+        if(unlikely(ret == -1)) {
+            error("Cannot read file '%s'", f->filename);
+            close(f->fd);
+            f->fd = -1;
+            continue;
+        }
+        buf[ret] = '\0';
+
+        if(lseek(f->fd, 0, SEEK_SET) == -1) {
+            error("Cannot seek in file '%s'", f->filename);
+            close(f->fd);
+            f->fd = -1;
+        }
+
+        files_read++;
+        f->found = 1;
+
+        f->value = str2ll(buf, NULL);
+        // info("read '%s', parsed as " COLLECTED_NUMBER_FORMAT, buf, f->value);
+        if(likely(f->value != 0))
+            files_nonzero++;
+    }
+
+    if(files_read == 0)
+        return -1;
+
+    if(files_nonzero == 0)
+        return 0;
+
+    return (int)files_nonzero;
+}
+
+static void chart_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, size_t index, RRDSET *st, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm) {
+    size_t x;
+    for(x = 0; x < len ; x++) {
+        struct per_core_single_number_file *f = &all_cpu_charts[x].files[index];
+
+        if(unlikely(!f->found))
+            continue;
+
+        if(unlikely(!f->rd))
+            f->rd = rrddim_add(st, all_cpu_charts[x].id, NULL, multiplier, divisor, algorithm);
+
+        rrddim_set_by_pointer(st, f->rd, f->value);
+    }
+}
 
 int do_proc_stat(int update_every, usec_t dt) {
     (void)dt;
@@ -21,22 +105,36 @@ int do_proc_stat(int update_every, usec_t dt) {
     static struct cpu_chart *all_cpu_charts = NULL;
     static size_t all_cpu_charts_size = 0;
     static procfile *ff = NULL;
-    static int do_cpu = -1, do_cpu_cores = -1, do_interrupts = -1, do_context = -1, do_forks = -1, do_processes = -1;
+    static int do_cpu = -1, do_cpu_cores = -1, do_interrupts = -1, do_context = -1, do_forks = -1, do_processes = -1, do_core_throttle_count = -1, do_package_throttle_count = -1, do_scaling_cur_freq = -1;
     static uint32_t hash_intr, hash_ctxt, hash_processes, hash_procs_running, hash_procs_blocked;
+    static char *core_throttle_count_filename = NULL, *package_throttle_count_filename = NULL, *scaling_cur_freq_filename = NULL;
 
     if(unlikely(do_cpu == -1)) {
-        do_cpu          = config_get_boolean("plugin:proc:/proc/stat", "cpu utilization", 1);
-        do_cpu_cores    = config_get_boolean("plugin:proc:/proc/stat", "per cpu core utilization", 1);
-        do_interrupts   = config_get_boolean("plugin:proc:/proc/stat", "cpu interrupts", 1);
-        do_context      = config_get_boolean("plugin:proc:/proc/stat", "context switches", 1);
-        do_forks        = config_get_boolean("plugin:proc:/proc/stat", "processes started", 1);
-        do_processes    = config_get_boolean("plugin:proc:/proc/stat", "processes running", 1);
+        do_cpu                    = config_get_boolean("plugin:proc:/proc/stat", "cpu utilization", 1);
+        do_cpu_cores              = config_get_boolean("plugin:proc:/proc/stat", "per cpu core utilization", 1);
+        do_interrupts             = config_get_boolean("plugin:proc:/proc/stat", "cpu interrupts", 1);
+        do_context                = config_get_boolean("plugin:proc:/proc/stat", "context switches", 1);
+        do_forks                  = config_get_boolean("plugin:proc:/proc/stat", "processes started", 1);
+        do_processes              = config_get_boolean("plugin:proc:/proc/stat", "processes running", 1);
+        do_core_throttle_count    = config_get_boolean_ondemand("plugin:proc:/proc/stat", "core_throttle_count", CONFIG_BOOLEAN_AUTO);
+        do_package_throttle_count = config_get_boolean_ondemand("plugin:proc:/proc/stat", "package_throttle_count", CONFIG_BOOLEAN_AUTO);
+        do_scaling_cur_freq       = config_get_boolean_ondemand("plugin:proc:/proc/stat", "scaling_cur_freq", CONFIG_BOOLEAN_AUTO);
 
         hash_intr = simple_hash("intr");
         hash_ctxt = simple_hash("ctxt");
         hash_processes = simple_hash("processes");
         hash_procs_running = simple_hash("procs_running");
         hash_procs_blocked = simple_hash("procs_blocked");
+
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/system/cpu/%s/thermal_throttle/core_throttle_count");
+        core_throttle_count_filename = config_get("plugin:proc:/proc/stat", "core_throttle_count filename to monitor", filename);
+
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/system/cpu/%s/thermal_throttle/package_throttle_count");
+        package_throttle_count_filename = config_get("plugin:proc:/proc/stat", "package_throttle_count filename to monitor", filename);
+
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/system/cpu/%s/cpufreq/scaling_cur_freq");
+        scaling_cur_freq_filename = config_get("plugin:proc:/proc/stat", "scaling_cur_freq filename to monitor", filename);
     }
 
     if(unlikely(!ff)) {
@@ -100,6 +198,8 @@ int do_proc_stat(int update_every, usec_t dt) {
                 struct cpu_chart *cpu_chart = &all_cpu_charts[core];
 
                 if(unlikely(!cpu_chart->st)) {
+                    cpu_chart->id = strdupz(id);
+
                     if(core == 0) {
                         title = "Total CPU utilization";
                         type = "system";
@@ -116,8 +216,36 @@ int do_proc_stat(int update_every, usec_t dt) {
 
                         // FIXME: check for /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
                         // FIXME: check for /sys/devices/system/cpu/cpu*/cpufreq/stats/time_in_state
-                        // FIXME: check for /sys/devices/system/cpu/cpu*/thermal_throttle/core_throttle_count
-                        // FIXME: check for /sys/devices/system/cpu/cpu*/thermal_throttle/package_throttle_count
+
+                        char filename[FILENAME_MAX + 1];
+                        struct stat stbuf;
+
+                        if(do_core_throttle_count != CONFIG_BOOLEAN_NO) {
+                            snprintfz(filename, FILENAME_MAX, core_throttle_count_filename, id);
+                            if (stat(filename, &stbuf) == 0) {
+                                cpu_chart->files[CORE_THROTTLE_COUNT_INDEX].filename = strdupz(filename);
+                                cpu_chart->files[CORE_THROTTLE_COUNT_INDEX].fd = -1;
+                                do_core_throttle_count = CONFIG_BOOLEAN_YES;
+                            }
+                        }
+
+                        if(do_package_throttle_count != CONFIG_BOOLEAN_NO) {
+                            snprintfz(filename, FILENAME_MAX, package_throttle_count_filename, id);
+                            if (stat(filename, &stbuf) == 0) {
+                                cpu_chart->files[PACKAGE_THROTTLE_COUNT_INDEX].filename = strdupz(filename);
+                                cpu_chart->files[PACKAGE_THROTTLE_COUNT_INDEX].fd = -1;
+                                do_package_throttle_count = CONFIG_BOOLEAN_YES;
+                            }
+                        }
+
+                        if(do_scaling_cur_freq != CONFIG_BOOLEAN_NO) {
+                            snprintfz(filename, FILENAME_MAX, scaling_cur_freq_filename, id);
+                            if (stat(filename, &stbuf) == 0) {
+                                cpu_chart->files[SCALING_CUR_FREQ_INDEX].filename = strdupz(filename);
+                                cpu_chart->files[SCALING_CUR_FREQ_INDEX].fd = -1;
+                                do_scaling_cur_freq = CONFIG_BOOLEAN_YES;
+                            }
+                        }
                     }
 
                     cpu_chart->st = rrdset_create_localhost(type, id, NULL, family, context, title, "percentage", priority, update_every, RRDSET_TYPE_STACKED);
@@ -238,6 +366,92 @@ int do_proc_stat(int update_every, usec_t dt) {
         rrddim_set_by_pointer(st_processes, rd_running, running);
         rrddim_set_by_pointer(st_processes, rd_blocked, blocked);
         rrdset_done(st_processes);
+    }
+
+    if(likely(all_cpu_charts_size > 1)) {
+        if(likely(do_core_throttle_count != CONFIG_BOOLEAN_NO)) {
+            int r = read_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, CORE_THROTTLE_COUNT_INDEX);
+            if(likely(r != -1 && (do_core_throttle_count == CONFIG_BOOLEAN_YES || r > 0))) {
+                do_core_throttle_count = CONFIG_BOOLEAN_YES;
+
+                static RRDSET *st_core_throttle_count = NULL;
+
+                if (unlikely(!st_core_throttle_count))
+                    st_core_throttle_count = rrdset_create_localhost(
+                            "cpu"
+                            , "core_throttling"
+                            , NULL
+                            , "throttling"
+                            , "cpu.core_throttling"
+                            , "Core Thermal Throttling Events"
+                            , "events/s"
+                            , 5001
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+                else
+                    rrdset_next(st_core_throttle_count);
+
+                chart_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, CORE_THROTTLE_COUNT_INDEX, st_core_throttle_count, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+                rrdset_done(st_core_throttle_count);
+            }
+        }
+
+        if(likely(do_package_throttle_count != CONFIG_BOOLEAN_NO)) {
+            int r = read_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, PACKAGE_THROTTLE_COUNT_INDEX);
+            if(likely(r != -1 && (do_package_throttle_count == CONFIG_BOOLEAN_YES || r > 0))) {
+                do_package_throttle_count = CONFIG_BOOLEAN_YES;
+
+                static RRDSET *st_package_throttle_count = NULL;
+
+                if(unlikely(!st_package_throttle_count))
+                    st_package_throttle_count = rrdset_create_localhost(
+                            "cpu"
+                            , "package_throttling"
+                            , NULL
+                            , "throttling"
+                            , "cpu.package_throttling"
+                            , "Package Thermal Throttling Events"
+                            , "events/s"
+                            , 5002
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+                else
+                    rrdset_next(st_package_throttle_count);
+
+                chart_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, PACKAGE_THROTTLE_COUNT_INDEX, st_package_throttle_count, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+                rrdset_done(st_package_throttle_count);
+            }
+        }
+
+        if(likely(do_scaling_cur_freq != CONFIG_BOOLEAN_NO)) {
+            int r = read_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, SCALING_CUR_FREQ_INDEX);
+            if(likely(r != -1 && (do_scaling_cur_freq == CONFIG_BOOLEAN_YES || r > 0))) {
+                do_scaling_cur_freq = CONFIG_BOOLEAN_YES;
+
+                static RRDSET *st_scaling_cur_freq = NULL;
+
+                if(unlikely(!st_scaling_cur_freq))
+                    st_scaling_cur_freq = rrdset_create_localhost(
+                            "cpu"
+                            , "scaling_cur_freq"
+                            , NULL
+                            , "cpufreq"
+                            , "cpu.scaling_cur_freq"
+                            , "Per CPU Core, Current CPU Scaling Frequency"
+                            , "MHz"
+                            , 5003
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+                else
+                    rrdset_next(st_scaling_cur_freq);
+
+                chart_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, SCALING_CUR_FREQ_INDEX, st_scaling_cur_freq, 1, 1000, RRD_ALGORITHM_ABSOLUTE);
+                rrdset_done(st_scaling_cur_freq);
+            }
+        }
     }
 
     return 0;

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -278,7 +278,18 @@ int do_proc_stat(int update_every, usec_t dt) {
                         }
                     }
 
-                    cpu_chart->st = rrdset_create_localhost(type, id, NULL, family, context, title, "percentage", priority, update_every, RRDSET_TYPE_STACKED);
+                    cpu_chart->st = rrdset_create_localhost(
+                            type
+                            , id
+                            , NULL
+                            , family
+                            , context
+                            , title
+                            , "percentage"
+                            , priority
+                            , update_every
+                            , RRDSET_TYPE_STACKED
+                    );
 
                     long multiplier = 1;
                     long divisor = 1; // sysconf(_SC_CLK_TCK);
@@ -317,8 +328,19 @@ int do_proc_stat(int update_every, usec_t dt) {
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1));
 
                 if(unlikely(!st_intr)) {
-                    st_intr = rrdset_create_localhost("system", "intr", NULL, "interrupts", NULL, "CPU Interrupts"
-                                                 , "interrupts/s", 900, update_every, RRDSET_TYPE_LINE);
+                    st_intr = rrdset_create_localhost(
+                            "system"
+                            , "intr"
+                            , NULL
+                            , "interrupts"
+                            , NULL
+                            , "CPU Interrupts"
+                            , "interrupts/s"
+                            , 900
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+
                     rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
                     rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -336,8 +358,18 @@ int do_proc_stat(int update_every, usec_t dt) {
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1));
 
                 if(unlikely(!st_ctxt)) {
-                    st_ctxt = rrdset_create_localhost("system", "ctxt", NULL, "processes", NULL, "CPU Context Switches"
-                                                 , "context switches/s", 800, update_every, RRDSET_TYPE_LINE);
+                    st_ctxt = rrdset_create_localhost(
+                            "system"
+                            , "ctxt"
+                            , NULL
+                            , "processes"
+                            , NULL
+                            , "CPU Context Switches"
+                            , "context switches/s"
+                            , 800
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
 
                     rd_switches = rrddim_add(st_ctxt, "switches", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
                 }
@@ -365,8 +397,18 @@ int do_proc_stat(int update_every, usec_t dt) {
         static RRDDIM *rd_started = NULL;
 
         if(unlikely(!st_forks)) {
-            st_forks = rrdset_create_localhost("system", "forks", NULL, "processes", NULL, "Started Processes", "processes/s"
-                                         , 700, update_every, RRDSET_TYPE_LINE);
+            st_forks = rrdset_create_localhost(
+                    "system"
+                    , "forks"
+                    , NULL
+                    , "processes"
+                    , NULL
+                    , "Started Processes"
+                    , "processes/s"
+                    , 700
+                    , update_every
+                    , RRDSET_TYPE_LINE
+            );
             rrdset_flag_set(st_forks, RRDSET_FLAG_DETAIL);
 
             rd_started = rrddim_add(st_forks, "started", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -385,8 +427,18 @@ int do_proc_stat(int update_every, usec_t dt) {
         static RRDDIM *rd_blocked = NULL;
 
         if(unlikely(!st_processes)) {
-            st_processes = rrdset_create_localhost("system", "processes", NULL, "processes", NULL, "System Processes", "processes"
-                                         , 600, update_every, RRDSET_TYPE_LINE);
+            st_processes = rrdset_create_localhost(
+                    "system"
+                    , "processes"
+                    , NULL
+                    , "processes"
+                    , NULL
+                    , "System Processes"
+                    , "processes"
+                    , 600
+                    , update_every
+                    , RRDSET_TYPE_LINE
+            );
 
             rd_running = rrddim_add(st_processes, "running", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_blocked = rrddim_add(st_processes, "blocked", NULL, -1, 1, RRD_ALGORITHM_ABSOLUTE);

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -47,9 +47,10 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
 
         if(unlikely(f->fd == -1)) {
             f->fd = open(f->filename, O_RDONLY);
-            if (unlikely(f->fd == -1))
+            if (unlikely(f->fd == -1)) {
                 error("Cannot open file '%s'", f->filename);
                 continue;
+            }
         }
 
         ssize_t ret = read(f->fd, buf, 50);

--- a/src/proc_sys_kernel_random_entropy_avail.c
+++ b/src/proc_sys_kernel_random_entropy_avail.c
@@ -17,15 +17,28 @@ int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt) {
 
     unsigned long long entropy = str2ull(procfile_lineword(ff, 0, 0));
 
-    RRDSET *st = rrdset_find_bytype_localhost("system", "entropy");
+    static RRDSET *st = NULL;
+    static RRDDIM *rd = NULL;
+
     if(unlikely(!st)) {
-        st = rrdset_create_localhost("system", "entropy", NULL, "entropy", NULL, "Available Entropy", "entropy", 1000
-                                     , update_every, RRDSET_TYPE_LINE);
-        rrddim_add(st, "entropy", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        st = rrdset_create_localhost(
+                "system"
+                , "entropy"
+                , NULL
+                , "entropy"
+                , NULL
+                , "Available Entropy"
+                , "entropy"
+                , 1000
+                , update_every
+                , RRDSET_TYPE_LINE
+        );
+
+        rd = rrddim_add(st, "entropy", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
     else rrdset_next(st);
 
-    rrddim_set(st, "entropy", entropy);
+    rrddim_set_by_pointer(st, rd, entropy);
     rrdset_done(st);
 
     return 0;

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -213,14 +213,14 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
                         buffer_sprintf(wb, "NETDATA_%s_%s=\"\"      # %s\n", chart, dimension, st->units);
                     else {
                         if(rd->multiplier < 0 || rd->divisor < 0) n = -n;
-                        n = roundl(n);
+                        n = calculated_number_round(n);
                         if(!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)) total += n;
                         buffer_sprintf(wb, "NETDATA_%s_%s=\"%0.0Lf\"      # %s\n", chart, dimension, n, st->units);
                     }
                 }
             }
 
-            total = roundl(total);
+            total = calculated_number_round(total);
             buffer_sprintf(wb, "NETDATA_%s_VISIBLETOTAL=\"%0.0Lf\"      # %s\n", chart, total, st->units);
             rrdset_unlock(st);
         }
@@ -243,7 +243,7 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
         if(isnan(n) || isinf(n))
             buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"\"      # %s\n", chart, alarm, rc->units);
         else {
-            n = roundl(n);
+            n = calculated_number_round(n);
             buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"%0.0Lf\"      # %s\n", chart, alarm, n, rc->units);
         }
 
@@ -1573,13 +1573,13 @@ RRDR *rrd2rrdr(RRDSET *st, long points, long long after, long long before, int g
             switch(group_method) {
                 case GROUP_MIN:
                     if(unlikely(isnan(group_values[c])) ||
-                            fabsl(value) < fabsl(group_values[c]))
+                            calculated_number_fabs(value) < calculated_number_fabs(group_values[c]))
                         group_values[c] = value;
                     break;
 
                 case GROUP_MAX:
                     if(unlikely(isnan(group_values[c])) ||
-                            fabsl(value) > fabsl(group_values[c]))
+                            calculated_number_fabs(value) > calculated_number_fabs(group_values[c]))
                         group_values[c] = value;
                     break;
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -445,7 +445,7 @@ static inline void statsd_process_counter(STATSD_METRIC *m, const char *value, c
 
     if(unlikely(m->reset)) statsd_reset_metric(m);
 
-    m->counter.value += roundl((long double)statsd_parse_int(value, 1) / statsd_parse_float(sampling, 1.0));
+    m->counter.value += llrintl((long double)statsd_parse_int(value, 1) / statsd_parse_float(sampling, 1.0));
 
     m->events++;
     m->count++;

--- a/src/storage_number.c
+++ b/src/storage_number.c
@@ -199,7 +199,7 @@ int print_calculated_number(char *str, calculated_number value) {
         *wstr++ = '.';
 
         // convert the fractional part to string (reversed)
-        char *fstre = print_number_llu_r_smart(fractional_str, (unsigned long long)llrintl(fractional));
+        char *fstre = print_number_llu_r_smart(fractional_str, (unsigned long long)calculated_number_llrint(fractional));
 
         // prepend zeros to reach 7 digits length
         int decimal = 7;

--- a/src/storage_number.h
+++ b/src/storage_number.h
@@ -14,6 +14,10 @@ typedef long double collected_number;
 #define COLLECTED_NUMBER_FORMAT "%0.7Lf"
 */
 
+#define calculated_number_llrint(x) llrintl(x)
+#define calculated_number_round(x) roundl(x)
+#define calculated_number_fabs(x) fabsl(x)
+
 typedef uint32_t storage_number;
 #define STORAGE_NUMBER_FORMAT "%u"
 

--- a/src/storage_number.h
+++ b/src/storage_number.h
@@ -32,7 +32,7 @@ typedef uint32_t storage_number;
 #define SN_FLAGS_MASK       (~(0x6 << 24))
 
 // extract the flags
-#define get_storage_number_flags(value) ((((storage_number)value) & (1 << 24)) | (((storage_number)value) & (2 << 24)) | (((storage_number)value) & (4 << 24)))
+#define get_storage_number_flags(value) ((((storage_number)(value)) & (1 << 24)) | (((storage_number)(value)) & (2 << 24)) | (((storage_number)(value)) & (4 << 24)))
 #define SN_EMPTY_SLOT 0x00000000
 
 // checks
@@ -44,13 +44,13 @@ calculated_number unpack_storage_number(storage_number value);
 
 int print_calculated_number(char *str, calculated_number value);
 
-#define STORAGE_NUMBER_POSITIVE_MAX 167772150000000.0
-#define STORAGE_NUMBER_POSITIVE_MIN 0.0000001
-#define STORAGE_NUMBER_NEGATIVE_MAX -0.0000001
-#define STORAGE_NUMBER_NEGATIVE_MIN -167772150000000.0
+#define STORAGE_NUMBER_POSITIVE_MAX (167772150000000.0)
+#define STORAGE_NUMBER_POSITIVE_MIN (0.0000001)
+#define STORAGE_NUMBER_NEGATIVE_MAX (-0.0000001)
+#define STORAGE_NUMBER_NEGATIVE_MIN (-167772150000000.0)
 
 // accepted accuracy loss
 #define ACCURACY_LOSS 0.0001
-#define accuracy_loss(t1, t2) ((t1 == t2 || t1 == 0.0 || t2 == 0.0) ? 0.0 : (100.0 - ((t1 > t2) ? (t2 * 100.0 / t1 ) : (t1 * 100.0 / t2))))
+#define accuracy_loss(t1, t2) (((t1) == (t2) || (t1) == 0.0 || (t2) == 0.0) ? 0.0 : (100.0 - (((t1) > (t2)) ? ((t2) * 100.0 / (t1) ) : ((t1) * 100.0 / (t2)))))
 
 #endif /* NETDATA_STORAGE_NUMBER_H */

--- a/src/sys_kernel_mm_ksm.c
+++ b/src/sys_kernel_mm_ksm.c
@@ -5,18 +5,18 @@ typedef struct ksm_name_value {
     unsigned long long value;
 } KSM_NAME_VALUE;
 
-#define PAGES_SHARED 0
-#define PAGES_SHARING 1
+#define PAGES_SHARED   0
+#define PAGES_SHARING  1
 #define PAGES_UNSHARED 2
 #define PAGES_VOLATILE 3
-#define PAGES_TO_SCAN 4
+#define PAGES_TO_SCAN  4
 
 KSM_NAME_VALUE values[] = {
-        [PAGES_SHARED] = { "/sys/kernel/mm/ksm/pages_shared", 0ULL },
-        [PAGES_SHARING] = { "/sys/kernel/mm/ksm/pages_sharing", 0ULL },
+        [PAGES_SHARED]   = { "/sys/kernel/mm/ksm/pages_shared",   0ULL },
+        [PAGES_SHARING]  = { "/sys/kernel/mm/ksm/pages_sharing",  0ULL },
         [PAGES_UNSHARED] = { "/sys/kernel/mm/ksm/pages_unshared", 0ULL },
         [PAGES_VOLATILE] = { "/sys/kernel/mm/ksm/pages_volatile", 0ULL },
-        [PAGES_TO_SCAN] = { "/sys/kernel/mm/ksm/pages_to_scan", 0ULL },
+        [PAGES_TO_SCAN]  = { "/sys/kernel/mm/ksm/pages_to_scan",  0ULL },
 };
 
 int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
@@ -24,61 +24,62 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
     static procfile *ff_pages_shared = NULL, *ff_pages_sharing = NULL, *ff_pages_unshared = NULL, *ff_pages_volatile = NULL, *ff_pages_to_scan = NULL;
     static long page_size = -1;
 
-    if(page_size == -1)
+    if(unlikely(page_size == -1))
         page_size = sysconf(_SC_PAGESIZE);
 
-    if(!ff_pages_shared) {
+    if(unlikely(!ff_pages_shared)) {
         snprintfz(values[PAGES_SHARED].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_shared");
         snprintfz(values[PAGES_SHARED].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_shared", values[PAGES_SHARED].filename));
         ff_pages_shared = procfile_open(values[PAGES_SHARED].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(!ff_pages_sharing) {
+    if(unlikely(!ff_pages_sharing)) {
         snprintfz(values[PAGES_SHARING].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_sharing");
         snprintfz(values[PAGES_SHARING].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_sharing", values[PAGES_SHARING].filename));
         ff_pages_sharing = procfile_open(values[PAGES_SHARING].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(!ff_pages_unshared) {
+    if(unlikely(!ff_pages_unshared)) {
         snprintfz(values[PAGES_UNSHARED].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_unshared");
         snprintfz(values[PAGES_UNSHARED].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_unshared", values[PAGES_UNSHARED].filename));
         ff_pages_unshared = procfile_open(values[PAGES_UNSHARED].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(!ff_pages_volatile) {
+    if(unlikely(!ff_pages_volatile)) {
         snprintfz(values[PAGES_VOLATILE].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_volatile");
         snprintfz(values[PAGES_VOLATILE].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_volatile", values[PAGES_VOLATILE].filename));
         ff_pages_volatile = procfile_open(values[PAGES_VOLATILE].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(!ff_pages_to_scan) {
+    if(unlikely(!ff_pages_to_scan)) {
         snprintfz(values[PAGES_TO_SCAN].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_to_scan");
         snprintfz(values[PAGES_TO_SCAN].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_to_scan", values[PAGES_TO_SCAN].filename));
         ff_pages_to_scan = procfile_open(values[PAGES_TO_SCAN].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(!ff_pages_shared || !ff_pages_sharing || !ff_pages_unshared || !ff_pages_volatile || !ff_pages_to_scan) return 1;
+    if(unlikely(!ff_pages_shared || !ff_pages_sharing || !ff_pages_unshared || !ff_pages_volatile || !ff_pages_to_scan))
+        return 1;
 
     unsigned long long pages_shared = 0, pages_sharing = 0, pages_unshared = 0, pages_volatile = 0, pages_to_scan = 0, offered = 0, saved = 0;
 
     ff_pages_shared = procfile_readall(ff_pages_shared);
-    if(!ff_pages_shared) return 0; // we return 0, so that we will retry to open it next time
+    if(unlikely(!ff_pages_shared)) return 0; // we return 0, so that we will retry to open it next time
     pages_shared = str2ull(procfile_lineword(ff_pages_shared, 0, 0));
 
     ff_pages_sharing = procfile_readall(ff_pages_sharing);
-    if(!ff_pages_sharing) return 0; // we return 0, so that we will retry to open it next time
+    if(unlikely(!ff_pages_sharing)) return 0; // we return 0, so that we will retry to open it next time
     pages_sharing = str2ull(procfile_lineword(ff_pages_sharing, 0, 0));
 
     ff_pages_unshared = procfile_readall(ff_pages_unshared);
-    if(!ff_pages_unshared) return 0; // we return 0, so that we will retry to open it next time
+    if(unlikely(!ff_pages_unshared)) return 0; // we return 0, so that we will retry to open it next time
     pages_unshared = str2ull(procfile_lineword(ff_pages_unshared, 0, 0));
 
     ff_pages_volatile = procfile_readall(ff_pages_volatile);
-    if(!ff_pages_volatile) return 0; // we return 0, so that we will retry to open it next time
+    if(unlikely(!ff_pages_volatile)) return 0; // we return 0, so that we will retry to open it next time
     pages_volatile = str2ull(procfile_lineword(ff_pages_volatile, 0, 0));
 
     ff_pages_to_scan = procfile_readall(ff_pages_to_scan);
-    if(!ff_pages_to_scan) return 0; // we return 0, so that we will retry to open it next time
+    if(unlikely(!ff_pages_to_scan)) return 0; // we return 0, so that we will retry to open it next time
     pages_to_scan = str2ull(procfile_lineword(ff_pages_to_scan, 0, 0));
 
     offered = pages_sharing + pages_shared + pages_unshared + pages_volatile;
@@ -86,55 +87,105 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
 
     if(!offered || !pages_to_scan) return 0;
 
-    RRDSET *st;
+    // --------------------------------------------------------------------
+
+    {
+        static RRDSET *st_mem_ksm = NULL;
+        static RRDDIM *rd_shared = NULL, *rd_unshared = NULL, *rd_sharing = NULL, *rd_volatile = NULL, *rd_to_scan = NULL;
+
+        if (unlikely(!st_mem_ksm)) {
+            st_mem_ksm = rrdset_create_localhost(
+                    "mem"
+                    , "ksm"
+                    , NULL
+                    , "ksm"
+                    , NULL
+                    , "Kernel Same Page Merging"
+                    , "MB"
+                    , 5000
+                    , update_every
+                    , RRDSET_TYPE_AREA
+            );
+
+            rd_shared   = rrddim_add(st_mem_ksm, "shared",   NULL,      1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            rd_unshared = rrddim_add(st_mem_ksm, "unshared", NULL,     -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            rd_sharing  = rrddim_add(st_mem_ksm, "sharing",  NULL,      1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            rd_volatile = rrddim_add(st_mem_ksm, "volatile", NULL,     -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            rd_to_scan  = rrddim_add(st_mem_ksm, "to_scan", "to scan", -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+        }
+        else
+            rrdset_next(st_mem_ksm);
+
+        rrddim_set_by_pointer(st_mem_ksm, rd_shared,   pages_shared   * page_size);
+        rrddim_set_by_pointer(st_mem_ksm, rd_unshared, pages_unshared * page_size);
+        rrddim_set_by_pointer(st_mem_ksm, rd_sharing,  pages_sharing  * page_size);
+        rrddim_set_by_pointer(st_mem_ksm, rd_volatile, pages_volatile * page_size);
+        rrddim_set_by_pointer(st_mem_ksm, rd_to_scan,  pages_to_scan  * page_size);
+
+        rrdset_done(st_mem_ksm);
+    }
 
     // --------------------------------------------------------------------
 
-    st = rrdset_find_localhost("mem.ksm");
-    if(!st) {
-        st = rrdset_create_localhost("mem", "ksm", NULL, "ksm", NULL, "Kernel Same Page Merging", "MB", 5000
-                                     , update_every, RRDSET_TYPE_AREA);
+    {
+        static RRDSET *st_mem_ksm_savings = NULL;
+        static RRDDIM *rd_savings = NULL, *rd_offered = NULL;
 
-        rrddim_add(st, "shared", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-        rrddim_add(st, "unshared", NULL, -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-        rrddim_add(st, "sharing", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-        rrddim_add(st, "volatile", NULL, -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-        rrddim_add(st, "to_scan", "to scan", -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+        if (unlikely(!st_mem_ksm_savings)) {
+            st_mem_ksm_savings = rrdset_create_localhost(
+                    "mem"
+                    , "ksm_savings"
+                    , NULL
+                    , "ksm"
+                    , NULL
+                    , "Kernel Same Page Merging Savings"
+                    , "MB"
+                    , 5001
+                    , update_every
+                    , RRDSET_TYPE_AREA
+            );
+
+            rd_savings = rrddim_add(st_mem_ksm_savings, "savings", NULL, -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            rd_offered = rrddim_add(st_mem_ksm_savings, "offered", NULL,  1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+        }
+        else
+            rrdset_next(st_mem_ksm_savings);
+
+        rrddim_set_by_pointer(st_mem_ksm_savings, rd_savings, saved * page_size);
+        rrddim_set_by_pointer(st_mem_ksm_savings, rd_offered, offered * page_size);
+
+        rrdset_done(st_mem_ksm_savings);
     }
-    else rrdset_next(st);
 
-    rrddim_set(st, "shared", pages_shared * page_size);
-    rrddim_set(st, "unshared", pages_unshared * page_size);
-    rrddim_set(st, "sharing", pages_sharing * page_size);
-    rrddim_set(st, "volatile", pages_volatile * page_size);
-    rrddim_set(st, "to_scan", pages_to_scan * page_size);
-    rrdset_done(st);
+    // --------------------------------------------------------------------
 
-    st = rrdset_find_localhost("mem.ksm_savings");
-    if(!st) {
-        st = rrdset_create_localhost("mem", "ksm_savings", NULL, "ksm", NULL, "Kernel Same Page Merging Savings", "MB"
-                                     , 5001, update_every, RRDSET_TYPE_AREA);
+    {
+        static RRDSET *st_mem_ksm_ratios = NULL;
+        static RRDDIM *rd_savings = NULL;
 
-        rrddim_add(st, "savings", NULL, -1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-        rrddim_add(st, "offered", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+        if (unlikely(!st_mem_ksm_ratios)) {
+            st_mem_ksm_ratios = rrdset_create_localhost(
+                    "mem"
+                    , "ksm_ratios"
+                    , NULL
+                    , "ksm"
+                    , NULL
+                    , "Kernel Same Page Merging Effectiveness"
+                    , "percentage"
+                    , 5002
+                    , update_every
+                    , RRDSET_TYPE_LINE
+            );
+
+            rd_savings = rrddim_add(st_mem_ksm_ratios, "savings", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
+        }
+        else
+            rrdset_next(st_mem_ksm_ratios);
+
+        rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, (saved * 1000000) / offered);
+
+        rrdset_done(st_mem_ksm_ratios);
     }
-    else rrdset_next(st);
-
-    rrddim_set(st, "savings", saved * page_size);
-    rrddim_set(st, "offered", offered * page_size);
-    rrdset_done(st);
-
-    st = rrdset_find_localhost("mem.ksm_ratios");
-    if(!st) {
-        st = rrdset_create_localhost("mem", "ksm_ratios", NULL, "ksm", NULL, "Kernel Same Page Merging Effectiveness"
-                                     , "percentage", 5002, update_every, RRDSET_TYPE_LINE);
-
-        rrddim_add(st, "savings", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
-    }
-    else rrdset_next(st);
-
-    rrddim_set(st, "savings", (saved * 1000000) / offered);
-    rrdset_done(st);
 
     return 0;
 }

--- a/src/sys_kernel_mm_ksm.c
+++ b/src/sys_kernel_mm_ksm.c
@@ -85,7 +85,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
     offered = pages_sharing + pages_shared + pages_unshared + pages_volatile;
     saved = pages_sharing - pages_shared;
 
-    if(!offered || !pages_to_scan) return 0;
+    if(unlikely(!offered || !pages_to_scan)) return 0;
 
     // --------------------------------------------------------------------
 

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -1037,7 +1037,7 @@ int run_test(struct test *test)
     for(c = 0 ; c < max ; c++) {
         calculated_number v = unpack_storage_number(rd->values[c]);
         calculated_number n = test->results[c];
-        int same = (roundl(v * 10000000.0) == roundl(n * 10000000.0))?1:0;
+        int same = (calculated_number_round(v * 10000000.0) == calculated_number_round(n * 10000000.0))?1:0;
         fprintf(stderr, "    %s/%s: checking position %lu (at %lu secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
             test->name, rd->name, c+1,
             (rrdset_first_entry_t(st) + c * st->update_every) - time_start,
@@ -1048,7 +1048,7 @@ int run_test(struct test *test)
         if(rd2) {
             v = unpack_storage_number(rd2->values[c]);
             n = test->results2[c];
-            same = (roundl(v * 10000000.0) == roundl(n * 10000000.0))?1:0;
+            same = (calculated_number_round(v * 10000000.0) == calculated_number_round(n * 10000000.0))?1:0;
             fprintf(stderr, "    %s/%s: checking position %lu (at %lu secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
                 test->name, rd2->name, c+1,
                 (rrdset_first_entry_t(st) + c * st->update_every) - time_start,
@@ -1062,8 +1062,7 @@ int run_test(struct test *test)
 
 static int test_variable_renames(void) {
     fprintf(stderr, "Creating chart\n");
-    RRDSET *st = rrdset_create_localhost("chart", "ID", NULL, "family", "context", "Unit Testing", "a value", 1, 1
-                                         , RRDSET_TYPE_LINE);
+    RRDSET *st = rrdset_create_localhost("chart", "ID", NULL, "family", "context", "Unit Testing", "a value", 1, 1, RRDSET_TYPE_LINE);
     fprintf(stderr, "Created chart with id '%s', name '%s'\n", st->id, st->name);
 
     fprintf(stderr, "Creating dimension DIM1\n");


### PR DESCRIPTION
This extends netdata to monitor CPU thermal events, throttling the CPUs.

2 new charts have been added:

1. Per core throttling count (how many times the CPU core has been throttled due to its thermal conditions)
2. Package throttling count (how many times the CPU package has been throttled due to the thermal conditions of any of its cores) - this is disabled be default, since it the information it provides is inferior to per core throttling count.

Also, cpufreq is replicated into netdata (from python), however the python version can use cpufreq statistics and estimate the average cpu frequency over the iteration period, so the internal one is disabled.
