### PR TITLE
calculate total system disk I/O by aggregating the I/O of all physical disks

### DIFF
--- a/src/proc_vmstat.c
+++ b/src/proc_vmstat.c
@@ -128,15 +128,15 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         if(unlikely(!st_io)) {
             st_io = rrdset_create_localhost(
                     "system"
-                    , "io"
+                    , "pgpgio"
                     , NULL
                     , "disk"
                     , NULL
-                    , "Disk I/O"
+                    , "Memory Paged from/to disk"
                     , "kilobytes/s"
                     , "proc"
                     , "vmstat"
-                    , 150
+                    , 151
                     , update_every
                     , RRDSET_TYPE_AREA
             );


### PR DESCRIPTION
fixes #2877

The total disk I/O reported by netdata came from `/proc/vmstat`, counters `pgpgin` and `pgpgout`:

- `pgpgin` is the amount of memory (in KB) that the kernel paged in from disk.
- `pgpgout` is the amount of memory (in KB) that the kernel paged out to disk.

It seems this does not include ZFS bandwidth.

So, this PR renames the old `system.io` to `system.pgpgio` and adds a new `system.io` that calculates its values as the sum of the all the physical disks of the system (it excludes partitions and disks with slaves).