### PR TITLE
cpuidle.chart.py: re-read schedstat after tickling idle CPUs

### DIFF
--- a/python.d/cpuidle.chart.py
+++ b/python.d/cpuidle.chart.py
@@ -82,12 +82,16 @@ class Service(SimpleService):
                 delta = schedstat[cpu] - active_time
                 if delta < 1:
                     needs_tickle.append(cpu)
-        self.last_schedstat = schedstat
 
         if needs_tickle:
             # This line is critical for the stats to update. If we don't "tickle"
             # idle CPUs, then the counters for those CPUs stop counting.
             self.__wake_cpus([int(cpu[3:]) for cpu in needs_tickle])
+
+            # Re-read schedstat now that we've tickled any idlers.
+            schedstat = self.__read_schedstat()
+
+        self.last_schedstat = schedstat
 
         for cpu, metrics in self.assignment.items():
             update_time = schedstat[cpu]


### PR DESCRIPTION
Oops, minor mistake. We also need to re-read `/proc/schedstat` once we've awoken the idlers, otherwise we'll have gaps in the data:

![2017-09-10 14_56_15-tobii highlighter](https://user-images.githubusercontent.com/29616/30253370-3c1d0198-9638-11e7-8d21-ef259ceaf5d4.png)
