### PR TITLE
dashboard show tooltip on charts, with the context and the resolution of the chart

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -368,9 +368,9 @@ typedef struct rrdset RRDSET;
 // and may lead to missing information.
 
 typedef enum rrdhost_flags {
-    RRDHOST_ORPHAN                 = 1 << 0, // this host is orphan (not receiving data)
-    RRDHOST_DELETE_OBSOLETE_CHARTS = 1 << 1, // delete files of obsolete charts
-    RRDHOST_DELETE_ORPHAN_HOST     = 1 << 2  // delete the entire host when orphan
+    RRDHOST_FLAG_ORPHAN                 = 1 << 0, // this host is orphan (not receiving data)
+    RRDHOST_FLAG_DELETE_OBSOLETE_CHARTS = 1 << 1, // delete files of obsolete charts
+    RRDHOST_FLAG_DELETE_ORPHAN_HOST     = 1 << 2  // delete the entire host when orphan
 } RRDHOST_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -608,6 +608,8 @@ extern void rrdhost_cleanup_orphan_hosts_nolock(RRDHOST *protected);
 extern void rrdhost_free(RRDHOST *host);
 extern void rrdhost_save_charts(RRDHOST *host);
 extern void rrdhost_delete_charts(RRDHOST *host);
+
+extern int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected, time_t now);
 
 extern void rrdset_update_heterogeneous_flag(RRDSET *st);
 

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -126,7 +126,8 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb) {
     }
     rrdhost_unlock(host);
 
-    buffer_sprintf(wb, "\n\t}"
+    buffer_sprintf(wb
+                   , "\n\t}"
                     ",\n\t\"charts_count\": %zu"
                     ",\n\t\"dimensions_count\": %zu"
                     ",\n\t\"alarms_count\": %zu"
@@ -142,24 +143,31 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb) {
 
     if(unlikely(rrd_hosts_available > 1)) {
         rrd_rdlock();
+
+        size_t found = 0;
         RRDHOST *h;
         rrdhost_foreach_read(h) {
-            buffer_sprintf(wb,
-                   "%s\n\t\t{"
-                   "\n\t\t\t\"hostname\": \"%s\""
-                   "\n\t\t}"
-                   , (h != localhost) ? "," : ""
-                   , h->hostname
-            );
+            if(!rrdhost_should_be_removed(h, host, now)) {
+                buffer_sprintf(wb
+                               , "%s\n\t\t{"
+                                "\n\t\t\t\"hostname\": \"%s\""
+                                "\n\t\t}"
+                               , (found > 0) ? "," : ""
+                               , h->hostname
+                );
+
+                found++;
+            }
         }
+
         rrd_unlock();
     }
     else {
-        buffer_sprintf(wb,
-                "\n\t\t{"
-                "\n\t\t\t\"hostname\": \"%s\""
-                "\n\t\t}"
-                , host->hostname
+        buffer_sprintf(wb
+                       , "\n\t\t{"
+                        "\n\t\t\t\"hostname\": \"%s\""
+                        "\n\t\t}"
+                       , host->hostname
         );
     }
 

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -754,7 +754,7 @@ static int rrdpush_receive(int fd, const char *key, const char *hostname, const 
     if(host->connected_senders > 0)
         info("STREAM %s [receive from [%s]:%s]: multiple streaming connections for the same host detected. If multiple netdata are pushing metrics for the same charts, at the same time, the result is unexpected.", host->hostname, client_ip, client_port);
 
-    rrdhost_flag_clear(host, RRDHOST_ORPHAN);
+    rrdhost_flag_clear(host, RRDHOST_FLAG_ORPHAN);
     host->connected_senders++;
     host->senders_disconnected_time = 0;
     if(health_enabled != CONFIG_BOOLEAN_NO) {
@@ -781,7 +781,7 @@ static int rrdpush_receive(int fd, const char *key, const char *hostname, const 
     host->senders_disconnected_time = now_realtime_sec();
     host->connected_senders--;
     if(!host->connected_senders) {
-        rrdhost_flag_set(host, RRDHOST_ORPHAN);
+        rrdhost_flag_set(host, RRDHOST_FLAG_ORPHAN);
         if(health_enabled == CONFIG_BOOLEAN_AUTO)
             host->health_enabled = 0;
     }

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -4088,7 +4088,7 @@ var NETDATA = window.NETDATA || {};
         }
 
         if(typeof seconds === 'string')
-            seconds = parseInt(seconds);
+            seconds = parseInt(seconds, 10);
 
         if(seconds === 0)
             return options.now;

--- a/web/index.html
+++ b/web/index.html
@@ -1540,7 +1540,7 @@
 
             sidebar += '<li class="" style="padding-top:15px;"><a href="https://github.com/firehol/netdata/wiki/Add-more-charts-to-netdata" target="_blank"><i class="fa fa-plus" aria-hidden="true"></i> add more charts</a></li>';
             sidebar += '<li class=""><a href="https://github.com/firehol/netdata/wiki/Add-more-alarms-to-netdata" target="_blank"><i class="fa fa-plus" aria-hidden="true"></i> add more alarms</a></li>';
-            sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' + data.hostname.toString() + '</b>, collects every ' + ((data.update_every === 1)?'second':data.update_every.toString() + ' seconds') + ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' + data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' + data.alarms_count.toLocaleString() + '</b> alarms, using ' + Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' + seconds4human(data.update_every * data.history) + ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>v' +  data.version.toString() +'</small></li>';
+            sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' + data.hostname.toString() + '</b>, collects every ' + ((data.update_every === 1)?'second':data.update_every.toString() + ' seconds') + ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' + data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' + data.alarms_count.toLocaleString() + '</b> alarms, using ' + Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' + NETDATA.seconds4human(data.update_every * data.history, { space: '&nbsp;' }) + ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>v' +  data.version.toString() +'</small></li>';
             sidebar += '</ul>';
             div.innerHTML = html;
             document.getElementById('sidebar').innerHTML = sidebar;
@@ -1711,7 +1711,7 @@
 
                     return '<code>' + alarm.lookup_method + '</code> '
                         + dimensions + ', of chart <code>' + alarm.chart + '</code>'
-                        + ', starting <code>' + seconds4human(alarm.lookup_after + alarm.lookup_before) + '</code> and up to <code>' + seconds4human(alarm.lookup_before) + '</code>'
+                        + ', starting <code>' + NETDATA.seconds4human(alarm.lookup_after + alarm.lookup_before, { space: '&nbsp;' }) + '</code> and up to <code>' + NETDATA.seconds4human(alarm.lookup_before, { space: '&nbsp;' }) + '</code>'
                         + ((alarm.lookup_options)?(', with options <code>' + alarm.lookup_options.replace(' ', ',&nbsp;') + '</code>'):'')
                         + '.';
                 }
@@ -1747,25 +1747,25 @@
                     var delay = '';
                     if((alarm.delay_up_duration > 0 || alarm.delay_down_duration > 0) && alarm.delay_multiplier !== 0 && alarm.delay_max_duration > 0) {
                         if(alarm.delay_up_duration === alarm.delay_down_duration) {
-                            delay += '<small><br/>hysteresis ' + seconds4human(alarm.delay_up_duration, { negative_suffix: '' });
+                            delay += '<small><br/>hysteresis ' + NETDATA.seconds4human(alarm.delay_up_duration, { space: '&nbsp;', negative_suffix: '' });
                         }
                         else {
                             delay = '<small><br/>hysteresis ';
                             if(alarm.delay_up_duration > 0) {
-                                delay += 'on&nbsp;escalation&nbsp;<code>' + seconds4human(alarm.delay_up_duration, { negative_suffix: '' }) + '</code>, ';
+                                delay += 'on&nbsp;escalation&nbsp;<code>' + NETDATA.seconds4human(alarm.delay_up_duration, { space: '&nbsp;', negative_suffix: '' }) + '</code>, ';
                             }
                             if(alarm.delay_down_duration > 0) {
-                                delay += 'on&nbsp;recovery&nbsp;<code>' + seconds4human(alarm.delay_down_duration, { negative_suffix: '' }) + '</code>, ';
+                                delay += 'on&nbsp;recovery&nbsp;<code>' + NETDATA.seconds4human(alarm.delay_down_duration, { space: '&nbsp;', negative_suffix: '' }) + '</code>, ';
                             }
                         }
                         if(alarm.delay_multiplier !== 1.0) {
                             delay += 'multiplied&nbsp;by&nbsp;<code>' + alarm.delay_multiplier.toString() + '</code>';
-                            delay += ',&nbsp;up&nbsp;to&nbsp;<code>' + seconds4human(alarm.delay_max_duration, { negative_suffix: '' }) + '</code>';
+                            delay += ',&nbsp;up&nbsp;to&nbsp;<code>' + NETDATA.seconds4human(alarm.delay_max_duration, { space: '&nbsp;', negative_suffix: '' }) + '</code>';
                         }
                         delay += '</small>';
                     }
 
-                    html += '<tr><td width="10%" style="text-align:right">check&nbsp;every</td><td>' + seconds4human(alarm.update_every, { negative_suffix: '' }) + '</td></tr>'
+                    html += '<tr><td width="10%" style="text-align:right">check&nbsp;every</td><td>' + NETDATA.seconds4human(alarm.update_every, { space: '&nbsp;', negative_suffix: '' }) + '</td></tr>'
                         + ((has_alarm === true)?('<tr><td width="10%" style="text-align:right">execute</td><td><span style="font-family: monospace;">' + alarm.exec + '</span>' + delay + '</td></tr>'):'')
                         + '<tr><td width="10%" style="text-align:right">source</td><td><span style="font-family: monospace;">' + alarm.source + '</span></td></tr>'
                         + '</table></td></tr>';
@@ -2103,7 +2103,7 @@
                                 formatter: function(value, row, index) {
                                     void(row);
                                     void(index);
-                                    return seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
+                                    return NETDATA.seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
                                 },
                                 align: 'center',
                                 valign: 'middle',
@@ -2117,7 +2117,7 @@
                                 formatter: function(value, row, index) {
                                     void(row);
                                     void(index);
-                                    return seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
+                                    return NETDATA.seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
                                 },
                                 align: 'center',
                                 valign: 'middle',
@@ -2234,7 +2234,7 @@
                                     void(row);
                                     void(index);
 
-                                    return seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
+                                    return NETDATA.seconds4human(value, { negative_suffix: '', space: ' ', now: 'no time' });
                                 },
                                 align: 'center',
                                 valign: 'middle',
@@ -2274,70 +2274,6 @@
                     // console.log($('#alarms_log_table').bootstrapTable('getOptions'));
                 });
             });
-        }
-
-        function seconds4human(seconds, options) {
-            var default_options = {
-                now: 'now',
-                space: '&nbsp;',
-                negative_suffix: 'ago',
-                hour: 'hour',
-                hours: 'hours',
-                minute: 'minute',
-                minutes: 'minutes',
-                second: 'second',
-                seconds: 'seconds',
-                and: 'and'
-            };
-
-            if(typeof options !== 'object')
-                options = default_options;
-            else {
-                var x;
-                for(x in default_options) {
-                    if(typeof options[x] !== 'string')
-                        options[x] = default_options[x];
-                }
-            }
-
-            if(typeof seconds === 'string')
-                seconds = parseInt(seconds);
-
-            if(seconds === 0)
-                return options.now;
-
-            var suffix = '';
-            if(seconds < 0) {
-                seconds = -seconds;
-                if(options.negative_suffix !== '') suffix = options.space + options.negative_suffix;
-            }
-
-            var hours = Math.floor(seconds / 3600);
-            seconds -= (hours * 3600);
-
-            var minutes = Math.floor(seconds / 60);
-            seconds -= (minutes * 60);
-
-            var txt = '';
-
-            if(hours > 1) txt += hours.toString() + options.space + options.hours;
-            else if(hours === 1) txt += hours.toString() + options.space + options.hour;
-
-            if(hours > 0 && minutes > 0 && seconds === 0)
-                txt += options.space + options.and + options.space;
-            else if(hours > 0 && minutes > 0 && seconds > 0)
-                txt += ',' + options.space;
-
-            if(minutes > 1) txt += minutes.toString() + options.space + options.minutes;
-            else if(minutes === 1) txt += minutes.toString() + options.space + options.minute;
-
-            if((minutes > 0 || minutes > 0) && seconds > 0)
-                txt += options.space + options.and + options.space;
-
-            if(seconds > 1) txt += Math.floor(seconds).toString() + options.space + options.seconds;
-            else if(seconds === 1) txt += Math.floor(seconds).toString() + options.space + options.second;
-
-            return txt + suffix;
         }
 
         function alarmsCallback(data) {
@@ -3597,4 +3533,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20170815-14"></script>
+<script type="text/javascript" src="dashboard.js?v20171003-20"></script>


### PR DESCRIPTION
Added 2 tooltips on the dashboard:

## Show the context of each chart

The `context` is used in alarm templates.

(hover on the date of the chart)

![image](https://user-images.githubusercontent.com/2662304/31103168-529d9a1a-a7de-11e7-8257-5f08d93083ba.png)

fixes #2829;

---

## show the resolution of the chart

(hover on the time of the chart)

![image](https://user-images.githubusercontent.com/2662304/31103223-7deaeaec-a7de-11e7-8470-f62191ec9303.png)

 fixes #2708

---

## do not show orphaned hosts mirrored to my-netdata menu

fixes #2832 