### PR TITLE
cpufreq.chart.py: fix accurate mode

### DIFF
--- a/python.d/cpufreq.chart.py
+++ b/python.d/cpufreq.chart.py
@@ -60,9 +60,6 @@ class Service(SimpleService):
 
             if accurate_ok:
                 return data
-            else:
-                self.alert("accurate method failed, falling back")
-                self.accurate_exists = False
 
 
         for name, paths in self.assignment.items():


### PR DESCRIPTION
It needs to fail one iteration so there's something to calculate deltas
against (the first iteration has no prior data). Once it has the first
pass, all future iterations will use the accurate mode data, if it's
available.

Note that we want to keep trying to use accurate mode even if it's not available, because if the user switches to a governor that does support cpufreq-stats, netdata should take advantage of it.