### PR TITLE
support chart custom variables at the API and streaming

### DIFF
--- a/src/health.h
+++ b/src/health.h
@@ -412,7 +412,8 @@ extern void rrdcalc_unlink_and_free(RRDHOST *host, RRDCALC *rc);
 extern void rrdcalctemplate_free(RRDCALCTEMPLATE *rt);
 extern void rrdcalctemplate_unlink_and_free(RRDHOST *host, RRDCALCTEMPLATE *rt);
 
-extern int  rrdvar_callback_for_all_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data);
+extern int  rrdvar_callback_for_all_host_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data);
+extern int rrdvar_callback_for_all_chart_variables(RRDSET *st, int (*callback)(void *rrdvar, void *data), void *data);
 
 #ifdef NETDATA_HEALTH_INTERNALS
 #define RRDVAR_MAX_LENGTH 1024

--- a/src/health.h
+++ b/src/health.h
@@ -11,7 +11,8 @@ typedef enum rrdvar_type {
     RRDVAR_TYPE_COLLECTED               = 3,
     RRDVAR_TYPE_TOTAL                   = 4,
     RRDVAR_TYPE_INT                     = 5,
-    RRDVAR_TYPE_CALCULATED_ALLOCATED    = 6  // a custom variable, allocate on purpose (ie. not inherited from charts)
+    RRDVAR_TYPE_CALCULATED_ALLOCATED    = 6  // a custom variable, allocated on purpose (ie. not inherited from charts)
+                                             // used only for custom host global variables
 } RRDVAR_TYPE;
 
 // the variables as stored in the variables indexes
@@ -38,14 +39,17 @@ typedef struct rrdvar {
 // these variables
 
 typedef enum rrdvar_options {
-    RRDVAR_OPTION_DEFAULT    = (0 << 0)
+    RRDVAR_OPTION_DEFAULT    = (0 << 0),
+    RRDVAR_OPTION_ALLOCATED  = (1 << 0) // the value ptr is allocated (not a reference)
     // future use
 } RRDVAR_OPTIONS;
 
 typedef struct rrdsetvar {
+    char *variable;                 // variable name
+    uint32_t hash;                  // variable name hash
+
     char *key_fullid;               // chart type.chart id.variable
     char *key_fullname;             // chart type.chart name.variable
-    char *variable;                 // variable
 
     RRDVAR_TYPE type;
     void *value;
@@ -365,8 +369,8 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);
 extern RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name);
 extern void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_number value);
 
-extern RRDVAR *rrdvar_custom_chart_variable_create(RRDSET *st, const char *name);
-extern void rrdvar_custom_chart_variable_set(RRDSET *st, RRDVAR *rv, calculated_number value);
+extern RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name);
+extern void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rv, calculated_number value);
 
 extern void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock);
 
@@ -413,7 +417,6 @@ extern void rrdcalctemplate_free(RRDCALCTEMPLATE *rt);
 extern void rrdcalctemplate_unlink_and_free(RRDHOST *host, RRDCALCTEMPLATE *rt);
 
 extern int  rrdvar_callback_for_all_host_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data);
-extern int rrdvar_callback_for_all_chart_variables(RRDSET *st, int (*callback)(void *rrdvar, void *data), void *data);
 
 #ifdef NETDATA_HEALTH_INTERNALS
 #define RRDVAR_MAX_LENGTH 1024

--- a/src/health.h
+++ b/src/health.h
@@ -16,9 +16,9 @@ typedef enum rrdvar_type {
 
 // the variables as stored in the variables indexes
 // there are 3 indexes:
-// 1. at each chart   (RRDSET.variables_root_index)
-// 2. at each context (RRDFAMILY.variables_root_index)
-// 3. at each host    (RRDHOST.variables_root_index)
+// 1. at each chart   (RRDSET.rrdvar_root_index)
+// 2. at each context (RRDFAMILY.rrdvar_root_index)
+// 3. at each host    (RRDHOST.rrdvar_root_index)
 typedef struct rrdvar {
     avl avl;
 
@@ -363,9 +363,12 @@ extern void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after);
 void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);
 
 extern RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name);
-extern void rrdvar_custom_host_variable_destroy(RRDHOST *host, const char *name);
 extern void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_number value);
-extern void rrdvar_free_remaining_variables(RRDHOST *host);
+
+extern RRDVAR *rrdvar_custom_chart_variable_create(RRDSET *st, const char *name);
+extern void rrdvar_custom_chart_variable_set(RRDSET *st, RRDVAR *rv, calculated_number value);
+
+extern void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock);
 
 extern const char *rrdcalc_status2string(RRDCALC_STATUS status);
 

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -377,21 +377,23 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             char *value = words[2];
             int global = (st)?0:1;
 
+            if(name && *name) {
+                if((strcmp(name, "GLOBAL") == 0 || strcmp(name, "HOST") == 0)) {
+                    global = 1;
+                    name = words[2];
+                    value  = words[3];
+                }
+                else if((strcmp(name, "LOCAL") == 0 || strcmp(name, "CHART") == 0)) {
+                    global = 0;
+                    name = words[2];
+                    value  = words[3];
+                }
+            }
+
             if(unlikely(!name || !*name)) {
                 error("PLUGINSD: '%s' is requesting a VARIABLE on host '%s', without a variable name. Disabling it.", cd->fullfilename, host->hostname);
                 enabled = 0;
                 break;
-            }
-
-            if(value && *value) {
-                if((strcmp(value, "GLOBAL") == 0 || strcmp(value, "HOST") == 0)) {
-                    global = 1;
-                    value  = words[3];
-                }
-                else if((strcmp(value, "LOCAL") == 0 || strcmp(value, "CHART") == 0)) {
-                    global = 0;
-                    value  = words[3];
-                }
             }
 
             if(unlikely(!value || !*value))

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -87,7 +87,7 @@ struct rrdfamily {
 
     size_t use_count;
 
-    avl_tree_lock variables_root_index;
+    avl_tree_lock rrdvar_root_index;
 };
 typedef struct rrdfamily RRDFAMILY;
 
@@ -266,9 +266,9 @@ struct rrdset {
     char *units;                                    // units of measurement
 
     char *context;                                  // the template of this data set
-    uint32_t hash_context;
+    uint32_t hash_context;                          // the hash of the chart's context
 
-    RRDSET_TYPE chart_type;
+    RRDSET_TYPE chart_type;                         // line, area, stacked
 
     int update_every;                               // every how many seconds is this updated?
 
@@ -282,7 +282,7 @@ struct rrdset {
     int gap_when_lost_iterations_above;             // after how many lost iterations a gap should be stored
                                                     // netdata will interpolate values for gaps lower than this
 
-    long priority;
+    long priority;                                  // the sorting priority of this chart
 
 
     // ------------------------------------------------------------------------
@@ -319,20 +319,20 @@ struct rrdset {
     total_number collected_total;                   // used internally to calculate percentages
     total_number last_collected_total;              // used internally to calculate percentages
 
-    RRDFAMILY *rrdfamily;
-    struct rrdhost *rrdhost;
+    RRDFAMILY *rrdfamily;                           // pointer to RRDFAMILY this chart belongs to
+    struct rrdhost *rrdhost;                        // pointer to RRDHOST this chart belongs to
 
     struct rrdset *next;                            // linking of rrdsets
 
     // ------------------------------------------------------------------------
     // local variables
 
-    calculated_number green;
-    calculated_number red;
+    calculated_number green;                        // green threshold for this chart
+    calculated_number red;                          // red threshold for this chart
 
-    avl_tree_lock variables_root_index;
-    RRDSETVAR *variables;
-    RRDCALC *alarms;
+    avl_tree_lock rrdvar_root_index;                // RRDVAR index for this chart
+    RRDSETVAR *variables;                           // RRDSETVAR linked list for this chart (one RRDSETVAR, many RRDVARs)
+    RRDCALC *alarms;                                // RRDCALC linked list for this chart
 
     // ------------------------------------------------------------------------
     // members for checking the data when loading from disk
@@ -504,7 +504,7 @@ struct rrdhost {
     avl_tree_lock rrdset_root_index_name;           // the host's charts index (by name)
 
     avl_tree_lock rrdfamily_root_index;             // the host's chart families index
-    avl_tree_lock variables_root_index;             // the host's chart variables index
+    avl_tree_lock rrdvar_root_index;                // the host's chart variables index
 
     struct rrdhost *next;
 };

--- a/src/rrdcalc.c
+++ b/src/rrdcalc.c
@@ -62,15 +62,15 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
         st->red = rc->red;
     }
 
-    rc->local  = rrdvar_create_and_index("local",  &st->variables_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
-    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->local  = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
 
     char fullname[RRDVAR_MAX_LENGTH + 1];
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->id, rc->name);
-    rc->hostid   = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->hostid   = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
 
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->name, rc->name);
-    rc->hostname = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->hostname = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
 
     if(!rc->units) rc->units = strdupz(st->units);
 
@@ -173,16 +173,16 @@ inline void rrdsetcalc_unlink(RRDCALC *rc) {
 
     rc->rrdset_prev = rc->rrdset_next = NULL;
 
-    rrdvar_free(st->rrdhost, &st->variables_root_index, rc->local);
+    rrdvar_free(st->rrdhost, &st->rrdvar_root_index, rc->local);
     rc->local = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rc->family);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rc->family);
     rc->family = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rc->hostid);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rc->hostid);
     rc->hostid = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rc->hostname);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rc->hostname);
     rc->hostname = NULL;
 
     rc->rrdset = NULL;

--- a/src/rrddimvar.c
+++ b/src/rrddimvar.c
@@ -13,38 +13,38 @@ static inline void rrddimvar_free_variables(RRDDIMVAR *rs) {
 
     // CHART VARIABLES FOR THIS DIMENSION
 
-    rrdvar_free(st->rrdhost, &st->variables_root_index, rs->var_local_id);
+    rrdvar_free(st->rrdhost, &st->rrdvar_root_index, rs->var_local_id);
     rs->var_local_id = NULL;
 
-    rrdvar_free(st->rrdhost, &st->variables_root_index, rs->var_local_name);
+    rrdvar_free(st->rrdhost, &st->rrdvar_root_index, rs->var_local_name);
     rs->var_local_name = NULL;
 
     // FAMILY VARIABLES FOR THIS DIMENSION
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family_id);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_id);
     rs->var_family_id = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family_name);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_name);
     rs->var_family_name = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family_contextid);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_contextid);
     rs->var_family_contextid = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family_contextname);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_contextname);
     rs->var_family_contextname = NULL;
 
     // HOST VARIABLES FOR THIS DIMENSION
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host_chartidid);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_chartidid);
     rs->var_host_chartidid = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host_chartidname);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_chartidname);
     rs->var_host_chartidname = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host_chartnameid);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_chartnameid);
     rs->var_host_chartnameid = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host_chartnamename);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_chartnamename);
     rs->var_host_chartnamename = NULL;
 
     // KEYS
@@ -115,8 +115,8 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $id
     // - $name
 
-    rs->var_local_id           = rrdvar_create_and_index("local", &st->variables_root_index, rs->key_id, rs->type, rs->value);
-    rs->var_local_name         = rrdvar_create_and_index("local", &st->variables_root_index, rs->key_name, rs->type, rs->value);
+    rs->var_local_id           = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_id, rs->type, rs->value);
+    rs->var_local_name         = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_name, rs->type, rs->value);
 
     // FAMILY VARIABLES FOR THIS DIMENSION
     // -----------------------------------
@@ -127,10 +127,10 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $chart-context.id
     // - $chart-context.name
 
-    rs->var_family_id          = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index, rs->key_id, rs->type, rs->value);
-    rs->var_family_name        = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index, rs->key_name, rs->type, rs->value);
-    rs->var_family_contextid   = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index, rs->key_contextid, rs->type, rs->value);
-    rs->var_family_contextname = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index, rs->key_contextname, rs->type, rs->value);
+    rs->var_family_id          = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_id, rs->type, rs->value);
+    rs->var_family_name        = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_name, rs->type, rs->value);
+    rs->var_family_contextid   = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextid, rs->type, rs->value);
+    rs->var_family_contextname = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextname, rs->type, rs->value);
 
     // HOST VARIABLES FOR THIS DIMENSION
     // -----------------------------------
@@ -141,10 +141,10 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $chart-name.id
     // - $chart-name.name
 
-    rs->var_host_chartidid      = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, rs->key_fullidid, rs->type, rs->value);
-    rs->var_host_chartidname    = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, rs->key_fullidname, rs->type, rs->value);
-    rs->var_host_chartnameid    = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, rs->key_fullnameid, rs->type, rs->value);
-    rs->var_host_chartnamename  = rrdvar_create_and_index("host", &st->rrdhost->variables_root_index, rs->key_fullnamename, rs->type, rs->value);
+    rs->var_host_chartidid      = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, rs->key_fullidid, rs->type, rs->value);
+    rs->var_host_chartidname    = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, rs->key_fullidname, rs->type, rs->value);
+    rs->var_host_chartnameid    = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, rs->key_fullnameid, rs->type, rs->value);
+    rs->var_host_chartnamename  = rrdvar_create_and_index("host", &st->rrdhost->rrdvar_root_index, rs->key_fullnamename, rs->type, rs->value);
 }
 
 RRDDIMVAR *rrddimvar_create(RRDDIM *rd, RRDVAR_TYPE type, const char *prefix, const char *suffix, void *value, RRDVAR_OPTIONS options) {

--- a/src/rrdfamily.c
+++ b/src/rrdfamily.c
@@ -30,7 +30,7 @@ RRDFAMILY *rrdfamily_create(RRDHOST *host, const char *id) {
         rc->hash_family = simple_hash(rc->family);
 
         // initialize the variables index
-        avl_init_lock(&rc->variables_root_index, rrdvar_compare);
+        avl_init_lock(&rc->rrdvar_root_index, rrdvar_compare);
 
         RRDFAMILY *ret = rrdfamily_index_add(host, rc);
         if(ret != rc)
@@ -48,7 +48,7 @@ void rrdfamily_free(RRDHOST *host, RRDFAMILY *rc) {
         if(ret != rc)
             fatal("RRDFAMILY: INTERNAL ERROR: Expected to DELETE RRDFAMILY '%s' from index, but deleted '%s'.", rc->family, (ret)?ret->family:"NONE");
 
-        if(rc->variables_root_index.avl_tree.root != NULL)
+        if(rc->rrdvar_root_index.avl_tree.root != NULL)
             fatal("RRDFAMILY: INTERNAL ERROR: Variables index of RRDFAMILY '%s' that is freed, is not empty.", rc->family);
 
         freez((void *)rc->family);

--- a/src/rrdfamily.c
+++ b/src/rrdfamily.c
@@ -34,7 +34,7 @@ RRDFAMILY *rrdfamily_create(RRDHOST *host, const char *id) {
 
         RRDFAMILY *ret = rrdfamily_index_add(host, rc);
         if(ret != rc)
-            fatal("RRDFAMILY: INTERNAL ERROR: Expected to INSERT RRDFAMILY '%s' into index, but inserted '%s'.", rc->family, (ret)?ret->family:"NONE");
+            error("RRDFAMILY: INTERNAL ERROR: Expected to INSERT RRDFAMILY '%s' into index, but inserted '%s'.", rc->family, (ret)?ret->family:"NONE");
     }
 
     rc->use_count++;
@@ -46,13 +46,14 @@ void rrdfamily_free(RRDHOST *host, RRDFAMILY *rc) {
     if(!rc->use_count) {
         RRDFAMILY *ret = rrdfamily_index_del(host, rc);
         if(ret != rc)
-            fatal("RRDFAMILY: INTERNAL ERROR: Expected to DELETE RRDFAMILY '%s' from index, but deleted '%s'.", rc->family, (ret)?ret->family:"NONE");
+            error("RRDFAMILY: INTERNAL ERROR: Expected to DELETE RRDFAMILY '%s' from index, but deleted '%s'.", rc->family, (ret)?ret->family:"NONE");
+        else {
+            debug(D_RRD_CALLS, "RRDFAMILY: Cleaning up remaining family variables for host '%s', family '%s'", host->hostname, rc->family);
+            rrdvar_free_remaining_variables(host, &rc->rrdvar_root_index);
 
-        if(rc->rrdvar_root_index.avl_tree.root != NULL)
-            fatal("RRDFAMILY: INTERNAL ERROR: Variables index of RRDFAMILY '%s' that is freed, is not empty.", rc->family);
-
-        freez((void *)rc->family);
-        freez(rc);
+            freez((void *) rc->family);
+            freez(rc);
+        }
     }
 }
 

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -151,7 +151,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     avl_init_lock(&(host->rrdset_root_index),      rrdset_compare);
     avl_init_lock(&(host->rrdset_root_index_name), rrdset_compare_name);
     avl_init_lock(&(host->rrdfamily_root_index),   rrdfamily_compare);
-    avl_init_lock(&(host->variables_root_index),   rrdvar_compare);
+    avl_init_lock(&(host->rrdvar_root_index),   rrdvar_compare);
 
     if(config_get_boolean(CONFIG_SECTION_GLOBAL, "delete obsolete charts files", 1))
         rrdhost_flag_set(host, RRDHOST_FLAG_DELETE_OBSOLETE_CHARTS);
@@ -496,7 +496,7 @@ void rrdhost_free(RRDHOST *host) {
     while(host->templates)
         rrdcalctemplate_unlink_and_free(host, host->templates);
 
-    rrdvar_free_remaining_variables(host);
+    rrdvar_free_remaining_variables(host, &host->rrdvar_root_index);
 
     health_alarm_log_free(host);
 

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -496,6 +496,7 @@ void rrdhost_free(RRDHOST *host) {
     while(host->templates)
         rrdcalctemplate_unlink_and_free(host, host->templates);
 
+    debug(D_RRD_CALLS, "RRDHOST: Cleaning up remaining host variables for host '%s'", host->hostname);
     rrdvar_free_remaining_variables(host, &host->rrdvar_root_index);
 
     health_alarm_log_free(host);

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -77,6 +77,29 @@ static inline int need_to_send_chart_definition(RRDSET *st) {
     return 0;
 }
 
+static int rrdpush_sender_add_chart_variable_to_buffer_nolock(void *rrdvar_ptr, void *rrdset_ptr) {
+    RRDVAR *rv = (RRDVAR *)rrdvar_ptr;
+
+    if(unlikely(rv->type == RRDVAR_TYPE_CALCULATED_ALLOCATED)) {
+        RRDSET *st = (RRDSET *)rrdset_ptr;
+
+        calculated_number *value = (calculated_number *) rv->value;
+
+        buffer_sprintf(
+                st->rrdhost->rrdpush_sender_buffer
+                , "VARIABLE CHART %s = " CALCULATED_NUMBER_FORMAT "\n"
+                , rv->name
+                , *value
+        );
+
+        debug(D_STREAM, "RRDVAR pushed CHART VARIABLE %s = " CALCULATED_NUMBER_FORMAT, rv->name, *value);
+
+        return 1;
+    }
+
+    return 0;
+}
+
 // sends the current chart definition
 static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
     rrdset_flag_set(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
@@ -117,6 +140,10 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
     }
 
     st->upstream_resync_time = st->last_collected_time.tv_sec + (remote_clock_resync_iterations * st->update_every);
+
+    int ret = rrdvar_callback_for_all_chart_variables(st, rrdpush_sender_add_chart_variable_to_buffer_nolock, st);
+    debug(D_STREAM, "RRDVAR sent %d VARIABLES", ret);
+
 }
 
 // sends the current chart dimensions
@@ -188,33 +215,33 @@ void rrdset_done_push(RRDSET *st) {
 // ----------------------------------------------------------------------------
 // rrdpush sender thread
 
-static inline void rrdpush_sender_add_variable_to_buffer_nolock(RRDHOST *host, RRDVAR *rv) {
+static inline void rrdpush_sender_add_host_variable_to_buffer_nolock(RRDHOST *host, RRDVAR *rv) {
     calculated_number *value = (calculated_number *)rv->value;
 
     buffer_sprintf(
             host->rrdpush_sender_buffer
-            , "VARIABLE %s = " CALCULATED_NUMBER_FORMAT "\n"
+            , "VARIABLE HOST %s = " CALCULATED_NUMBER_FORMAT "\n"
             , rv->name
             , *value
     );
 
-    debug(D_STREAM, "RRDVAR pushed VARIABLE %s = " CALCULATED_NUMBER_FORMAT, rv->name, *value);
+    debug(D_STREAM, "RRDVAR pushed HOST VARIABLE %s = " CALCULATED_NUMBER_FORMAT, rv->name, *value);
 }
 
-void rrdpush_sender_send_this_variable_now(RRDHOST *host, RRDVAR *rv) {
+void rrdpush_sender_send_this_host_variable_now(RRDHOST *host, RRDVAR *rv) {
     if(host->rrdpush_send_enabled && host->rrdpush_sender_spawn && host->rrdpush_sender_connected) {
         rrdpush_buffer_lock(host);
-        rrdpush_sender_add_variable_to_buffer_nolock(host, rv);
+        rrdpush_sender_add_host_variable_to_buffer_nolock(host, rv);
         rrdpush_buffer_unlock(host);
     }
 }
 
-static int rrdpush_sender_thread_custom_variables_callback(void *rrdvar_ptr, void *host_ptr) {
+static int rrdpush_sender_thread_custom_host_variables_callback(void *rrdvar_ptr, void *host_ptr) {
     RRDVAR *rv = (RRDVAR *)rrdvar_ptr;
     RRDHOST *host = (RRDHOST *)host_ptr;
 
     if(unlikely(rv->type == RRDVAR_TYPE_CALCULATED_ALLOCATED)) {
-        rrdpush_sender_add_variable_to_buffer_nolock(host, rv);
+        rrdpush_sender_add_host_variable_to_buffer_nolock(host, rv);
 
         // return 1, so that the traversal will return the number of variables sent
         return 1;
@@ -224,8 +251,8 @@ static int rrdpush_sender_thread_custom_variables_callback(void *rrdvar_ptr, voi
     return 0;
 }
 
-static void rrdpush_sender_thread_send_custom_variables(RRDHOST *host) {
-    int ret = rrdvar_callback_for_all_variables(host, rrdpush_sender_thread_custom_variables_callback, host);
+static void rrdpush_sender_thread_send_custom_host_variables(RRDHOST *host) {
+    int ret = rrdvar_callback_for_all_host_variables(host, rrdpush_sender_thread_custom_host_variables_callback, host);
     debug(D_STREAM, "RRDVAR sent %d VARIABLES", ret);
 }
 
@@ -236,6 +263,7 @@ static void rrdpush_sender_thread_reset_all_charts(RRDHOST *host) {
 
     RRDSET *st;
     rrdset_foreach_read(st, host) {
+        rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
 
         st->upstream_resync_time = 0;
 
@@ -260,7 +288,7 @@ static inline void rrdpush_sender_thread_data_flush(RRDHOST *host) {
     buffer_flush(host->rrdpush_sender_buffer);
 
     rrdpush_sender_thread_reset_all_charts(host);
-    rrdpush_sender_thread_send_custom_variables(host);
+    rrdpush_sender_thread_send_custom_host_variables(host);
 
     rrdpush_buffer_unlock(host);
 }

--- a/src/rrdpush.h
+++ b/src/rrdpush.h
@@ -14,6 +14,6 @@ extern void *rrdpush_sender_thread(void *ptr);
 extern int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url);
 extern void rrdpush_sender_thread_stop(RRDHOST *host);
 
-extern void rrdpush_sender_send_this_variable_now(RRDHOST *host, RRDVAR *rv);
+extern void rrdpush_sender_send_this_host_variable_now(RRDHOST *host, RRDVAR *rv);
 
 #endif //NETDATA_RRDPUSH_H

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -316,6 +316,7 @@ void rrdset_free(RRDSET *st) {
 
     rrdfamily_free(st->rrdhost, st->rrdfamily);
 
+    debug(D_RRD_CALLS, "RRDSET: Cleaning up remaining chart variables for host '%s', chart '%s'", st->rrdhost->hostname, st->id);
     rrdvar_free_remaining_variables(st->rrdhost, &st->rrdvar_root_index);
 
     // ------------------------------------------------------------------------
@@ -662,11 +663,11 @@ RRDSET *rrdset_create_custom(
     host->rrdset_root = st;
 
     if(host->health_enabled) {
-        rrdsetvar_create(st, "last_collected_t", RRDVAR_TYPE_TIME_T, &st->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);
-        rrdsetvar_create(st, "collected_total_raw", RRDVAR_TYPE_TOTAL, &st->last_collected_total, RRDVAR_OPTION_DEFAULT);
-        rrdsetvar_create(st, "green", RRDVAR_TYPE_CALCULATED, &st->green, RRDVAR_OPTION_DEFAULT);
-        rrdsetvar_create(st, "red", RRDVAR_TYPE_CALCULATED, &st->red, RRDVAR_OPTION_DEFAULT);
-        rrdsetvar_create(st, "update_every", RRDVAR_TYPE_INT, &st->update_every, RRDVAR_OPTION_DEFAULT);
+        rrdsetvar_create(st, "last_collected_t",    RRDVAR_TYPE_TIME_T,     &st->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);
+        rrdsetvar_create(st, "collected_total_raw", RRDVAR_TYPE_TOTAL,      &st->last_collected_total,       RRDVAR_OPTION_DEFAULT);
+        rrdsetvar_create(st, "green",               RRDVAR_TYPE_CALCULATED, &st->green,                      RRDVAR_OPTION_DEFAULT);
+        rrdsetvar_create(st, "red",                 RRDVAR_TYPE_CALCULATED, &st->red,                        RRDVAR_OPTION_DEFAULT);
+        rrdsetvar_create(st, "update_every",        RRDVAR_TYPE_INT,        &st->update_every,               RRDVAR_OPTION_DEFAULT);
     }
 
     if(unlikely(rrdset_index_add(host, st) != st))

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -316,6 +316,8 @@ void rrdset_free(RRDSET *st) {
 
     rrdfamily_free(st->rrdhost, st->rrdfamily);
 
+    rrdvar_free_remaining_variables(st->rrdhost, &st->rrdvar_root_index);
+
     // ------------------------------------------------------------------------
     // unlink it from the host
 
@@ -506,7 +508,7 @@ RRDSET *rrdset_create_custom(
         if(st) {
             memset(&st->avl, 0, sizeof(avl));
             memset(&st->avlname, 0, sizeof(avl));
-            memset(&st->variables_root_index, 0, sizeof(avl_tree_lock));
+            memset(&st->rrdvar_root_index, 0, sizeof(avl_tree_lock));
             memset(&st->dimensions_index, 0, sizeof(avl_tree_lock));
             memset(&st->rrdset_rwlock, 0, sizeof(netdata_rwlock_t));
 
@@ -640,7 +642,7 @@ RRDSET *rrdset_create_custom(
     st->upstream_resync_time = 0;
 
     avl_init_lock(&st->dimensions_index, rrddim_compare);
-    avl_init_lock(&st->variables_root_index, rrdvar_compare);
+    avl_init_lock(&st->rrdvar_root_index, rrdvar_compare);
 
     netdata_rwlock_init(&st->rrdset_rwlock);
 

--- a/src/rrdsetvar.c
+++ b/src/rrdsetvar.c
@@ -10,23 +10,23 @@ static inline void rrdsetvar_free_variables(RRDSETVAR *rs) {
 
     // CHART
 
-    rrdvar_free(st->rrdhost, &st->variables_root_index, rs->var_local);
+    rrdvar_free(st->rrdhost, &st->rrdvar_root_index, rs->var_local);
     rs->var_local = NULL;
 
     // FAMILY
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family);
     rs->var_family = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host);
     rs->var_host = NULL;
 
     // HOST
 
-    rrdvar_free(st->rrdhost, &st->rrdfamily->variables_root_index, rs->var_family_name);
+    rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_name);
     rs->var_family_name = NULL;
 
-    rrdvar_free(st->rrdhost, &st->rrdhost->variables_root_index, rs->var_host_name);
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_name);
     rs->var_host_name = NULL;
 
     // KEYS
@@ -54,17 +54,17 @@ static inline void rrdsetvar_create_variables(RRDSETVAR *rs) {
 
     // CHART
 
-    rs->var_local       = rrdvar_create_and_index("local",  &st->variables_root_index,               rs->variable, rs->type, rs->value);
+    rs->var_local       = rrdvar_create_and_index("local",  &st->rrdvar_root_index,               rs->variable, rs->type, rs->value);
 
     // FAMILY
 
-    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index,    rs->key_fullid,   rs->type, rs->value);
-    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->variables_root_index,    rs->key_fullname, rs->type, rs->value);
+    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index,    rs->key_fullid,   rs->type, rs->value);
+    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index,    rs->key_fullname, rs->type, rs->value);
 
     // HOST
 
-    rs->var_host        = rrdvar_create_and_index("host",   &st->rrdhost->variables_root_index,      rs->key_fullid,   rs->type, rs->value);
-    rs->var_host_name   = rrdvar_create_and_index("host",   &st->rrdhost->variables_root_index,      rs->key_fullname, rs->type, rs->value);
+    rs->var_host        = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index,      rs->key_fullid,   rs->type, rs->value);
+    rs->var_host_name   = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index,      rs->key_fullname, rs->type, rs->value);
 
 }
 

--- a/src/rrdsetvar.c
+++ b/src/rrdsetvar.c
@@ -8,29 +8,29 @@
 static inline void rrdsetvar_free_variables(RRDSETVAR *rs) {
     RRDSET *st = rs->rrdset;
 
+    // ------------------------------------------------------------------------
     // CHART
-
     rrdvar_free(st->rrdhost, &st->rrdvar_root_index, rs->var_local);
     rs->var_local = NULL;
 
+    // ------------------------------------------------------------------------
     // FAMILY
-
     rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family);
     rs->var_family = NULL;
-
-    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host);
-    rs->var_host = NULL;
-
-    // HOST
 
     rrdvar_free(st->rrdhost, &st->rrdfamily->rrdvar_root_index, rs->var_family_name);
     rs->var_family_name = NULL;
 
+    // ------------------------------------------------------------------------
+    // HOST
+    rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host);
+    rs->var_host = NULL;
+
     rrdvar_free(st->rrdhost, &st->rrdhost->rrdvar_root_index, rs->var_host_name);
     rs->var_host_name = NULL;
 
+    // ------------------------------------------------------------------------
     // KEYS
-
     freez(rs->key_fullid);
     rs->key_fullid = NULL;
 
@@ -39,10 +39,14 @@ static inline void rrdsetvar_free_variables(RRDSETVAR *rs) {
 }
 
 static inline void rrdsetvar_create_variables(RRDSETVAR *rs) {
-    rrdsetvar_free_variables(rs);
-
     RRDSET *st = rs->rrdset;
 
+    // ------------------------------------------------------------------------
+    // free the old ones (if any)
+
+    rrdsetvar_free_variables(rs);
+
+    // ------------------------------------------------------------------------
     // KEYS
 
     char buffer[RRDVAR_MAX_LENGTH + 1];
@@ -52,20 +56,19 @@ static inline void rrdsetvar_create_variables(RRDSETVAR *rs) {
     snprintfz(buffer, RRDVAR_MAX_LENGTH, "%s.%s", st->name, rs->variable);
     rs->key_fullname = strdupz(buffer);
 
+    // ------------------------------------------------------------------------
     // CHART
+    rs->var_local       = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rs->variable, rs->type, rs->value);
 
-    rs->var_local       = rrdvar_create_and_index("local",  &st->rrdvar_root_index,               rs->variable, rs->type, rs->value);
-
+    // ------------------------------------------------------------------------
     // FAMILY
+    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullid,   rs->type, rs->value);
+    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullname, rs->type, rs->value);
 
-    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index,    rs->key_fullid,   rs->type, rs->value);
-    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index,    rs->key_fullname, rs->type, rs->value);
-
+    // ------------------------------------------------------------------------
     // HOST
-
-    rs->var_host        = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index,      rs->key_fullid,   rs->type, rs->value);
-    rs->var_host_name   = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index,      rs->key_fullname, rs->type, rs->value);
-
+    rs->var_host        = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index, rs->key_fullid,   rs->type, rs->value);
+    rs->var_host_name   = rrdvar_create_and_index("host",   &st->rrdhost->rrdvar_root_index, rs->key_fullname, rs->type, rs->value);
 }
 
 RRDSETVAR *rrdsetvar_create(RRDSET *st, const char *variable, RRDVAR_TYPE type, void *value, RRDVAR_OPTIONS options) {
@@ -73,6 +76,7 @@ RRDSETVAR *rrdsetvar_create(RRDSET *st, const char *variable, RRDVAR_TYPE type, 
     RRDSETVAR *rs = (RRDSETVAR *)callocz(1, sizeof(RRDSETVAR));
 
     rs->variable = strdupz(variable);
+    rs->hash = simple_hash(rs->variable);
     rs->type = type;
     rs->value = value;
     rs->options = options;
@@ -89,11 +93,9 @@ RRDSETVAR *rrdsetvar_create(RRDSET *st, const char *variable, RRDVAR_TYPE type, 
 void rrdsetvar_rename_all(RRDSET *st) {
     debug(D_VARIABLES, "RRDSETVAR rename for chart id '%s' name '%s'", st->id, st->name);
 
-    RRDSETVAR *rs, *next = st->variables;
-    while((rs = next)) {
-        next = rs->next;
+    RRDSETVAR *rs;
+    for(rs = st->variables; rs ; rs = rs->next)
         rrdsetvar_create_variables(rs);
-    }
 
     rrdsetcalc_link_matching(st);
 }
@@ -115,6 +117,63 @@ void rrdsetvar_free(RRDSETVAR *rs) {
     rrdsetvar_free_variables(rs);
 
     freez(rs->variable);
+
+    if(rs->options & RRDVAR_OPTION_ALLOCATED)
+        freez(rs->value);
+
     freez(rs);
 }
 
+// --------------------------------------------------------------------------------------------------------------------
+// custom chart variables
+
+RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name) {
+    char *n = strdupz(name);
+    rrdvar_fix_name(n);
+    uint32_t hash = simple_hash(n);
+
+    rrdset_wrlock(st);
+
+    // find it
+    RRDSETVAR *rs;
+    for(rs = st->variables; rs ; rs = rs->next) {
+        if(hash == rs->hash && strcmp(n, rs->variable) == 0) {
+            rrdset_unlock(st);
+            if(rs->options & RRDVAR_OPTION_ALLOCATED) {
+                free(n);
+                return rs;
+            }
+            else {
+                error("RRDSETVAR: custom variable '%s' on chart '%s' of host '%s', conflicts with an internal chart variable", n, st->id, st->rrdhost->hostname);
+                free(n);
+                return NULL;
+            }
+        }
+    }
+
+    // not found, allocate one
+
+    calculated_number *v = mallocz(sizeof(calculated_number));
+    *v = NAN;
+
+    rs = rrdsetvar_create(st, n, RRDVAR_TYPE_CALCULATED, v, RRDVAR_OPTION_ALLOCATED);
+    rrdset_unlock(st);
+
+    free(n);
+    return rs;
+}
+
+void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rs, calculated_number value) {
+    if(unlikely(!(rs->options & RRDVAR_OPTION_ALLOCATED))) {
+        error("RRDSETVAR: requested to set variable '%s' of chart '%s' on host '%s' to value " CALCULATED_NUMBER_FORMAT " but the variable is not a custom one.", rs->variable, rs->rrdset->id, rs->rrdset->rrdhost->hostname, value);
+    }
+    else {
+        calculated_number *v = rs->value;
+        if(*v != value) {
+            *v = value;
+
+            // mark the chart to be sent upstream
+            rrdset_flag_clear(rs->rrdset, RRDSET_FLAG_EXPOSED_UPSTREAM);
+        }
+    }
+}

--- a/src/rrdvar.c
+++ b/src/rrdvar.c
@@ -56,7 +56,7 @@ inline void rrdvar_free(RRDHOST *host, avl_tree_lock *tree, RRDVAR *rv) {
     if(tree) {
         debug(D_VARIABLES, "Deleting variable '%s'", rv->name);
         if(unlikely(!rrdvar_index_del(tree, rv)))
-            error("Attempted to delete variable '%s' from host '%s', but it is not found.", rv->name, host->hostname);
+            error("RRDVAR: Attempted to delete variable '%s' from host '%s', but it is not found.", rv->name, host->hostname);
     }
 
     if(rv->type == RRDVAR_TYPE_CALCULATED_ALLOCATED)
@@ -105,18 +105,27 @@ inline RRDVAR *rrdvar_create_and_index(const char *scope, avl_tree_lock *tree, c
     return rv;
 }
 
+void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock) {
+    // FIXME: this is not bullet proof - avl should support some means to destroy it
+    // with a callback for each item already in the index
+    while(host->rrdvar_root_index.avl_tree.root) {
+        RRDVAR *rv = (RRDVAR *)tree_lock->avl_tree.root;
+        rrdvar_free(host, tree_lock, rv);
+    }
+}
+
 // ----------------------------------------------------------------------------
 // CUSTOM VARIABLES
 
 inline int rrdvar_callback_for_all_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data) {
-    return avl_traverse_lock(&host->variables_root_index, callback, data);
+    return avl_traverse_lock(&host->rrdvar_root_index, callback, data);
 }
 
-RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name) {
+static RRDVAR *rrdvar_custom_variable_create(const char *scope, avl_tree_lock *tree_lock, const char *name) {
     calculated_number *v = callocz(1, sizeof(calculated_number));
     *v = NAN;
 
-    RRDVAR *rv = rrdvar_create_and_index("host", &host->variables_root_index, name, RRDVAR_TYPE_CALCULATED_ALLOCATED, v);
+    RRDVAR *rv = rrdvar_create_and_index(scope, tree_lock, name, RRDVAR_TYPE_CALCULATED_ALLOCATED, v);
     if(unlikely(!rv)) {
         free(v);
         debug(D_VARIABLES, "Requested variable '%s' already exists - possibly 2 plugins are updating it at the same time.", name);
@@ -125,7 +134,7 @@ RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name) {
         rrdvar_fix_name(variable);
         uint32_t hash = simple_hash(variable);
 
-        rv = rrdvar_index_find(&host->variables_root_index, variable, hash);
+        rv = rrdvar_index_find(tree_lock, variable, hash);
 
         freez(variable);
     }
@@ -133,41 +142,12 @@ RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name) {
     return rv;
 }
 
-void rrdvar_free_remaining_variables(RRDHOST *host) {
-    // FIXME: this is not bullet proof - avl should support some means to destroy it
-    // with a callback for each item already in the index
-    while(host->variables_root_index.avl_tree.root) {
-        RRDVAR *rv = (RRDVAR *)host->variables_root_index.avl_tree.root;
-        rrdvar_free(host, &host->variables_root_index, rv);
-    }
+RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name) {
+    return rrdvar_custom_variable_create("host", &host->rrdvar_root_index, name);
 }
 
-void rrdvar_custom_host_variable_destroy(RRDHOST *host, const char *name) {
-    char *variable = strdupz(name);
-    rrdvar_fix_name(variable);
-    uint32_t hash = simple_hash(variable);
-
-    RRDVAR *rv = rrdvar_index_find(&host->variables_root_index, variable, hash);
-    freez(variable);
-
-    if(!rv) {
-        error("Attempted to remove variable '%s' from host '%s', but it does not exist.", name, host->hostname);
-        return;
-    }
-
-    if(rv->type != RRDVAR_TYPE_CALCULATED_ALLOCATED) {
-        error("Attempted to remove variable '%s' from host '%s', but it does not a custom allocated variable.", name, host->hostname);
-        return;
-    }
-
-    if(!rrdvar_index_del(&host->variables_root_index, rv)) {
-        error("Attempted to remove variable '%s' from host '%s', but it cannot be found.", name, host->hostname);
-        return;
-    }
-
-    freez(rv->name);
-    freez(rv->value);
-    freez(rv);
+RRDVAR *rrdvar_custom_chart_variable_create(RRDSET *st, const char *name) {
+    return rrdvar_custom_variable_create("local", &st->rrdvar_root_index, name);
 }
 
 void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_number value) {
@@ -175,10 +155,26 @@ void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_numbe
         error("requested to set variable '%s' to value " CALCULATED_NUMBER_FORMAT " but the variable is not a custom one.", rv->name, value);
     else {
         calculated_number *v = rv->value;
-        *v = value;
+        if(*v != value) {
+            *v = value;
 
-        // if the host is streaming, send this variable upstream immediately
-        rrdpush_sender_send_this_variable_now(host, rv);
+            // if the host is streaming, send this variable upstream immediately
+            rrdpush_sender_send_this_variable_now(host, rv);
+        }
+    }
+}
+
+void rrdvar_custom_chart_variable_set(RRDSET *st, RRDVAR *rv, calculated_number value) {
+    if(rv->type != RRDVAR_TYPE_CALCULATED_ALLOCATED)
+        error("requested to set variable '%s' to value " CALCULATED_NUMBER_FORMAT " but the variable is not a custom one.", rv->name, value);
+    else {
+        calculated_number *v = rv->value;
+        if(*v != value) {
+            *v = value;
+
+            // mark the chart to be sent upstream
+            rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+        }
     }
 }
 
@@ -225,19 +221,19 @@ int health_variable_lookup(const char *variable, uint32_t hash, RRDCALC *rc, cal
 
     if(!st) return 0;
 
-    rv = rrdvar_index_find(&st->variables_root_index, variable, hash);
+    rv = rrdvar_index_find(&st->rrdvar_root_index, variable, hash);
     if(rv) {
         *result = rrdvar2number(rv);
         return 1;
     }
 
-    rv = rrdvar_index_find(&st->rrdfamily->variables_root_index, variable, hash);
+    rv = rrdvar_index_find(&st->rrdfamily->rrdvar_root_index, variable, hash);
     if(rv) {
         *result = rrdvar2number(rv);
         return 1;
     }
 
-    rv = rrdvar_index_find(&st->rrdhost->variables_root_index, variable, hash);
+    rv = rrdvar_index_find(&st->rrdhost->rrdvar_root_index, variable, hash);
     if(rv) {
         *result = rrdvar2number(rv);
         return 1;
@@ -276,13 +272,13 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf) {
     };
 
     buffer_sprintf(buf, "{\n\t\"chart\": \"%s\",\n\t\"chart_name\": \"%s\",\n\t\"chart_context\": \"%s\",\n\t\"chart_variables\": {", st->id, st->name, st->context);
-    avl_traverse_lock(&st->variables_root_index, single_variable2json, (void *)&helper);
+    avl_traverse_lock(&st->rrdvar_root_index, single_variable2json, (void *)&helper);
     buffer_sprintf(buf, "\n\t},\n\t\"family\": \"%s\",\n\t\"family_variables\": {", st->family);
     helper.counter = 0;
-    avl_traverse_lock(&st->rrdfamily->variables_root_index, single_variable2json, (void *)&helper);
+    avl_traverse_lock(&st->rrdfamily->rrdvar_root_index, single_variable2json, (void *)&helper);
     buffer_sprintf(buf, "\n\t},\n\t\"host\": \"%s\",\n\t\"host_variables\": {", st->rrdhost->hostname);
     helper.counter = 0;
-    avl_traverse_lock(&st->rrdhost->variables_root_index, single_variable2json, (void *)&helper);
+    avl_traverse_lock(&st->rrdhost->rrdvar_root_index, single_variable2json, (void *)&helper);
     buffer_strcat(buf, "\n\t}\n}\n");
 }
 

--- a/src/rrdvar.c
+++ b/src/rrdvar.c
@@ -117,8 +117,12 @@ void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock) {
 // ----------------------------------------------------------------------------
 // CUSTOM VARIABLES
 
-inline int rrdvar_callback_for_all_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data) {
+inline int rrdvar_callback_for_all_host_variables(RRDHOST *host, int (*callback)(void *rrdvar, void *data), void *data) {
     return avl_traverse_lock(&host->rrdvar_root_index, callback, data);
+}
+
+inline int rrdvar_callback_for_all_chart_variables(RRDSET *st, int (*callback)(void *rrdvar, void *data), void *data) {
+    return avl_traverse_lock(&st->rrdhost->rrdvar_root_index, callback, data);
 }
 
 static RRDVAR *rrdvar_custom_variable_create(const char *scope, avl_tree_lock *tree_lock, const char *name) {
@@ -159,7 +163,7 @@ void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_numbe
             *v = value;
 
             // if the host is streaming, send this variable upstream immediately
-            rrdpush_sender_send_this_variable_now(host, rv);
+            rrdpush_sender_send_this_host_variable_now(host, rv);
         }
     }
 }


### PR DESCRIPTION
 fixes #2884 

The `VARIABLE` lines of external plugins, now follow this template:

```
VARIABLE [SCOPE] name = value
```

The optional `SCOPE` can be:

- `GLOBAL` or `HOST` to define the variable at the host level.
- `LOCAL` or `CHART` define the variable at the chart level.

The position of the `VARIABLE` line, sets its scope too.

So, defining a `VARIABLE` before any `CHART`, or between `END` and `BEGIN` (outside any chart), sets `GLOBAL` scope, while defining a `VARIABLE` just after a `CHART` or a `DIMENSION`, or within the `BEGIN` - `END` block of a chart, sets `LOCAL` scope.

~~This is untested currently.~~ tested it.