### PR TITLE
add postmaster as postgres into sql group

### DIFF
--- a/conf.d/apps_groups.conf
+++ b/conf.d/apps_groups.conf
@@ -100,7 +100,7 @@ puma: *puma*
 # -----------------------------------------------------------------------------
 # database servers
 
-sql: mysqld* mariad* postgres* oracle_* ora_*
+sql: mysqld* mariad* postgres* postmaster* oracle_* ora_*
 nosql: mongod redis* memcached *couchdb*
 timedb: prometheus *carbon-cache.py* *carbon-aggregator.py* *graphite/manage.py* *net.opentsdb.tools.TSDMain*
 


### PR DESCRIPTION
It seems that on my host,  postgres displays its name as `postmaster` in `ps -e` and `/proc/$pid/stat`

```
[root@dev-db opt]# ps -ef|grep postgres|head -1
postgres   605 29986  0 10:05 ?        00:00:00 postgres: postgres sde 10.3.100.175(20704) idle
[root@dev-db opt]# ps -e|grep postmaster|head -1
  605 ?        00:00:00 postmaster
```

this patch add `postmaster*` into the sql group


