### PR TITLE
add streaming access lists and fix unix domain sockets access lists

### DIFF
--- a/conf.d/stream.conf
+++ b/conf.d/stream.conf
@@ -21,13 +21,13 @@
     #
     # If many are given, the first available will get the metrics.
     #
-    # PROTOCOL  = tcp or udp (only tcp is supported by masters)
-    # HOST      = an IPv4, IPv6 IP, or a hostname.
+    # PROTOCOL  = tcp, udp, or unix (only tcp and unix are supported by masters)
+    # HOST      = an IPv4, IPv6 IP, or a hostname, or a unix domain socket path.
     #             IPv6 IPs should be given with brackets [ip:address]
-    # INTERFACE = the network interface to use
+    # INTERFACE = the network interface to use (only for IPv6)
     # PORT      = the port number or service name (/etc/services)
     #
-    # This communication is not HTTP (cannot be proxied by web proxies).
+    # This communication is not HTTP (it cannot be proxied by web proxies).
     destination =
 
     # The API_KEY to use (as the sender)
@@ -56,25 +56,33 @@
 # -----------------------------------------------------------------------------
 # 2. ON MASTER NETDATA - THE ONE THAT WILL BE RECEIVING METRICS
 
-#    You can have one API key per slave, or the same API key for all slaves.
+#    You can have one API key per slave,
+#         or the same API key for all slaves.
 #
 #    netdata searches for options in this order:
 #
-#    a) [MACHINE_GUID] section  (settings for each machine)
-#    b) [API_KEY] section       (settings for the API key)
-#    c) master netdata settings (netdata.conf)
+#    a) master netdata settings (netdata.conf)
+#    b) [API_KEY] section       (below, settings for the API key)
+#    c) [MACHINE_GUID] section  (below, settings for each machine)
 #
 #    You can combine the above (the more specific setting will be used).
 
 # API key authentication
-# If the key is not listed here, it will not be able to connect.
+# If the key is not listed here, it will not be able to push metrics.
 
+# [API_KEY] is [YOUR-API-KEY], i.e [11111111-2222-3333-4444-555555555555]
 [API_KEY]
-    # Default settings for the API key
+    # Default settings for this API key
 
     # You can disable the API key, by setting this to: no
     # The default (for unknown API keys) is: no
     enabled = no
+
+    # A list of simple patterns matching the IPs of the servers that
+    # will be pushing metrics using this API key.
+    # The metrics are received via the API port, so the same IPs
+    # should also be matched at netdata.conf [web].allow connections from
+    allow from = *
 
     # The default history in entries, for all hosts using this API key.
     # You can also set it per host below.
@@ -131,6 +139,13 @@
     # THIS IS NOT A SECURITY MECHANISM - AN ATTACKER CAN SET ANY OTHER GUID.
     # Use only the API key for security.
     enabled = no
+
+    # A list of simple patterns matching the IPs of the servers that
+    # will be pushing metrics using this MACHINE GUID.
+    # The metrics are received via the API port, so the same IPs
+    # should also be matched at netdata.conf [web].allow connections from
+    # and at stream.conf [API_KEY].allow from
+    allow from = *
 
     # The number of entries in the database
     history = 3600

--- a/configs.signatures
+++ b/configs.signatures
@@ -355,6 +355,7 @@ declare -A configs_signatures=(
   ['b181dcca01a258d9792ad703583baed2']='statsd.d/example.conf'
   ['b185914d4f795e1732273dc4c7a35845']='health.d/memory.conf'
   ['b27f10a38a95edbbec20f44a4728b7c4']='python.d.conf'
+  ['b28c77dceeb398ca4ceec44c646f5431']='stream.conf'
   ['b32164929eda7449a9677044e11151bf']='python.d.conf'
   ['b3d48935ab7f44a57d40ad349df0033d']='python.d/postgres.conf'
   ['b3fc4749b132e55ac0d3a0f92859237e']='health.d/tcp_resets.conf'

--- a/src/main.c
+++ b/src/main.c
@@ -83,11 +83,11 @@ void web_server_config_options(void) {
     web_x_frame_options = config_get(CONFIG_SECTION_WEB, "x-frame-options response header", "");
     if(!*web_x_frame_options) web_x_frame_options = NULL;
 
-    web_allow_connections_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow connections from", "127.* ::1 *"), SIMPLE_PATTERN_EXACT);
+    web_allow_connections_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow connections from", "localhost *"), SIMPLE_PATTERN_EXACT);
     web_allow_badges_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow badges from", "*"), SIMPLE_PATTERN_EXACT);
     web_allow_registry_from = simple_pattern_create(config_get(CONFIG_SECTION_REGISTRY, "allow from", "*"), SIMPLE_PATTERN_EXACT);
     web_allow_streaming_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow streaming from", "*"), SIMPLE_PATTERN_EXACT);
-    web_allow_netdataconf_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow netdata.conf from", "::1 fd* 127.* 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*"), SIMPLE_PATTERN_EXACT);
+    web_allow_netdataconf_from = simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow netdata.conf from", "localhost fd* 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*"), SIMPLE_PATTERN_EXACT);
 
 #ifdef NETDATA_WITH_ZLIB
     web_enable_gzip = config_get_boolean(CONFIG_SECTION_WEB, "enable gzip compression", web_enable_gzip);

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -77,6 +77,7 @@ typedef enum web_client_flags {
 
 #define web_client_set_tcp(w) web_client_flag_set(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 #define web_client_set_unix(w) web_client_flag_set(w, WEB_CLIENT_FLAG_UNIX_CLIENT)
+#define web_client_check_unix(w) web_client_flag_check(w, WEB_CLIENT_FLAG_UNIX_CLIENT)
 
 #define web_client_is_corkable(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -168,6 +168,11 @@ void *socket_listen_main_multi_threaded(void *ptr) {
                     continue;
                 }
 
+                if(api_sockets.fds_families[i] == AF_UNIX)
+                    web_client_set_unix(w);
+                else
+                    web_client_set_tcp(w);
+
                 if(pthread_create(&w->thread, NULL, web_client_main, w) != 0) {
                     error("%llu: failed to create new thread for web client.", w->id);
                     WEB_CLIENT_IS_OBSOLETE(w);


### PR DESCRIPTION
now `127.0.0.1`, `::1` and unix domain sockets are matched with `localhost`

also streaming now always returns http 401 on error, to prevent a possible attacker for gaining info about the specific error.

fixes #2636 (check this issue for full description of the changes)
