### PR TITLE
faster dashboard selection sync on charts

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -364,8 +364,6 @@ var NETDATA = window.NETDATA || {};
 
             smooth_plot: (isSlowDevice() === false), // enable smooth plot, where possible
 
-            charts_selection_animation_delay: 50, // delay to animate charts when syncing selection
-
             color_fill_opacity_line: 1.0,
             color_fill_opacity_area: 0.2,
             color_fill_opacity_stacked: 0.8,
@@ -1986,7 +1984,7 @@ var NETDATA = window.NETDATA || {};
                 if (this.timeout_id !== null)
                     clearTimeout(this.timeout_id);
 
-                this.timeout_id = setTimeout(this.__syncSlaves, 5);
+                this.timeout_id = setTimeout(this.__syncSlaves, 0);
             }
         }
     };
@@ -6227,7 +6225,7 @@ var NETDATA = window.NETDATA || {};
             state.tmp.easyPieChartEvent.timer = setTimeout(function() {
                 state.tmp.easyPieChartEvent.timer = undefined;
                 state.tmp.easyPieChart_instance.update(state.tmp.easyPieChartEvent.pcent);
-            }, NETDATA.options.current.charts_selection_animation_delay);
+            }, 0);
         }
 
         return true;
@@ -6508,7 +6506,7 @@ var NETDATA = window.NETDATA || {};
             state.tmp.gaugeEvent.timer = setTimeout(function() {
                 state.tmp.gaugeEvent.timer = undefined;
                 NETDATA.gaugeSet(state, state.tmp.gaugeEvent.value, state.tmp.gaugeEvent.min, state.tmp.gaugeEvent.max);
-            }, NETDATA.options.current.charts_selection_animation_delay);
+            }, 0);
         }
 
         return true;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -1899,7 +1899,7 @@ var NETDATA = window.NETDATA || {};
 
         // return true if global selection sync can be enabled now
         enabled: function() {
-            console.log('enabled()');
+            // console.log('enabled()');
             // can we globally apply selection sync?
             if(NETDATA.options.current.sync_selection === false)
                 return false;
@@ -1909,7 +1909,7 @@ var NETDATA = window.NETDATA || {};
 
         // set the global selection sync master
         setMaster: function(state) {
-            console.log('setMaster()');
+            // console.log('setMaster()');
             if(NETDATA.options.current.sync_selection === false || this.state === state)
                 return;
 
@@ -1934,7 +1934,7 @@ var NETDATA = window.NETDATA || {};
 
         // stop global selection sync
         stop: function() {
-            console.log('stop()');
+            // console.log('stop()');
             if(this.state !== null) {
                 var len = this.slaves.length;
                 while (len--)
@@ -1950,7 +1950,7 @@ var NETDATA = window.NETDATA || {};
 
         // delay global selection sync for some time
         delay: function(ms) {
-            console.log('delay()');
+            // console.log('delay()');
 
             if(this.state !== null && NETDATA.options.current.sync_selection === true) {
                 if(typeof ms === 'number')
@@ -1972,7 +1972,7 @@ var NETDATA = window.NETDATA || {};
         // sync all the visible charts to the given time
         // this is to be called from the chart libraries
         sync: function(state, t) {
-            console.log('sync()');
+            // console.log('sync()');
 
             if(NETDATA.options.current.sync_selection === true) {
                 if(this.state !== state)


### PR DESCRIPTION
time selection on charts (global sync of selection, when the mouse hovers over a chart), was perfect for chrome, but had issues on all other browsers:

1. chrome: perfect
2. firefox: slow
3. edge: very slow
4. opera: good

This PR split global selection sync in 2 parts:

1. selection on the current chart
2. sync of all other charts

Now, the selection of current chart is always perfect on all browsers. Then all the other charts are updated as the browser allows it (it uses all the available power of the browser).

So, with this PR:

1. chrome: perfect
2. firefox: perfect
3. edge: current chart perfect, other charts good
4. opera: perfect
