### PR TITLE
Install init.d file for SLC 6.9

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -437,7 +437,7 @@ install_non_systemd_init() {
             run update-rc.d netdata defaults && \
             run update-rc.d netdata enable && \
             return 0
-        elif [[ "${key}" =~ ^(amzn-201[567]|ol|CentOS release 6|Red Hat Enterprise Linux Server release 6).* ]]
+        elif [[ "${key}" =~ ^(amzn-201[567]|ol|CentOS release 6|Red Hat Enterprise Linux Server release 6|Scientific Linux CERN SLC release 6.9).* ]]
             then
             echo >&2 "Installing init.d file..."
             run cp system/netdata-init-d /etc/init.d/netdata && \


### PR DESCRIPTION
Double checked, seems everything is ok
```
 --- Install netdata at system init --- 
Installing init.d file...
[/tmp/foo/netdata-1.8.0]# cp system/netdata-init-d /etc/init.d/netdata 
 OK   

[/tmp/foo/netdata-1.8.0]# chmod 755 /etc/init.d/netdata 
 OK   

[/tmp/foo/netdata-1.8.0]# chkconfig netdata on 
 OK   

 --- Start netdata --- 
[/tmp/foo/netdata-1.8.0]# /sbin/service netdata stop 
 OK   

[/tmp/foo/netdata-1.8.0]# /sbin/service netdata restart 
Stopping netdata...                                        [FAILED]
Starting netdata...                                        [  OK  ]
 OK   
[netdata-1.8.0]$ sudo service netdata status
netdata (pid  27743) is running...
[netdata-1.8.0]$ sudo service netdata restart
Stopping netdata...                                        [  OK  ]
Starting netdata...                                        [  OK  ]
[netdata-1.8.0]$ sudo service netdata stop
Stopping netdata...                                        [  OK  ]
[netdata-1.8.0]$ sudo service netdata start
Starting netdata...                                        [  OK  ]
[netdata-1.8.0]$ sudo service netdata stop
Stopping netdata...                                        [  OK  ]
[netdata-1.8.0]$ sudo service netdata restart
Stopping netdata...                                        [FAILED]
Starting netdata...                                        [  OK  ]

```