### PR TITLE
preserve settings that are loaded from disk, even if they match the defaults

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -567,6 +567,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
             else pri = 2;
 
             if(i == pri) {
+                int loaded = 0;
                 int used = 0;
                 int changed = 0;
                 int count = 0;
@@ -574,13 +575,14 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
                 config_section_wrlock(co);
                 for(cv = co->values; cv ; cv = cv->next) {
                     used += (cv->flags & CONFIG_VALUE_USED)?1:0;
+                    loaded += (cv->flags & CONFIG_VALUE_LOADED)?1:0;
                     changed += (cv->flags & CONFIG_VALUE_CHANGED)?1:0;
                     count++;
                 }
                 config_section_unlock(co);
 
                 if(!count) continue;
-                if(only_changed && !changed) continue;
+                if(only_changed && !changed && !loaded) continue;
 
                 if(!used) {
                     buffer_sprintf(wb, "\n# section '%s' is not used.", co->name);
@@ -594,7 +596,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
                     if(used && !(cv->flags & CONFIG_VALUE_USED)) {
                         buffer_sprintf(wb, "\n\t# option '%s' is not used.\n", cv->name);
                     }
-                    buffer_sprintf(wb, "\t%s%s = %s\n", ((!(cv->flags & CONFIG_VALUE_CHANGED)) && (cv->flags & CONFIG_VALUE_USED))?"# ":"", cv->name, cv->value);
+                    buffer_sprintf(wb, "\t%s%s = %s\n", ((!(cv->flags & CONFIG_VALUE_LOADED)) && (!(cv->flags & CONFIG_VALUE_CHANGED)) && (cv->flags & CONFIG_VALUE_USED))?"# ":"", cv->name, cv->value);
                 }
                 config_section_unlock(co);
             }

--- a/src/avl.c
+++ b/src/avl.c
@@ -306,7 +306,10 @@ int avl_walker(avl *node, int (*callback)(void *entry, void *data), void *data) 
 }
 
 int avl_traverse(avl_tree *t, int (*callback)(void *entry, void *data), void *data) {
-    return avl_walker(t->root, callback, data);
+    if(t->root)
+        return avl_walker(t->root, callback, data);
+    else
+        return 0;
 }
 
 // ---------------------------


### PR DESCRIPTION
`http://ip:19999/netdata.conf` now generates config that preserves (shows not-commented) the settings that have been read from `/etc/netdata/netdata.conf`, even if they match the defaults.

This is useful in case netdata defaults are changed in the future, or if netdata is started using multiple methods.

---

fixed a bug under macOS that prevented streaming with `memory mode = none`. fixes #2890 