### PR TITLE
system.net chart

### DIFF
--- a/src/proc_net_dev.c
+++ b/src/proc_net_dev.c
@@ -867,7 +867,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                     , NULL
                     , "network"
                     , NULL
-                    , "Network Interfaces Aggregated Bandwidth"
+                    , "Physical Network Interfaces Aggregated Bandwidth"
                     , "kilobits/s"
                     , "proc"
                     , "net/dev"

--- a/src/proc_net_dev.c
+++ b/src/proc_net_dev.c
@@ -9,6 +9,7 @@ static struct netdev {
     size_t len;
 
     // flags
+    int virtual;
     int configured;
     int enabled;
     int updated;
@@ -428,8 +429,14 @@ int do_proc_net_dev(int update_every, usec_t dt) {
     static procfile *ff = NULL;
     static int enable_new_interfaces = -1;
     static int do_bandwidth = -1, do_packets = -1, do_errors = -1, do_drops = -1, do_fifo = -1, do_compressed = -1, do_events = -1;
+    static char *path_to_sys_devices_virtual_net = NULL;
 
     if(unlikely(enable_new_interfaces == -1)) {
+        char filename[FILENAME_MAX + 1];
+
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/virtual/net/%s");
+        path_to_sys_devices_virtual_net = config_get("plugin:proc:/proc/net/dev", "path to get virtual interfaces", filename);
+
         enable_new_interfaces = config_get_boolean_ondemand("plugin:proc:/proc/net/dev", "enable new interfaces detected at runtime", CONFIG_BOOLEAN_AUTO);
 
         do_bandwidth    = config_get_boolean_ondemand("plugin:proc:/proc/net/dev", "bandwidth for all interfaces", CONFIG_BOOLEAN_AUTO);
@@ -482,31 +489,42 @@ int do_proc_net_dev(int update_every, usec_t dt) {
             if(d->enabled)
                 d->enabled = !simple_pattern_matches(disabled_list, d->name);
 
-            char var_name[512 + 1];
-            snprintfz(var_name, 512, "plugin:proc:/proc/net/dev:%s", d->name);
-            d->enabled = config_get_boolean_ondemand(var_name, "enabled", d->enabled);
+            char buffer[FILENAME_MAX + 1];
+
+            snprintfz(buffer, FILENAME_MAX, path_to_sys_devices_virtual_net, d->name);
+            if(likely(access(buffer, R_OK) == 0)) {
+                d->virtual = 1;
+            }
+            else
+                d->virtual = 0;
+
+            snprintfz(buffer, FILENAME_MAX, "plugin:proc:/proc/net/dev:%s", d->name);
+            d->enabled = config_get_boolean_ondemand(buffer, "enabled", d->enabled);
+            d->virtual = config_get_boolean(buffer, "virtual", d->virtual);
 
             if(d->enabled == CONFIG_BOOLEAN_NO)
                 continue;
 
-            d->do_bandwidth  = config_get_boolean_ondemand(var_name, "bandwidth",  do_bandwidth);
-            d->do_packets    = config_get_boolean_ondemand(var_name, "packets",    do_packets);
-            d->do_errors     = config_get_boolean_ondemand(var_name, "errors",     do_errors);
-            d->do_drops      = config_get_boolean_ondemand(var_name, "drops",      do_drops);
-            d->do_fifo       = config_get_boolean_ondemand(var_name, "fifo",       do_fifo);
-            d->do_compressed = config_get_boolean_ondemand(var_name, "compressed", do_compressed);
-            d->do_events     = config_get_boolean_ondemand(var_name, "events",     do_events);
+            d->do_bandwidth  = config_get_boolean_ondemand(buffer, "bandwidth",  do_bandwidth);
+            d->do_packets    = config_get_boolean_ondemand(buffer, "packets",    do_packets);
+            d->do_errors     = config_get_boolean_ondemand(buffer, "errors",     do_errors);
+            d->do_drops      = config_get_boolean_ondemand(buffer, "drops",      do_drops);
+            d->do_fifo       = config_get_boolean_ondemand(buffer, "fifo",       do_fifo);
+            d->do_compressed = config_get_boolean_ondemand(buffer, "compressed", do_compressed);
+            d->do_events     = config_get_boolean_ondemand(buffer, "events",     do_events);
         }
 
         if(unlikely(!d->enabled))
             continue;
 
-        if(likely(d->do_bandwidth != CONFIG_BOOLEAN_NO)) {
+        if(likely(d->do_bandwidth != CONFIG_BOOLEAN_NO || !d->virtual)) {
             d->rbytes      = str2kernel_uint_t(procfile_lineword(ff, l, 1));
             d->tbytes      = str2kernel_uint_t(procfile_lineword(ff, l, 9));
 
-            system_rbytes += d->rbytes;
-            system_tbytes += d->tbytes;
+            if(likely(!d->virtual)) {
+                system_rbytes += d->rbytes;
+                system_tbytes += d->tbytes;
+            }
         }
 
         if(likely(d->do_packets != CONFIG_BOOLEAN_NO)) {
@@ -839,13 +857,13 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
     if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO && (system_rbytes || system_tbytes))) {
         do_bandwidth = CONFIG_BOOLEAN_YES;
-        static RRDSET *st_system_bandwidth = NULL;
+        static RRDSET *st_system_net = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_system_bandwidth)) {
-            st_system_bandwidth = rrdset_create_localhost(
+        if(unlikely(!st_system_net)) {
+            st_system_net = rrdset_create_localhost(
                     "system"
-                    , "bandwidth"
+                    , "net"
                     , NULL
                     , "network"
                     , NULL
@@ -858,16 +876,16 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                     , RRDSET_TYPE_AREA
             );
 
-            rd_in  = rrddim_add(st_system_bandwidth, "InOctets",  "received", 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
-            rd_out = rrddim_add(st_system_bandwidth, "OutOctets", "sent",    -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_in  = rrddim_add(st_system_net, "InOctets",  "received", 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_out = rrddim_add(st_system_net, "OutOctets", "sent",    -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
         }
         else
-            rrdset_next(st_system_bandwidth);
+            rrdset_next(st_system_net);
 
-        rrddim_set_by_pointer(st_system_bandwidth, rd_in,  (collected_number)system_rbytes);
-        rrddim_set_by_pointer(st_system_bandwidth, rd_out, (collected_number)system_tbytes);
+        rrddim_set_by_pointer(st_system_net, rd_in,  (collected_number)system_rbytes);
+        rrddim_set_by_pointer(st_system_net, rd_out, (collected_number)system_tbytes);
 
-        rrdset_done(st_system_bandwidth);
+        rrdset_done(st_system_net);
     }
 
     netdev_cleanup();

--- a/src/proc_net_netstat.c
+++ b/src/proc_net_netstat.c
@@ -262,7 +262,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                             , "kilobits/s"
                             , "proc"
                             , "net/netstat"
-                            , 500
+                            , 501
                             , update_every
                             , RRDSET_TYPE_AREA
                     );

--- a/src/proc_net_snmp6.c
+++ b/src/proc_net_snmp6.c
@@ -291,7 +291,7 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
                     , "kilobits/s"
                     , "proc"
                     , "net/snmp6"
-                    , 500
+                    , 502
                     , update_every
                     , RRDSET_TYPE_AREA
             );

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -497,7 +497,18 @@ netdataDashboard.context = {
     },
 
     'system.io': {
-        info: 'Total Disk I/O, for all disks. You can get detailed information about each disk at the <a href="#menu_disk">Disks</a> section and per application Disk usage at the <a href="#menu_apps">Applications Monitoring</a> section.'
+        info: function(os) {
+            var s = 'Total Disk I/O, for all physical disks. You can get detailed information about each disk at the <a href="#menu_disk">Disks</a> section and per application Disk usage at the <a href="#menu_apps">Applications Monitoring</a> section.';
+
+            if(os === 'linux')
+                return s + ' Physical are all the disks that are listed in <code>/sys/block</code>, but do not exist in <code>/sys/devices/virtual/block</code>.';
+            else
+                return s;
+        }
+    },
+
+    'system.pgpgio': {
+        info: 'Memory paged from/to disk. This is usually the total disk I/O of the system.'
     },
 
     'system.swapio': {
@@ -552,7 +563,7 @@ netdataDashboard.context = {
             var s = 'Total bandwidth of all physical network interfaces. This does not include <code>lo</code>, VPNs, network bridges, IFB devices, bond interfaces, etc. Only the bandwidth of physical network interfaces is aggregated.';
 
             if(os === 'linux')
-                return s + ' Physical are all the network interfaces that are listed in <code>/proc/net/dev</code>, but do not exist in <code>/sys/devices/virtual/net</code>.'
+                return s + ' Physical are all the network interfaces that are listed in <code>/proc/net/dev</code>, but do not exist in <code>/sys/devices/virtual/net</code>.';
             else
                 return s;
         }

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -547,6 +547,17 @@ netdataDashboard.context = {
         info: 'Idle jitter is calculated by netdata. A thread is spawned that requests to sleep for a few microseconds. When the system wakes it up, it measures how many microseconds have passed. The difference between the requested and the actual duration of the sleep, is the <b>idle jitter</b>. This number is useful in real-time environments, where CPU jitter can affect the quality of the service (like VoIP media gateways).'
     },
 
+    'system.net': {
+        info: function(os) {
+            var s = 'Total bandwidth of all physical network interfaces. This does not include <code>lo</code>, VPNs, network bridges, IFB devices, bond interfaces, etc. Only the bandwidth of physical network interfaces is aggregated.';
+
+            if(os === 'linux')
+                return s + ' Physical are all the network interfaces that are listed in <code>/proc/net/dev</code>, but do not exist in <code>/sys/devices/virtual/net</code>.'
+            else
+                return s;
+        }
+    },
+
     'system.ipv4': {
         info: 'Total IPv4 Traffic.'
     },

--- a/web/index.html
+++ b/web/index.html
@@ -3007,7 +3007,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20170916-1',
+                url: NETDATA.serverDefault + 'dashboard_info.js?v20171027-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });
@@ -4097,4 +4097,4 @@
     </div>
 </body>
 </html>
-<script type="text/javascript" src="dashboard.js?v20171008-1"></script>
+<script type="text/javascript" src="dashboard.js?v20171027-1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -1316,117 +1316,140 @@
 
             if(typeof charts['system.swap'] !== 'undefined')
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.swap"'
-                + ' data-dimensions="used"'
-                + ' data-append-options="percentage"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="Used Swap"'
-                + ' data-units="%"'
-                + ' data-easypiechart-max-value="100"'
-                + ' data-width="9%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-colors="#DD4400"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="used"'
+                    + ' data-append-options="percentage"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Used Swap"'
+                    + ' data-units="%"'
+                    + ' data-easypiechart-max-value="100"'
+                    + ' data-width="9%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-colors="#DD4400"'
+                    + ' role="application"></div>';
 
             if(typeof charts['system.io'] !== 'undefined') {
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.io"'
-                + ' data-dimensions="in"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="Disk Read"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.io.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="in"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Disk Read"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.io.mainhead"'
+                    + ' role="application"></div>';
 
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.io"'
-                + ' data-dimensions="out"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="Disk Write"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.io.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="out"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Disk Write"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.io.mainhead"'
+                    + ' role="application"></div>';
+            }
+            else if(typeof charts['system.pgpgio'] !== 'undefined') {
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.pgpgio"'
+                    + ' data-dimensions="in"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Disk Read"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.pgpgio.mainhead"'
+                    + ' role="application"></div>';
+
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.pgpgio"'
+                    + ' data-dimensions="out"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Disk Write"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.pgpgio.mainhead"'
+                    + ' role="application"></div>';
             }
 
             if(typeof charts['system.cpu'] !== 'undefined')
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.cpu"'
-                + ' data-chart-library="gauge"'
-                + ' data-title="CPU"'
-                + ' data-units="%"'
-                + ' data-gauge-max-value="100"'
-                + ' data-width="20%"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-colors="' + NETDATA.colors[12] + '"'
-                + ' role="application"></div>';
+                    + ' data-chart-library="gauge"'
+                    + ' data-title="CPU"'
+                    + ' data-units="%"'
+                    + ' data-gauge-max-value="100"'
+                    + ' data-width="20%"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-colors="' + NETDATA.colors[12] + '"'
+                    + ' role="application"></div>';
 
             if(typeof charts['system.ipv4'] !== 'undefined') {
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ipv4"'
-                + ' data-dimensions="received"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="IPv4 Inbound"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.ipv4.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="received"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="IPv4 Inbound"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.ipv4.mainhead"'
+                    + ' role="application"></div>';
 
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ipv4"'
-                + ' data-dimensions="sent"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="IPv4 Outbound"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.ipv4.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="sent"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="IPv4 Outbound"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.ipv4.mainhead"'
+                    + ' role="application"></div>';
             }
             else if(typeof charts['system.ipv6'] !== 'undefined') {
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ipv6"'
-                + ' data-dimensions="received"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="IPv6 Inbound"'
-                + ' data-units="kbps"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.ipv6.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="received"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="IPv6 Inbound"'
+                    + ' data-units="kbps"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.ipv6.mainhead"'
+                    + ' role="application"></div>';
 
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ipv6"'
-                + ' data-dimensions="sent"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="IPv6 Outbound"'
-                + ' data-units="kbps"'
-                + ' data-width="11%"'
-                + ' data-before="0"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-common-units="system.ipv6.mainhead"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="sent"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="IPv6 Outbound"'
+                    + ' data-units="kbps"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.ipv6.mainhead"'
+                    + ' role="application"></div>';
             }
 
             if(typeof charts['system.ram'] !== 'undefined')
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ram"'
-                + ' data-dimensions="used|buffers|active|wired"' // active and wired are FreeBSD stats
-                + ' data-append-options="percentage"'
-                + ' data-chart-library="easypiechart"'
-                + ' data-title="Used RAM"'
-                + ' data-units="%"'
-                + ' data-easypiechart-max-value="100"'
-                + ' data-width="9%"'
-                + ' data-after="-' + duration.toString() + '"'
-                + ' data-points="' + duration.toString() + '"'
-                + ' data-colors="' + NETDATA.colors[7] + '"'
-                + ' role="application"></div>';
+                    + ' data-dimensions="used|buffers|active|wired"' // active and wired are FreeBSD stats
+                    + ' data-append-options="percentage"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Used RAM"'
+                    + ' data-units="%"'
+                    + ' data-easypiechart-max-value="100"'
+                    + ' data-width="9%"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-colors="' + NETDATA.colors[7] + '"'
+                    + ' role="application"></div>';
 
             return head;
         }

--- a/web/index.html
+++ b/web/index.html
@@ -1388,7 +1388,30 @@
                     + ' data-colors="' + NETDATA.colors[12] + '"'
                     + ' role="application"></div>';
 
-            if(typeof charts['system.ipv4'] !== 'undefined') {
+            if(typeof charts['system.bandwidth'] !== 'undefined') {
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.bandwidth"'
+                    + ' data-dimensions="received"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Net Inbound"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.bandwidth.mainhead"'
+                    + ' role="application"></div>';
+
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.bandwidth"'
+                    + ' data-dimensions="sent"'
+                    + ' data-chart-library="easypiechart"'
+                    + ' data-title="Net Outbound"'
+                    + ' data-width="11%"'
+                    + ' data-before="0"'
+                    + ' data-after="-' + duration.toString() + '"'
+                    + ' data-points="' + duration.toString() + '"'
+                    + ' data-common-units="system.bandwidth.mainhead"'
+                    + ' role="application"></div>';
+            }
+            else if(typeof charts['system.ipv4'] !== 'undefined') {
                 head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.ipv4"'
                     + ' data-dimensions="received"'
                     + ' data-chart-library="easypiechart"'

--- a/web/index.html
+++ b/web/index.html
@@ -1388,8 +1388,8 @@
                     + ' data-colors="' + NETDATA.colors[12] + '"'
                     + ' role="application"></div>';
 
-            if(typeof charts['system.bandwidth'] !== 'undefined') {
-                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.bandwidth"'
+            if(typeof charts['system.net'] !== 'undefined') {
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.net"'
                     + ' data-dimensions="received"'
                     + ' data-chart-library="easypiechart"'
                     + ' data-title="Net Inbound"'
@@ -1397,10 +1397,10 @@
                     + ' data-before="0"'
                     + ' data-after="-' + duration.toString() + '"'
                     + ' data-points="' + duration.toString() + '"'
-                    + ' data-common-units="system.bandwidth.mainhead"'
+                    + ' data-common-units="system.net.mainhead"'
                     + ' role="application"></div>';
 
-                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.bandwidth"'
+                head += '<div class="netdata-container" style="margin-right: 10px;" data-netdata="system.net"'
                     + ' data-dimensions="sent"'
                     + ' data-chart-library="easypiechart"'
                     + ' data-title="Net Outbound"'
@@ -1408,7 +1408,7 @@
                     + ' data-before="0"'
                     + ' data-after="-' + duration.toString() + '"'
                     + ' data-points="' + duration.toString() + '"'
-                    + ' data-common-units="system.bandwidth.mainhead"'
+                    + ' data-common-units="system.net.mainhead"'
                     + ' role="application"></div>';
             }
             else if(typeof charts['system.ipv4'] !== 'undefined') {

--- a/web/index.html
+++ b/web/index.html
@@ -3007,7 +3007,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20171027-1',
+                url: NETDATA.serverDefault + 'dashboard_info.js?v20171027-3',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });


### PR DESCRIPTION
Added `system.net` chart that aggregates all the bandwidth of the physical network interfaces of the machine.

Physical are all the network interfaces that are listed in `/proc/net/dev`, but do not exist in `/sys/devices/virtual/net`.

The top gauges that were showing `system.ipv4` or `system.ipv6`, now show `system.net`.

---

Physical disks are now detected via `/sys/block` (`vmstat` does this) and virtual disks via `/sys/devices/virtual/block`.
