### PR TITLE
cgroup-network can now detect libvirt tun/tap interfaces

### DIFF
--- a/plugins.d/Makefile.am
+++ b/plugins.d/Makefile.am
@@ -12,6 +12,7 @@ dist_plugins_SCRIPTS = \
 	alarm-notify.sh \
 	alarm-test.sh \
 	cgroup-name.sh \
+	cgroup-network-helper.sh \
 	charts.d.dryrun-helper.sh \
 	charts.d.plugin \
 	fping.plugin \

--- a/plugins.d/cgroup-network-helper.sh
+++ b/plugins.d/cgroup-network-helper.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+# cgroup-network-helper.sh
+# detect container and virtual machine interfaces
+#
+# (C) 2017 Costa Tsaousis
+# GPL v3+
+#
+# This script is called as root (by cgroup-network), with either a pid, or a cgroup path.
+# It tries to find all the network interfaces that belong to the same cgroup.
+#
+# It supports several method for this detection:
+#
+# 1. cgroup-network (the binary father of this script) detects veth network interfaces,
+#    by examining iflink and ifindex IDs and switching namespaces
+#    (it also detects the interface name as it is used by the container).
+#
+# 2. this script, uses /proc/PID/fdinfo to find tun/tap network interfaces.
+#
+# 3. this script, calls virsh to find libvirt network interfaces.
+#
+
+# -----------------------------------------------------------------------------
+
+PROGRAM_NAME="$(basename "${0}")"
+
+logdate() {
+    date "+%Y-%m-%d %H:%M:%S"
+}
+
+log() {
+    local status="${1}"
+    shift
+
+    echo >&2 "$(logdate): ${PROGRAM_NAME}: ${status}: ${*}"
+
+}
+
+warning() {
+    log WARNING "${@}"
+}
+
+error() {
+    log ERROR "${@}"
+}
+
+info() {
+    log INFO "${@}"
+}
+
+fatal() {
+    log FATAL "${@}"
+    exit 1
+}
+
+debug=0
+debug() {
+    [ "${debug}" = "1" ] && log DEBUG "${@}"
+}
+
+# -----------------------------------------------------------------------------
+# check for BASH v4+ (required for associative arrays)
+
+[ $(( ${BASH_VERSINFO[0]} )) -lt 4 ] && \
+    fatal "BASH version 4 or later is required (this is ${BASH_VERSION})."
+
+# -----------------------------------------------------------------------------
+# defaults to allow running this script by hand
+
+[ -z "${NETDATA_PLUGINS_DIR}"  ] && NETDATA_PLUGINS_DIR="$(dirname "${0}")"
+[ -z "${NETDATA_CONFIG_DIR}"   ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
+[ -z "${NETDATA_CACHE_DIR}"    ] && NETDATA_CACHE_DIR="$(dirname "${0}")/../../../../var/cache/netdata"
+
+# -----------------------------------------------------------------------------
+# parse the arguments
+
+pid=
+cgroup=
+while [ ! -z "${1}" ]
+do
+    case "${1}" in
+        --cgroup) cgroup="${2}"; shift 1;;
+        --pid|-p) pid="${2}"; shift 1;;
+        --debug|debug) debug=1;;
+        *) fatal "Cannot understand argument '${1}'";;
+    esac
+
+    shift
+done
+
+if [ -z "${pid}" -a -z "${cgroup}" ]
+then
+    fatal "Either --pid or --cgroup is required"
+fi
+
+# -----------------------------------------------------------------------------
+
+set_source() {
+    [ ${debug} -eq 1 ] && echo "SRC ${*}"
+}
+
+
+# -----------------------------------------------------------------------------
+# veth interfaces via cgroup
+
+# cgroup-network can detect veth interfaces by itself (written in C).
+# If you seek for a shell version of what it does, check this:
+# https://github.com/firehol/netdata/issues/474#issuecomment-317866709
+
+
+# -----------------------------------------------------------------------------
+# tun/tap interfaces via /proc/PID/fdinfo
+
+# find any tun/tap devices linked to a pid
+proc_pid_fdinfo_iff() {
+    local p="${1}" # the pid
+
+    debug "Searching for tun/tap interfaces for pid ${p}..."
+    set_source "fdinfo"
+    grep ^iff:.* "${NETDATA_HOST_PREFIX}/proc/${p}/fdinfo"/* 2>/dev/null | cut -f 2
+}
+
+find_tun_tap_interfaces_for_cgroup() {
+    local c="${1}" # the cgroup path
+
+    # for each pid of the cgroup
+    # find any tun/tap devices linked to the pid
+    if [ -f "${c}/emulator/cgroup.procs" ]
+    then
+        local p
+        for p in $(< "${c}/emulator/cgroup.procs" )
+        do
+            proc_pid_fdinfo_iff ${p}
+        done
+    fi
+}
+
+
+# -----------------------------------------------------------------------------
+# virsh domain network interfaces
+
+virsh_cgroup_to_domain_name() {
+    local c="${1}" # the cgroup path
+
+    debug "extracting a possible virsh domain from cgroup ${c}..."
+
+    # extract for the cgroup path
+    # \1 = domain id
+    # \2 = domain name
+
+    echo "${c}" |\
+        sed "s|.*/machine-qemu\\\\x2d\([0-9]\+\)\\\\x2d\(.*\)\.scope$|virsh_domain_found \2|" |\
+        grep ^virsh_domain_found |\
+        cut -d ' ' -f 2
+}
+
+virsh_find_all_interfaces_for_cgroup() {
+    local c="${1}" # the cgroup path
+
+    # the virsh command
+    local virsh="$(which virsh 2>/dev/null || command -v virsh 2>/dev/null)"
+
+    if [ ! -z "${virsh}" ]
+    then
+        local d="$(virsh_cgroup_to_domain_name "${c}")"
+
+        if [ ! -z "${d}" ]
+        then
+            debug "running: virsh domiflist ${d}; to find the network interfaces"
+
+            set_source "virsh"
+            "${virsh}" domiflist ${d} |\
+                grep -Ev "^(Interface|----)" |\
+                cut -d ' ' -f 1
+        else
+            debug "no virsh domain extracted from cgroup ${c}"
+        fi
+    else
+        debug "virsh command is not available"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+
+find_all_interfaces_of_pid_or_cgroup() {
+    local p="${1}" c="${2}" # the pid and the cgroup path
+
+    if [ ! -z "${pid}" ]
+    then
+        # we have been called with a pid
+
+        proc_pid_fdinfo_iff ${p}
+
+    elif [ ! -z "${c}" ]
+    then
+        # we have been called with a cgroup
+
+        info "searching for network interfaces of cgroup '${c}'"
+
+        find_tun_tap_interfaces_for_cgroup "${c}"
+        virsh_find_all_interfaces_for_cgroup "${c}"
+
+    else
+
+        error "Either a pid or a cgroup path is needed"
+        return 1
+
+    fi
+
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+
+# an associative array to store the interfaces
+# the index is the interface name as seen by the host
+# the value is the interface name as seen by the guest / container
+declare -A devs=()
+
+# store all interfaces found in the associative array
+# this will also give the unique devices, as seen by the host
+last_src=
+while read host_device guest_device
+do
+    [ -z "${host_device}" ] && continue
+
+    [ "${host_device}" = "SRC" ] && last_src="${guest_device}" && continue
+
+    # the default guest_device is the host_device
+    [ -z "${guest_device}" ] && guest_device="${host_device}"
+
+    # when we run in debug, show the source
+    debug "Found host device '${host_device}', guest device '${guest_device}', detected via '${last_src}'"
+
+    [ -z "${devs[${host_device}]}" -o "${devs[${host_device}]}" = "${host_device}" ] && \
+        devs[${host_device}]="${guest_device}"
+
+done < <( find_all_interfaces_of_pid_or_cgroup "${pid}" "${cgroup}" )
+
+# print the interfaces found, in the format netdata expects them
+found=0
+for x in "${!devs[@]}"
+do
+    found=$((found + 1))
+    echo "${x} ${devs[${x}]}"
+done
+
+debug "found ${found} network interfaces for pid '${pid}', cgroup '${cgroup}', run as ${USER}, ${UID}"
+
+# let netdata know if we found any
+[ ${found} -eq 0 ] && exit 1
+exit 0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -260,6 +260,8 @@ cgroup_network_SOURCES = \
     inlined.h \
     log.c log.h \
 	procfile.c procfile.h \
+	popen.c popen.h \
+	signals.c signals.h \
     $(NULL)
 
 cgroup_network_LDADD = \

--- a/src/cgroup-network.c
+++ b/src/cgroup-network.c
@@ -15,6 +15,10 @@ void netdata_cleanup_and_exit(int ret) {
     exit(ret);
 }
 
+void health_reload(void) {};
+void rrdhost_save_all(void) {};
+
+
 struct iface {
     const char *device;
     uint32_t hash;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -762,7 +762,7 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
                 }
 
                 if(!*t) {
-                    error("CGROUP: empty container interface returned by script");
+                    error("CGROUP: empty guest interface returned by script");
                     continue;
                 }
 


### PR DESCRIPTION
 and move them to cgroup section, much like it did for veth interfaces.

There is now a new external helper script that can also query virsh, docker, lxc, etc.
This script is executed by `cgroup-network`, so it runs as `root`.

The result is now that VMs also get their network interfaces at their section:

![screenshot from 2017-10-31 01-32-43](https://user-images.githubusercontent.com/2662304/32200665-7c2b2d1c-bddb-11e7-98a8-c027578b2b0a.png)

fixes  #2545