### PR TITLE
updated to latest makeself

### DIFF
--- a/makeself/makeself-header.sh
+++ b/makeself/makeself-header.sh
@@ -218,10 +218,9 @@ MS_Check()
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1 "$UNTAR_EXTRA" -vf - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1vf - $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." > /dev/tty; kill -15 \$$; }
     else
-
-		tar \$1 "$UNTAR_EXTRA" -f - 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1f - $UNTAR_EXTRA 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
     fi
 }
 

--- a/makeself/makeself.sh
+++ b/makeself/makeself.sh
@@ -470,8 +470,8 @@ gpg-asymmetric)
     GUNZIP_CMD="gpg --yes -d"
     ;;
 openssl)
-    GZIP_CMD="openssl aes-256-cbc -a -salt"
-    GUNZIP_CMD="openssl aes-256-cbc -d -a"
+    GZIP_CMD="openssl aes-256-cbc -a -salt -md sha256"
+    GUNZIP_CMD="openssl aes-256-cbc -d -a -md sha256"
     ;;
 Unix)
     GZIP_CMD="compress -cf"
@@ -529,7 +529,8 @@ if test "$QUIET" = "n";then
    echo Adding files to archive named \"$archname\"...
 fi
 exec 3<> "$tmpfile"
-(cd "$archdir" && ( tar "$TAR_EXTRA" -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || { echo Aborting: Archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
+( cd "$archdir" && ( tar $TAR_EXTRA -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || \
+    { echo Aborting: archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
 exec 3>&- # try to close the archive
 
 fsize=`cat "$tmpfile" | wc -c | tr -d " "`
@@ -617,4 +618,3 @@ else
     fi
 fi
 rm -f "$tmpfile"
-


### PR DESCRIPTION
There was a bug in the version of `makeself` used by netdata, that prevented it from extracting the archive when `tar` is supplied by busybox. 

https://github.com/megastep/makeself/issues/119