### PR TITLE
added field for source device in pushbullet sender

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -161,6 +161,9 @@ SEND_PUSHBULLET="YES"
 PUSHBULLET_ACCESS_TOKEN=""
 DEFAULT_RECIPIENT_PUSHBULLET=""
 
+# Device iden of the sending device. Optional.
+SOURCE_DEVICE=""
+
 
 #------------------------------------------------------------------------------
 # Twilio (twilio.com) SMS options

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -162,7 +162,7 @@ PUSHBULLET_ACCESS_TOKEN=""
 DEFAULT_RECIPIENT_PUSHBULLET=""
 
 # Device iden of the sending device. Optional.
-SOURCE_DEVICE=""
+PUSHBULLET_SOURCE_DEVICE=""
 
 
 #------------------------------------------------------------------------------

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1417,7 +1417,6 @@ Severity: ${severity}\n
 Chart: ${chart}\n
 Family: ${family}\n
 $(date -d @${when})\n
-To View Netdata go to: ${goto_url}\n
 The source of this alarm is line ${src}"
 
 SENT_PUSHBULLET=$?

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -249,6 +249,7 @@ declare -A role_recipients_pushover=()
 
 # pushbullet configs
 PUSHBULLET_ACCESS_TOKEN=
+PUSHBULLET_SOURCE_DEVICE=
 DEFAULT_RECIPIENT_PUSHBULLET=
 declare -A role_recipients_pushbullet=()
 
@@ -849,7 +850,7 @@ send_pushover() {
 # pushbullet sender
 
 send_pushbullet() {
-    local userapikey="${1}" recipients="${2}"  title="${3}" message="${4}" httpcode sent=0 user
+    local userapikey="${1}" source_device="${2}" recipients="${3}"  title="${4}" message="{5}" httpcode sent=0 user
     if [ "${SEND_PUSHBULLET}" = "YES" -a ! -z "${userapikey}" -a ! -z "${recipients}" -a ! -z "${message}" -a ! -z "${title}" ]
         then
         #https://docs.pushbullet.com/#create-push
@@ -862,7 +863,8 @@ send_pushbullet() {
                               {"title": "${title}",
                               "type": "note",
                               "email": "${user}",
-                              "body": "$( echo -n ${message})"}
+                              "body": "$( echo -n ${message})",
+                              "source_device_iden": "${source_device}"}
 EOF
                ) "https://api.pushbullet.com/v2/pushes" -X POST)
 
@@ -1409,7 +1411,7 @@ SENT_PUSHOVER=$?
 # -----------------------------------------------------------------------------
 # send the pushbullet notification
 
-send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${to_pushbullet}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\n
+send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to_pushbullet}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\n
 Severity: ${severity}\n
 Chart: ${chart}\n
 Family: ${family}\n

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1413,10 +1413,10 @@ SENT_PUSHOVER=$?
 # send the pushbullet notification
 
 send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to_pushbullet}" "${goto_url}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\n
-$(date -d @${when})\n
 Severity: ${severity}\n
 Chart: ${chart}\n
 Family: ${family}\n
+$(date -d @${when})\n
 To View Netdata go to: ${goto_url}\n
 The source of this alarm is line ${src}"
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -850,7 +850,7 @@ send_pushover() {
 # pushbullet sender
 
 send_pushbullet() {
-    local userapikey="${1}" source_device="${2}" recipients="${3}"  title="${4}" message="{5}" httpcode sent=0 user
+    local userapikey="${1}" source_device="${2}" recipients="${3}" url="{4}" title="${5}" message="{6}" httpcode sent=0 user
     if [ "${SEND_PUSHBULLET}" = "YES" -a ! -z "${userapikey}" -a ! -z "${recipients}" -a ! -z "${message}" -a ! -z "${title}" ]
         then
         #https://docs.pushbullet.com/#create-push
@@ -861,9 +861,10 @@ send_pushbullet() {
               --header 'Content-Type: application/json' \
               --data-binary  @<(cat <<EOF
                               {"title": "${title}",
-                              "type": "note",
+                              "type": "link",
                               "email": "${user}",
                               "body": "$( echo -n ${message})",
+                              "url": "${url}",
                               "source_device_iden": "${source_device}"}
 EOF
                ) "https://api.pushbullet.com/v2/pushes" -X POST)
@@ -1411,7 +1412,8 @@ SENT_PUSHOVER=$?
 # -----------------------------------------------------------------------------
 # send the pushbullet notification
 
-send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to_pushbullet}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\n
+send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to_pushbullet}" "${goto_url}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\n
+$(date -d @${when})\n
 Severity: ${severity}\n
 Chart: ${chart}\n
 Family: ${family}\n


### PR DESCRIPTION
This allows for clearly setting the source of alarm, uniquely identifiable by the unique device id when mentioned.
Also helps when running netdata on multiple machines. Using this, alerts from same devices can be grouped together in Pushbullet's interface.

In the below screenshot, notice that the notifications originates from "RaspberryPi" and are hence consolidated under it separately (don't mix with other user pushes). 
![screenshot from 2017-10-24 02-20-34](https://user-images.githubusercontent.com/6129517/31912635-212a7dec-b862-11e7-8a0e-25145848db05.png)

Related information about [creating devices](https://docs.pushbullet.com/#create-device) for Pushbullet.
