### PR TITLE
support multiple plugin directories

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -243,6 +243,7 @@ typedef enum rrdcalc_status {
 extern char *netdata_configured_hostname;
 extern char *netdata_configured_config_dir;
 extern char *netdata_configured_log_dir;
+extern char *netdata_configured_plugins_dir_base;
 extern char *netdata_configured_plugins_dir;
 extern char *netdata_configured_web_dir;
 extern char *netdata_configured_cache_dir;

--- a/src/plugins_d.h
+++ b/src/plugins_d.h
@@ -16,6 +16,9 @@
 #define PLUGINSD_LINE_MAX 1024
 #define PLUGINSD_MAX_WORDS 20
 
+#define PLUGINSD_MAX_DIRECTORIES 20
+extern char *plugin_directories[PLUGINSD_MAX_DIRECTORIES];
+
 struct plugind {
     char id[CONFIG_MAX_NAME+1];         // config node id
 
@@ -44,7 +47,12 @@ struct plugind {
 extern struct plugind *pluginsd_root;
 
 extern void *pluginsd_main(void *ptr);
+extern void pluginsd_stop_all_external_plugins(void);
+
 extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int trust_durations);
 extern int pluginsd_split_words(char *str, char **words, int max_words);
+
+extern int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char));
+extern int config_isspace(char c);
 
 #endif /* NETDATA_PLUGINS_D_H */

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -6357,7 +6357,8 @@ var NETDATA = window.NETDATA || {};
         }
 
         state.legendSetUnitsString = function(units) {
-            state.tmp.easyPieChartUnits.innerText = units;
+            if(typeof state.tmp.easyPieChartUnits !== 'undefined')
+                state.tmp.easyPieChartUnits.innerText = units;
         };
         state.legendShowUndefined = function() {};
 
@@ -6730,7 +6731,9 @@ var NETDATA = window.NETDATA || {};
             animate = false;
 
         state.legendSetUnitsString = function(units) {
-            state.tmp.gaugeChartUnits.innerText = units;
+            if(typeof state.tmp.gaugeChartUnits !== 'undefined')
+                state.tmp.gaugeChartUnits.innerText = units;
+
             state.tmp.___gaugeOld__.valueLabel = null;
             state.tmp.___gaugeOld__.minLabel = null;
             state.tmp.___gaugeOld__.maxLabel = null;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -6356,12 +6356,6 @@ var NETDATA = window.NETDATA || {};
                 barColor = tmp;
         }
 
-        state.legendSetUnitsString = function(units) {
-            if(typeof state.tmp.easyPieChartUnits !== 'undefined')
-                state.tmp.easyPieChartUnits.innerText = units;
-        };
-        state.legendShowUndefined = function() {};
-
         var pcent = NETDATA.easypiechartPercentFromValueMinMax(state, value, min, max);
         chart.data('data-percent', pcent);
 
@@ -6389,6 +6383,13 @@ var NETDATA = window.NETDATA || {};
         if(animate === false) state.tmp.easyPieChart_instance.disableAnimation();
         state.tmp.easyPieChart_instance.update(pcent);
         if(animate === false) state.tmp.easyPieChart_instance.enableAnimation();
+
+        state.legendSetUnitsString = function(units) {
+            if(typeof state.tmp.easyPieChartUnits !== 'undefined')
+                state.tmp.easyPieChartUnits.innerText = units;
+        };
+        state.legendShowUndefined = function() {};
+
         return true;
     };
 
@@ -6730,16 +6731,6 @@ var NETDATA = window.NETDATA || {};
         if(typeof state.tmp.gauge_instance !== 'undefined')
             animate = false;
 
-        state.legendSetUnitsString = function(units) {
-            if(typeof state.tmp.gaugeChartUnits !== 'undefined')
-                state.tmp.gaugeChartUnits.innerText = units;
-
-            state.tmp.___gaugeOld__.valueLabel = null;
-            state.tmp.___gaugeOld__.minLabel = null;
-            state.tmp.___gaugeOld__.maxLabel = null;
-        };
-        state.legendShowUndefined = function() {};
-
         state.tmp.gauge_instance = new Gauge(state.tmp.gauge_canvas).setOptions(options); // create sexy gauge!
 
         state.tmp.___gaugeOld__ = {
@@ -6759,6 +6750,17 @@ var NETDATA = window.NETDATA || {};
         NETDATA.gaugeSet(state, value, min, max);
         NETDATA.gaugeSetLabels(state, value, min, max);
         NETDATA.gaugeAnimation(state, true);
+
+        state.legendSetUnitsString = function(units) {
+            if(typeof state.tmp.gaugeChartUnits !== 'undefined') {
+                state.tmp.gaugeChartUnits.innerText = units;
+                state.tmp.___gaugeOld__.valueLabel = null;
+                state.tmp.___gaugeOld__.minLabel = null;
+                state.tmp.___gaugeOld__.maxLabel = null;
+            }
+        };
+        state.legendShowUndefined = function() {};
+
         return true;
     };
 


### PR DESCRIPTION
 fixes #2009 

netdata now supports multiple external plugin directories. They are configured via the same variable, but now it accepts a space separated list of directories:

```
[global]
    plugins directory = "/usr/libexec/netdata/plugins.d" "/etc/netdata/custom-plugins.d"
```

By default netdata adds the directory `custom-plugins.d` inside the configs directory. Custom plugins can be made executable, with suffix `.plugin` and placed in this directory.
