### PR TITLE
add web API port access list

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -83,6 +83,8 @@ void web_server_config_options(void) {
     web_x_frame_options = config_get(CONFIG_SECTION_WEB, "x-frame-options response header", "");
     if(!*web_x_frame_options) web_x_frame_options = NULL;
 
+    web_client_access_list = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "global allow from", "127.* ::1 *"), SIMPLE_PATTERN_EXACT);
+
 #ifdef NETDATA_WITH_ZLIB
     web_enable_gzip = config_get_boolean(CONFIG_SECTION_WEB, "enable gzip compression", web_enable_gzip);
 

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,7 @@ void web_server_config_options(void) {
     web_x_frame_options = config_get(CONFIG_SECTION_WEB, "x-frame-options response header", "");
     if(!*web_x_frame_options) web_x_frame_options = NULL;
 
-    web_client_access_list = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "global allow from", "127.* ::1 *"), SIMPLE_PATTERN_EXACT);
+    web_client_access_list = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "global API allow from", "127.* ::1 *"), SIMPLE_PATTERN_EXACT);
 
 #ifdef NETDATA_WITH_ZLIB
     web_enable_gzip = config_get_boolean(CONFIG_SECTION_WEB, "enable gzip compression", web_enable_gzip);

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -699,7 +699,7 @@ static int rrdpush_receive(int fd, const char *key, const char *hostname, const 
 
     // call the plugins.d processor to receive the metrics
     info("STREAM %s [receive from [%s]:%s]: receiving metrics...", host->hostname, client_ip, client_port);
-    log_stream_connection(client_ip, client_port, key, host->hostname, "ACCESS GRANDED");
+    log_stream_connection(client_ip, client_port, key, host->hostname, "CONNECTED");
 
     size_t count = pluginsd_process(host, &cd, fp, 1);
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -35,7 +35,7 @@ extern int sock_setreuse_port(int fd, int reuse);
 extern int sock_enlarge_in(int fd);
 extern int sock_enlarge_out(int fd);
 
-extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize);
+extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, SIMPLE_PATTERN *access_list);
 
 #ifndef HAVE_ACCEPT4
 extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
@@ -56,6 +56,7 @@ extern void poll_events(LISTEN_SOCKETS *sockets
         , void  (*del_callback)(int fd, void *data)
         , int   (*rcv_callback)(int fd, int socktype, void *data, short int *events)
         , int   (*snd_callback)(int fd, int socktype, void *data, short int *events)
+        , SIMPLE_PATTERN *access_list
         , void *data
 );
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -912,6 +912,7 @@ void *statsd_collector_thread(void *ptr) {
             , statsd_del_callback
             , statsd_rcv_callback
             , statsd_snd_callback
+            , NULL
             , (void *)d
     );
 

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -138,13 +138,37 @@ void web_client_reset(struct web_client *w) {
 
 
         // --------------------------------------------------------------------
+
+        const char *mode;
+        switch(w->mode) {
+            case WEB_CLIENT_MODE_FILECOPY:
+                mode = "FILECOPY";
+                break;
+
+            case WEB_CLIENT_MODE_OPTIONS:
+                mode = "OPTIONS";
+                break;
+
+            case WEB_CLIENT_MODE_STREAM:
+                mode = "STREAM";
+                break;
+
+            case WEB_CLIENT_MODE_NORMAL:
+                mode = "DATA";
+                break;
+
+            default:
+                mode = "UNKNOWN";
+                break;
+        }
+
         // access log
         log_access("%llu: %d '[%s]:%s' '%s' (sent/all = %zu/%zu bytes %0.0f%%, prep/sent/total = %0.2f/%0.2f/%0.2f ms) %d '%s'",
                    w->id
                    , gettid()
                    , w->client_ip
                    , w->client_port
-                   , (w->mode == WEB_CLIENT_MODE_FILECOPY) ? "FILECOPY" : ((w->mode == WEB_CLIENT_MODE_OPTIONS) ? "OPTIONS" : "DATA")
+                   , mode
                    , sent
                    , size
                    , -((size > 0) ? ((size - sent) / (double) size * 100.0) : 0.0)

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1760,9 +1760,11 @@ void *web_client_main(void *ptr)
         }
     }
 
+    if(w->mode != WEB_CLIENT_MODE_STREAM)
+        log_connection(w, "DISCONNECTED");
+
     web_client_reset(w);
 
-    log_connection(w, "DISCONNECTED");
     debug(D_WEB_CLIENT, "%llu: done...", w->id);
 
     // close the sockets/files now

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -142,6 +142,7 @@ struct web_client {
 };
 
 extern struct web_client *web_clients;
+extern SIMPLE_PATTERN *web_client_access_list;
 
 extern uid_t web_files_uid(void);
 extern uid_t web_files_gid(void);


### PR DESCRIPTION
This PR adds support for applying access control to the web API ports.

This access control is global, meaning that it is applied when a client is attempting to connect. For filtered out clients, will not be able the send even a single byte to netdata.

It is configured in `netdata.conf`, like this:

```
[web]
    global API allow from = 127.* ::1 *
```

The default is shown above. It is redundant, meaning that `*` matches `127.*` and `::1`, but it is a good default for customization, since to allow `10.*` the users should change it to `127.* ::1 10.*`, to allow both localhost and `10.*`.

When the access list is denying access, it logs `DENIED ACCESS to client 'IP'` to `error.log`.

> **IMPORTANT**: This setting is applied to all the functions of all web ports netdata listens. This includes streaming, but it does not include statsd.

#2636

---

also reformatted `access.log`. Now it also logs streaming operations.
