### PR TITLE
Beanstalk module + optimization (SimpleService, Charts)

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -27,6 +27,7 @@ dist_nodeconfig_DATA = \
 pythonconfigdir=$(configdir)/python.d
 dist_pythonconfig_DATA = \
     python.d/apache.conf \
+    python.d/beanstalk.conf \
     python.d/bind_rndc.conf \
     python.d/chrony.conf \
     python.d/couchdb.conf \

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -9,13 +9,6 @@
 # Enable / disable the whole python.d.plugin (all its modules)
 enabled: yes
 
-# Prevent log flood
-# Define how many log messages can be written to log file in one log_interval
-logs_per_interval: 200
-
-# Define how long is one logging interval (in seconds)
-log_interval: 3600
-
 # ----------------------------------------------------------------------
 # Enable / Disable python.d.plugin modules
 #default_run: yes

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -22,6 +22,7 @@ enabled: yes
 # apache_cache has been replaced by web_log
 apache_cache: no
 # apache: yes
+# beanstalk: yes
 # bind_rndc: yes
 chrony: no
 # couchdb: yes
@@ -47,6 +48,7 @@ go_expvar: no
 # isc_dhcpd: yes
 # mdstat: yes
 # memcached: yes
+# mongodb: yes
 # mysql: yes
 # nginx: yes
 # nsd: yes
@@ -58,6 +60,7 @@ nginx_log: no
 # phpfpm: yes
 # postfix: yes
 # postgres: yes
+# powerdns: yes
 # rabbitmq: yes
 # redis: yes
 # retroshare: yes

--- a/conf.d/python.d/beanstalk.conf
+++ b/conf.d/python.d/beanstalk.conf
@@ -1,4 +1,4 @@
-# netdata python.d.plugin configuration for couchdb
+# netdata python.d.plugin configuration for beanstalk
 #
 # This file is in YaML format. Generally the format is:
 #
@@ -20,8 +20,7 @@
 
 # update_every sets the default data collection frequency.
 # If unset, the python.d.plugin default is used.
-# By default, CouchDB only updates its stats every 10 seconds.
-update_every: 10
+# update_every: 1
 
 # priority controls the order of charts at the netdata dashboard.
 # Lower numbers move the charts towards the top of the page.
@@ -39,6 +38,16 @@ update_every: 10
 # Attempts to start the job are made once every autodetection_retry.
 # This feature is disabled by default.
 # autodetection_retry: 0
+
+# chart_cleanup sets the default chart cleanup interval in iterations.
+# A chart is marked as obsolete if it has not been updated
+# 'chart_cleanup' iterations in a row.
+# When a plugin sends the obsolete flag, the charts are not deleted
+# from netdata immediately.
+# They will be hidden immediately (not offered to dashboard viewer,
+# streamed upstream and archived to backends) and deleted one hour
+# later (configurable from netdata.conf).
+# chart_cleanup: 10
 
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)
@@ -61,31 +70,11 @@ update_every: 10
 #     priority: 60000         # the JOB's order on the dashboard
 #     retries: 60             # the JOB's number of restoration attempts
 #     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#     chart_cleanup: 10       # the JOB's chart cleanup interval in iterations
 #
-# Additionally to the above, the couchdb plugin also supports the following:
+# Additionally to the above, apache also supports the following:
 #
-#     host: 'ipaddress'                # Server ip address or hostname. Default: 127.0.0.1
-#     port: 'port'                     # CouchDB port. Default: 15672
-#     scheme: 'scheme'                 # http or https. Default: http
-#     node: 'couchdb@127.0.0.1'        # CouchDB node name. Same as -name vm.args argument.
-#
-# if the URL is password protected, the following are supported:
-#
-#     user: 'username'
-#     pass: 'password'
-#
-# if db-specific stats are desired, place their names in databases:
-#     databases: 'npm-registry animaldb'
+#     host: 'host'       # Server ip address or hostname. Default: 127.0.0.1
+#     port: port         # Beanstalkd port. Default:
 #
 # ----------------------------------------------------------------------
-# AUTO-DETECTION JOBS
-# only one of them will run (they have the same name)
-#
-localhost:
- name: 'local'
- host: '127.0.0.1'
- port: '5984'
- node: 'couchdb@127.0.0.1'
- scheme: 'http'
-# user: 'admin'
-# pass: 'password'

--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -41,6 +41,7 @@ BASE_CONFIG = {'update_every': os.getenv('NETDATA_UPDATE_EVERY', 1),
                'retries': 60,
                'priority': 60000,
                'autodetection_retry': 0,
+               'chart_cleanup': 10,
                'name': str()}
 
 
@@ -173,16 +174,14 @@ class Module(object):
                 initialized_job = self.service.Service(configuration=job_config)
             except Exception as error:
                 Logger.error("job initialization: '{module_name} {job_name}' "
-                             "=> [{status}] ({error})".format(status='FAILED',
-                                                              module_name=self.name,
+                             "=> ['FAILED'] ({error})".format(module_name=self.name,
                                                               job_name=job_name,
                                                               error=error))
                 continue
             else:
                 Logger.debug("job initialization: '{module_name} {job_name}' "
-                             "=> [{status}]".format(status='OK',
-                                                    module_name=self.name,
-                                                    job_name=job_name or self.name))
+                             "=> ['OK']".format(module_name=self.name,
+                                                job_name=job_name or self.name))
                 self.jobs[job_id] = Job(initialized_job=initialized_job,
                                         job_id=job_id)
         del self.config

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -14,6 +14,7 @@ dist_python_SCRIPTS = \
 dist_python_DATA = \
     README.md \
     apache.chart.py \
+    beanstalk.chart.py \
     bind_rndc.chart.py \
     chrony.chart.py \
     couchdb.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -125,13 +125,118 @@ If no configuration is given, module will attempt to read log file at `/var/log/
 
 ---
 
+# beanstalk
+
+Module monitors provides server and tube level statistics:
+
+**Requirements:**
+ * `python-beanstalkc`
+ * `python-yaml`
+
+**Server statistics:**
+
+1. **Cpu usage** in cpu time
+ * user
+ * system
+ 
+2. **Jobs rate** in jobs/s
+ * total
+ * timeouts
+ 
+3. **Connections rate** in connections/s
+ * connections
+ 
+4. **Commands rate** in commands/s
+ * put
+ * peek
+ * peek-ready
+ * peek-delayed
+ * peek-buried
+ * reserve
+ * use
+ * watch
+ * ignore
+ * delete
+ * release
+ * bury
+ * kick
+ * stats
+ * stats-job
+ * stats-tube
+ * list-tubes
+ * list-tube-used
+ * list-tubes-watched
+ * pause-tube
+ 
+5. **Current tubes** in tubes
+ * tubes
+ 
+6. **Current jobs** in jobs
+ * urgent
+ * ready
+ * reserved
+ * delayed
+ * buried
+ 
+7. **Current connections** in connections
+ * written
+ * producers
+ * workers
+ * waiting
+ 
+8. **Binlog** in records/s
+ * written
+ * migrated
+ 
+9. **Uptime** in seconds
+ * uptime
+
+**Per tube statistics:**
+
+1. **Jobs rate** in jobs/s
+ * jobs
+ 
+2. **Jobs** in jobs
+ * using
+ * ready
+ * reserved
+ * delayed
+ * buried
+
+3. **Connections** in connections
+ * using
+ * waiting
+ * watching
+
+4. **Commands** in commands/s
+ * deletes
+ * pauses
+ 
+5. **Pause** in seconds
+ * since
+ * left
+
+ 
+### configuration
+
+Sample:
+
+```yaml
+host         : '127.0.0.1'
+port         : 11300
+```
+
+If no configuration is given, module will attempt to connect to beanstalkd on `127.0.0.1:11300` address
+
+---
+
 # bind_rndc
 
 Module parses bind dump file to collect real-time performance metrics
 
 **Requirements:**
  * Version of bind must be 9.6 +
- * Netdata must have permissions to run `rndc status`
+ * Netdata must have permissions to run `rndc stats`
 
 It produces:
 

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -127,7 +127,7 @@ If no configuration is given, module will attempt to read log file at `/var/log/
 
 # beanstalk
 
-Module monitors provides server and tube level statistics:
+Module provides server and tube level statistics:
 
 **Requirements:**
  * `python-beanstalkc`

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# Description: beanstalk netdata python.d module
+# Author: l2isbad
+
+from collections import defaultdict
+from sys import version_info
+
+try:
+    import beanstalkc
+    BEANSTALKC = True
+except ImportError:
+    BEANSTALKC = False
+
+
+if version_info[:2] > (3, 1):
+    import pyyaml3 as yaml
+else:
+    import pyyaml2 as yaml
+
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+# default module values (can be overridden per job in `config`)
+# update_every = 2
+priority = 60000
+retries = 60
+
+
+def chart_template(name):
+    order = ['{0}_jobs_rate'.format(name),
+             '{0}_jobs'.format(name),
+             '{0}_connections'.format(name),
+             '{0}_commands'.format(name),
+             '{0}_pause'.format(name)
+             ]
+    family = 'tube {0}'.format(name)
+
+    charts = {
+        order[0]: {
+            'options': [None, 'Job Rate', 'jobs/s', family, 'beanstalk.jobs_rate', 'area'],
+            'lines': [
+                ['_'.join([name, 'total-jobs']), 'jobs', 'incremental']
+            ]},
+        order[1]: {
+            'options': [None, 'Jobs', 'jobs', family, 'beanstalk.jobs', 'stacked'],
+            'lines': [
+                ['_'.join([name, 'current-jobs-urgent']), 'urgent'],
+                ['_'.join([name, 'current-jobs-ready']), 'ready'],
+                ['_'.join([name, 'current-jobs-reserved']), 'reserved'],
+                ['_'.join([name, 'current-jobs-delayed']), 'delayed'],
+                ['_'.join([name, 'current-jobs-buried']), 'buried']
+            ]},
+        order[2]: {
+            'options': [None, 'Connections', 'connections', family, 'beanstalk.connections', 'stacked'],
+            'lines': [
+                ['_'.join([name, 'current-using']), 'using'],
+                ['_'.join([name, 'current-waiting']), 'waiting'],
+                ['_'.join([name, 'current-watching']), 'watching']
+            ]},
+        order[3]: {
+            'options': [None, 'Commands', 'command/s', family, 'beanstalk.commands', 'stacked'],
+            'lines': [
+                ['_'.join([name, 'cmd-delete']), 'deletes', 'incremental'],
+                ['_'.join([name, 'cmd-pause-tube']), 'pauses', 'incremental']
+            ]},
+        order[4]: {
+            'options': [None, 'Pause', 'seconds', family, 'beanstalk.pause', 'stacked'],
+            'lines': [
+                ['_'.join([name, 'pause']), 'since'],
+                ['_'.join([name, 'pause-time-left']), 'left']
+            ]}
+
+    }
+
+    return order, charts
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.configuration = configuration
+        self.conn = self.connect()
+        self.order = list()
+        self.definitions = dict()
+        self.alive = True
+
+    def check(self):
+        if not BEANSTALKC:
+            self.error("'beanstalkc' module is needed to use beanstalk.chart.py")
+            return False
+
+        if not self.conn:
+            return False
+
+        for tube in self.conn.tubes():
+            order, charts = chart_template(tube)
+            self.order.extend(order)
+            self.definitions.update(charts)
+
+        return bool(self.order)
+
+    def get_data(self):
+        """
+        Format data received from shell command
+        :return: dict
+        """
+        if not self.is_alive():
+            return None
+        else:
+            self.alive = True
+
+        tubes_stats, data = defaultdict(dict), dict()
+        try:
+            for tube in self.conn.tubes():
+                stats = self.conn.stats_tube(tube)
+                for stat in stats:
+                    dimension, value = '_'.join([tube, stat]),  stats[stat]
+                    tubes_stats[tube][dimension] = value
+        except beanstalkc.SocketError:
+            self.alive = False
+            return None
+
+        for tube in tubes_stats:
+            if tube + '_jobs' not in self.charts.active_charts():
+                self.create_new_tube_charts(tube)
+
+            data.update(tubes_stats[tube])
+
+        return data or None
+
+    def create_new_tube_charts(self, tube):
+        order, charts = chart_template(tube)
+
+        for chart_name in order:
+            params = [chart_name] + charts[chart_name]['options']
+            dimensions = charts[chart_name]['lines']
+
+            new_chart = self.charts.add_chart(params)
+            for dimension in dimensions:
+                new_chart.add_dimension(dimension)
+
+    def connect(self):
+        host = self.configuration.get('host', '127.0.0.1')
+        port = self.configuration.get('port', 11300)
+        try:
+            return beanstalkc.Connection(host=host,
+                                         port=port)
+        except beanstalkc.SocketError as error:
+            self.error('Connection to {0}:{1} failed: {2}'.format(host, port, error))
+            return None
+
+    def reconnect(self):
+        try:
+            self.conn.reconnect()
+            return True
+        except beanstalkc.SocketError:
+            return False
+
+    def is_alive(self):
+        if not self.alive:
+            return self.reconnect()
+        return True

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -214,8 +214,9 @@ class Service(SimpleService):
             self.alive = False
             return None
 
+        active_charts = self.charts.active_charts()
         for tube in tubes_stats:
-            if tube + '_jobs' not in self.charts.active_charts():
+            if tube + '_jobs_rate' not in active_charts:
                 self.create_new_tube_charts(tube)
 
             data.update(tubes_stats[tube])

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -48,7 +48,7 @@ CHARTS = {
         ]
     },
     'commands_rate': {
-        'options': [None, 'Commands Rate', 'command/s', 'statistics', 'beanstalk.commands_rate', 'stacked'],
+        'options': [None, 'Commands Rate', 'commands/s', 'statistics', 'beanstalk.commands_rate', 'stacked'],
         'lines': [
             ['cmd-put', 'put', 'incremental'],
             ['cmd-peek', 'peek', 'incremental'],

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -186,7 +186,6 @@ class Service(SimpleService):
 
     def get_data(self):
         """
-        Format data received from shell command
         :return: dict
         """
         if not self.is_alive():

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -3,7 +3,6 @@
 # Author: l2isbad
 
 from collections import defaultdict
-from sys import version_info
 
 try:
     import beanstalkc
@@ -11,12 +10,11 @@ try:
 except ImportError:
     BEANSTALKC = False
 
-
-if version_info[:2] > (3, 1):
-    import pyyaml3 as yaml
-else:
-    import pyyaml2 as yaml
-
+try:
+    import yaml
+    YAML = True
+except ImportError:
+    YAML = False
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
@@ -168,7 +166,7 @@ class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.configuration = configuration
-        self.conn = self.connect()
+        self.conn = None
         self.order = ORDER[:]
         self.definitions = dict(CHARTS)
         self.alive = True
@@ -177,6 +175,12 @@ class Service(SimpleService):
         if not BEANSTALKC:
             self.error("'beanstalkc' module is needed to use beanstalk.chart.py")
             return False
+
+        if not YAML:
+            self.error("'yaml' module is needed to use beanstalk.chart.py")
+            return False
+
+        self.conn = self.connect()
 
         if not self.conn:
             return False

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -236,9 +236,12 @@ class Service(SimpleService):
     def connect(self):
         host = self.configuration.get('host', '127.0.0.1')
         port = self.configuration.get('port', 11300)
+        timeout = self.configuration.get('timeout', 1)
         try:
             return beanstalkc.Connection(host=host,
-                                         port=port)
+                                         port=port,
+                                         connect_timeout=timeout,
+                                         parse_yaml=yaml.load)
         except beanstalkc.SocketError as error:
             self.error('Connection to {0}:{1} failed: {2}'.format(host, port, error))
             return None

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -145,7 +145,7 @@ def tube_chart_template(name):
                 ['_'.join([name, 'current-watching']), 'watching']
             ]},
         order[3]: {
-            'options': [None, 'Commands', 'command/s', family, 'beanstalk.commands', 'stacked'],
+            'options': [None, 'Commands', 'commands/s', family, 'beanstalk.commands', 'stacked'],
             'lines': [
                 ['_'.join([name, 'cmd-delete']), 'deletes', 'incremental'],
                 ['_'.join([name, 'cmd-pause-tube']), 'pauses', 'incremental']

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -42,7 +42,8 @@ CHARTS = {
         ]
     },
     'connections_rate': {
-        'options': [None, 'Connections Rate', 'connections/s', 'server statistics', 'beanstalk.connections_rate', 'area'],
+        'options': [None, 'Connections Rate', 'connections/s', 'server statistics', 'beanstalk.connections_rate',
+                    'area'],
         'lines': [
             ['total-connections', 'connections', 'incremental']
         ]

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -28,27 +28,27 @@ ORDER = ['cpu_usage', 'jobs_rate', 'connections_rate', 'commands_rate', 'current
 
 CHARTS = {
     'cpu_usage': {
-        'options': [None, 'Cpu Usage', 'cpu time', 'statistics', 'beanstalk.cpu_usage', 'area'],
+        'options': [None, 'Cpu Usage', 'cpu time', 'server statistics', 'beanstalk.cpu_usage', 'area'],
         'lines': [
             ['rusage-utime', 'user', 'incremental'],
             ['rusage-stime', 'system', 'incremental']
         ]
     },
     'jobs_rate': {
-        'options': [None, 'Jobs Rate', 'jobs/s', 'statistics', 'beanstalk.jobs_rate', 'line'],
+        'options': [None, 'Jobs Rate', 'jobs/s', 'server statistics', 'beanstalk.jobs_rate', 'line'],
         'lines': [
             ['total-jobs', 'total', 'incremental'],
             ['job-timeouts', 'timeouts', 'incremental']
         ]
     },
     'connections_rate': {
-        'options': [None, 'Connections Rate', 'connections/s', 'statistics', 'beanstalk.connections_rate', 'area'],
+        'options': [None, 'Connections Rate', 'connections/s', 'server statistics', 'beanstalk.connections_rate', 'area'],
         'lines': [
             ['total-connections', 'connections', 'incremental']
         ]
     },
     'commands_rate': {
-        'options': [None, 'Commands Rate', 'commands/s', 'statistics', 'beanstalk.commands_rate', 'stacked'],
+        'options': [None, 'Commands Rate', 'commands/s', 'server statistics', 'beanstalk.commands_rate', 'stacked'],
         'lines': [
             ['cmd-put', 'put', 'incremental'],
             ['cmd-peek', 'peek', 'incremental'],
@@ -73,13 +73,13 @@ CHARTS = {
         ]
     },
     'current_tubes': {
-        'options': [None, 'Current Tubes', 'tubes', 'statistics', 'beanstalk.current_tubes', 'area'],
+        'options': [None, 'Current Tubes', 'tubes', 'server statistics', 'beanstalk.current_tubes', 'area'],
         'lines': [
             ['current-tubes', 'tubes']
         ]
     },
     'current_jobs': {
-        'options': [None, 'Current Jobs', 'jobs', 'statistics', 'beanstalk.current_jobs', 'stacked'],
+        'options': [None, 'Current Jobs', 'jobs', 'server statistics', 'beanstalk.current_jobs', 'stacked'],
         'lines': [
             ['current-jobs-urgent', 'urgent'],
             ['current-jobs-ready', 'ready'],
@@ -89,7 +89,8 @@ CHARTS = {
         ]
     },
     'current_connections': {
-        'options': [None, 'Current Connections', 'connections', 'statistics', 'beanstalk.current_connections', 'line'],
+        'options': [None, 'Current Connections', 'connections', 'server statistics',
+                    'beanstalk.current_connections', 'line'],
         'lines': [
             ['current-connections', 'written'],
             ['current-producers', 'producers'],
@@ -98,14 +99,14 @@ CHARTS = {
         ]
     },
     'binlog': {
-        'options': [None, 'Binlog', 'records/s', 'statistics', 'beanstalk.binlog', 'line'],
+        'options': [None, 'Binlog', 'records/s', 'server statistics', 'beanstalk.binlog', 'line'],
         'lines': [
             ['binlog-records-written', 'written', 'incremental'],
             ['binlog-records-migrated', 'migrated', 'incremental']
         ]
     },
     'uptime': {
-        'options': [None, 'Uptime', 'seconds', 'statistics', 'beanstalk.uptime', 'line'],
+        'options': [None, 'Uptime', 'seconds', 'server statistics', 'beanstalk.uptime', 'line'],
         'lines': [
             ['uptime'],
             ]

--- a/python.d/bind_rndc.chart.py
+++ b/python.d/bind_rndc.chart.py
@@ -165,7 +165,7 @@ class Service(SimpleService):
                 if dimension_id not in self.data:
                     dimension = dimension_id.replace(chart_name[:9], '')
                     if dimension_id not in self.charts[chart_name]:
-                        self.charts[chart_name].add_dimension_and_push_chart([dimension_id, dimension, 'incremental'])
+                        self.charts[chart_name].add_dimension([dimension_id, dimension, 'incremental'])
 
                 self.data[dimension_id] = value
 

--- a/python.d/cpufreq.chart.py
+++ b/python.d/cpufreq.chart.py
@@ -14,7 +14,7 @@ ORDER = ['cpufreq']
 
 CHARTS = {
     'cpufreq': {
-        'options': [None, 'CPU Clock', 'MHz', 'cpufreq', 'cpufreq', 'line'],
+        'options': [None, 'CPU Clock', 'MHz', 'cpufreq', 'cpufreq.cpufreq', 'line'],
         'lines': [
             # lines are created dynamically in `check()` method
         ]}

--- a/python.d/cpuidle.chart.py
+++ b/python.d/cpuidle.chart.py
@@ -122,7 +122,7 @@ class Service(SimpleService):
                 self.order.append(orderid)
                 active_name = '%s_active_time' % (cpu,)
                 self.definitions[orderid] = {
-                    'options': [None, 'C-state residency', 'time%', 'cpuidle', 'cpuidle', 'stacked'],
+                    'options': [None, 'C-state residency', 'time%', 'cpuidle', 'cpuidle.cpuidle', 'stacked'],
                     'lines': [
                         [active_name, 'C0 (active)', 'percentage-of-incremental-row', 1, 1],
                     ],

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -37,7 +37,7 @@ class Service(SimpleService):
         dimension = ''.join(['random', str(random.randint(1, 3))])
 
         if dimension not in self.charts['random']:
-            self.charts['random'].add_dimension_and_push_chart([dimension])
+            self.charts['random'].add_dimension([dimension])
 
         self.data[dimension] = random.randint(0, 100)
 

--- a/python.d/example.chart.py
+++ b/python.d/example.chart.py
@@ -2,7 +2,7 @@
 # Description: example netdata python.d module
 # Author: Pawel Krupa (paulfantom)
 
-import random
+from random import SystemRandom
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
@@ -24,22 +24,24 @@ CHARTS = {
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
-        super(self.__class__, self).__init__(configuration=configuration, name=name)
+        SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
-        self.data = dict()
+        self.random = SystemRandom()
 
     @staticmethod
     def check():
         return True
 
     def get_data(self):
-        dimension = ''.join(['random', str(random.randint(1, 3))])
+        data = dict()
 
-        if dimension not in self.charts['random']:
-            self.charts['random'].add_dimension([dimension])
+        for i in range(1, 4):
+            dimension_id = ''.join(['random', str(i)])
 
-        self.data[dimension] = random.randint(0, 100)
+            if dimension_id not in self.charts['random']:
+                self.charts['random'].add_dimension([dimension_id])
 
-        return self.data
+            data[dimension_id] = self.random.randint(0, 100)
 
+        return data

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -84,7 +84,7 @@ class Service(SimpleService):
         self.sub_echo = [self.echo, RADIUS_MSG]
         self.sub_radclient = [self.radclient, '-r', '1', '-t', '1',
                               ':'.join([self.host, self.port]), 'status', self.secret]
-    
+
     def check(self):
         if not all([self.echo, self.radclient]):
             self.error('Can\'t locate "radclient" binary or binary is not executable by netdata')

--- a/python.d/memcached.chart.py
+++ b/python.d/memcached.chart.py
@@ -149,7 +149,6 @@ class Service(SocketService):
                     data[t[0]] = t[1]
                 except (IndexError, ValueError):
                     self.debug("invalid line received: " + str(line))
-                    pass
 
         if not data:
             self.error("received data doesn't have any records")

--- a/python.d/mysql.chart.py
+++ b/python.d/mysql.chart.py
@@ -6,7 +6,7 @@ from bases.FrameworkServices.MySQLService import MySQLService
 
 # default module values (can be overridden per job in `config`)
 # update_every = 3
-priority = 90000
+priority = 60000
 retries = 60
 
 # query executed on MySQL server

--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -225,7 +225,7 @@ CHARTS = {
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
-        super(self.__class__, self).__init__(configuration=configuration, name=name)
+        SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER[:]
         self.definitions = deepcopy(CHARTS)
         self.table_stats = configuration.pop('table_stats', False)

--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -17,7 +17,7 @@ from bases.FrameworkServices.SimpleService import SimpleService
 
 # default module values
 update_every = 1
-priority = 90000
+priority = 60000
 retries = 60
 
 METRICS = dict(

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -211,7 +211,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
                 continue
             elif self.charts.cleanup and chart.penalty >= self.charts.cleanup:
                 chart.obsolete()
-                self.error("chart '{0}' was removed due to non updating".format(chart.name))
+                self.error("chart '{0}' was suppressed due to non updating".format(chart.name))
                 continue
 
             ok = chart.update(data, interval)

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -208,20 +208,23 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
 
         for chart in self.charts:
 
-            if chart.flags.OBSOLETE:
+            if chart.flags.obsoleted:
                 continue
-            elif chart.cleanup and chart.penalty > chart.cleanup:
-                chart.push_obsolete()
+            elif self.charts.cleanup and chart.penalty >= self.charts.cleanup:
+                chart.obsolete()
                 self.error("chart '{0}' was removed due to non updating".format(chart.name))
                 continue
 
-            since_last = 0 if chart.flags.NEW else interval
+            since_last = 0 if chart.flags.new else interval
             ok = chart.update(data, since_last)
             if ok:
+                chart.penalty = 0
                 updated = True
+            else:
+                chart.penalty += 1
 
         if not updated:
-            self.debug('none of the charts have been updated')
+            self.debug('none of the charts has been updated')
 
         return updated
 

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -216,11 +216,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
 
             ok = chart.update(data, interval)
             if ok:
-                chart.penalty = 0
                 updated = True
-            else:
-                chart.flags.new = True
-                chart.penalty += 1
 
         if not updated:
             self.debug('none of the charts has been updated')

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -65,7 +65,8 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
         self.charts = Charts(job_name=self.actual_name,
                              priority=configuration.pop('priority'),
                              cleanup=configuration.pop('chart_cleanup'),
-                             get_update_every=self.get_update_every)
+                             get_update_every=self.get_update_every,
+                             module_name=self.module_name)
 
     def __repr__(self):
         return '<{cls_bases}: {name}>'.format(cls_bases=', '.join(c.__name__ for c in self.__class__.__bases__),

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -227,11 +227,12 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
         return updated
 
     def manage_retries(self):
-        self._runtime_counters.RETRIES += 1
-        if self._runtime_counters.RETRIES % 5 == 0:
-            self._runtime_counters.PENALTY = int(self._runtime_counters.RETRIES * self.update_every / 2)
-        if self._runtime_counters.RETRIES >= self._runtime_counters.RETRIES_MAX:
-            self.error('stopped after {0} data collection failures in a row'.format(self._runtime_counters.RETRIES_MAX))
+        rc = self._runtime_counters
+        rc.RETRIES += 1
+        if rc.RETRIES % 5 == 0:
+            rc.PENALTY = int(rc.RETRIES * self.update_every / 2)
+        if rc.RETRIES >= rc.RETRIES_MAX:
+            self.error('stopped after {0} data collection failures in a row'.format(rc.RETRIES_MAX))
             return False
         return True
 

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -208,14 +208,14 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
 
         for chart in self.charts:
 
-            if chart.flags.obsolete:
+            if chart.flags.OBSOLETE:
                 continue
             elif chart.cleanup and chart.penalty > chart.cleanup:
                 chart.push_obsolete()
                 self.error("chart '{0}' was removed due to non updating".format(chart.name))
                 continue
 
-            since_last = 0 if chart.flags.new else interval
+            since_last = 0 if chart.flags.NEW else interval
             ok = chart.update(data, since_last)
             if ok:
                 updated = True

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -215,8 +215,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
                 self.error("chart '{0}' was removed due to non updating".format(chart.name))
                 continue
 
-            since_last = 0 if chart.flags.new else interval
-            ok = chart.update(data, since_last)
+            ok = chart.update(data, interval)
             if ok:
                 chart.penalty = 0
                 updated = True

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -219,6 +219,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
                 chart.penalty = 0
                 updated = True
             else:
+                chart.flags.new = True
                 chart.penalty += 1
 
         if not updated:

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -207,7 +207,6 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
         updated = False
 
         for chart in self.charts:
-
             if chart.flags.obsoleted:
                 continue
             elif self.charts.cleanup and chart.penalty >= self.charts.cleanup:

--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -14,8 +14,6 @@ from bases.charts import Charts, ChartError, create_runtime_chart
 from bases.collection import OldVersionCompatibility, safe_print
 from bases.loggers import PythonDLimitedLogger
 
-CHART_OBSOLETE_PENALTY = 10
-
 RUNTIME_CHART_UPDATE = 'BEGIN netdata.runtime_{job_name} {since_last}\n' \
                        'SET run_time = {elapsed}\n' \
                        'END\n'
@@ -66,6 +64,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
         self._runtime_counters = RuntimeCounters(configuration=configuration)
         self.charts = Charts(job_name=self.actual_name,
                              priority=configuration.pop('priority'),
+                             cleanup=configuration.pop('chart_cleanup'),
                              get_update_every=self.get_update_every)
 
     def __repr__(self):
@@ -211,7 +210,7 @@ class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, objec
 
             if chart.flags.obsolete:
                 continue
-            elif chart.penalty > CHART_OBSOLETE_PENALTY:
+            elif chart.cleanup and chart.penalty > chart.cleanup:
                 chart.push_obsolete()
                 self.error("chart '{0}' was removed due to non updating".format(chart.name))
                 continue

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -218,7 +218,7 @@ class Chart:
         for var in self.variables:
             value = var.get_value(data)
             if value is not None:
-                updated_variables += var.set(var.get_value(data))
+                updated_variables += var.set(value)
 
         if updated_dimensions:
             if self.flags.create:

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -131,7 +131,7 @@ class Charts:
         return new_chart
 
     def active_charts(self):
-        return [chart.id for chart in self if not chart.flags.obsolete]
+        return [chart.id for chart in self if not chart.flags.OBSOLETE]
 
 
 class Chart:
@@ -207,7 +207,7 @@ class Chart:
         return chart + dimensions + variables
 
     def push_obsolete(self):
-        self.flags.obsolete = True
+        self.flags.OBSOLETE = True
         safe_print(CHART_OBSOLETE.format(**self.params))
 
     def update(self, data, since_last):
@@ -230,7 +230,7 @@ class Chart:
                 updated_variables += var.set(value)
 
         if updated_dimensions:
-            if self.flags.push:
+            if self.flags.PUSH:
                 self.push_created()
 
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
@@ -242,8 +242,8 @@ class Chart:
 
     def push_created(self):
         self.penalty = 0
-        self.flags.push = False
-        self.flags.new = False
+        self.flags.PUSH = False
+        self.flags.NEW = False
         safe_print(self.create())
 
     @staticmethod
@@ -252,10 +252,10 @@ class Chart:
 
     def refresh(self):
         self.penalty = 0
-        self.flags.push = True
-        if self.flags.obsolete:
-            self.flags.new = True
-        self.flags.obsolete = False
+        self.flags.PUSH = True
+        if self.flags.OBSOLETE:
+            self.flags.NEW = True
+        self.flags.OBSOLETE = False
 
 
 class Dimension:
@@ -353,6 +353,6 @@ class ChartVariable:
 
 class ChartFlags:
     def __init__(self):
-        self.new = True
-        self.obsolete = False
-        self.push = True
+        self.NEW = True
+        self.OBSOLETE = False
+        self.PUSH = True

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -207,7 +207,7 @@ class Chart:
 
         safe_print(chart + dimensions + variables)
 
-    def update(self, data, since_last):
+    def update(self, data, interval):
         updated_dimensions, updated_variables = str(), str()
 
         for dim in self.dimensions:
@@ -224,6 +224,7 @@ class Chart:
             if self.flags.create:
                 self.create()
 
+            since_last = 0 if self.flags.new else interval
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
             safe_print(chart_begin, updated_dimensions, updated_variables, 'END\n')
 

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -13,7 +13,7 @@ DIMENSION_ALGORITHMS = ['absolute', 'incremental', 'percentage-of-absolute-row',
 
 CHART_BEGIN = 'BEGIN {type}.{id} {since_last}\n'
 CHART_CREATE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{context}' " \
-               "{chart_type} {priority} {update_every}\n"
+               "{chart_type} {priority} {update_every} '' 'python.d.plugin' '{module_name}'\n"
 CHART_OBSOLETE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{context}' " \
                "{chart_type} {priority} {update_every} 'obsolete'\n"
 
@@ -71,7 +71,7 @@ class Charts:
     All charts stored in a dict.
     Chart is a instance of Chart class.
     Charts adding must be done using Charts.add_chart() method only"""
-    def __init__(self, job_name, priority, cleanup, get_update_every):
+    def __init__(self, job_name, priority, cleanup, get_update_every, module_name):
         """
         :param job_name: <bound method>
         :param priority: <int>
@@ -81,6 +81,7 @@ class Charts:
         self.priority = priority
         self.cleanup = cleanup
         self.get_update_every = get_update_every
+        self.module_name = module_name
         self.charts = dict()
 
     def __len__(self):
@@ -123,6 +124,7 @@ class Charts:
 
         new_chart.params['update_every'] = self.get_update_every()
         new_chart.params['priority'] = self.priority
+        new_chart.params['module_name'] = self.module_name
 
         self.priority += 1
         self.charts[new_chart.id] = new_chart

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -211,10 +211,14 @@ class Chart:
         updated_dimensions, updated_variables = str(), str()
 
         for dim in self.dimensions:
-            updated_dimensions += dim.set(dim.get_value(data))
+            value = dim.get_value(data)
+            if value is not None:
+                updated_dimensions += dim.set(value)
 
         for var in self.variables:
-            updated_variables += var.set(var.get_value(data))
+            value = var.get_value(data)
+            if value is not None:
+                updated_variables += var.set(var.get_value(data))
 
         if updated_dimensions:
             if self.flags.create:
@@ -288,7 +292,7 @@ class Dimension:
         try:
             return int(data[self.id])
         except (KeyError, TypeError):
-            return ''
+            return None
 
 
 class ChartVariable:
@@ -340,7 +344,7 @@ class ChartVariable:
         try:
             return int(data[self.id])
         except (KeyError, TypeError):
-            return ''
+            return None
 
 
 class ChartFlags:

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -202,7 +202,7 @@ class Chart:
         chart = CHART_CREATE.format(**self.params)
         dimensions = ''.join([dimension.create() for dimension in self.dimensions])
         variables = ''.join([var.set(var.value) for var in self.variables if var])
-        self.flags.new = False
+
         self.flags.create = False
 
         safe_print(chart + dimensions + variables)
@@ -228,7 +228,12 @@ class Chart:
 
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
             safe_print(chart_begin, updated_dimensions, updated_variables, 'END\n')
+
             self.flags.new = False
+            self.penalty = 0
+        else:
+            self.penalty += 1
+            self.flags.new = True
 
         return bool(updated_dimensions)
 
@@ -240,8 +245,6 @@ class Chart:
     def refresh(self):
         self.penalty = 0
         self.flags.create = True
-        if self.flags.obsoleted:
-            self.flags.new = True
         self.flags.obsoleted = False
 
 

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -123,7 +123,7 @@ class Charts:
 
         new_chart.params['update_every'] = self.get_update_every()
         new_chart.params['priority'] = self.priority
-        new_chart.params['cleanup'] = self.cleanup
+        new_chart.cleanup = self.cleanup
 
         self.priority += 1
         self.charts[new_chart.id] = new_chart

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -251,6 +251,7 @@ class Chart:
         safe_print(''.join(data))
 
     def refresh(self):
+        self.penalty = 0
         self.flags.push = True
         if self.flags.obsolete:
             self.flags.new = True

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -71,7 +71,7 @@ class Charts:
     All charts stored in a dict.
     Chart is a instance of Chart class.
     Charts adding must be done using Charts.add_chart() method only"""
-    def __init__(self, job_name, priority, get_update_every):
+    def __init__(self, job_name, priority, cleanup, get_update_every):
         """
         :param job_name: <bound method>
         :param priority: <int>
@@ -79,6 +79,7 @@ class Charts:
         """
         self.job_name = job_name
         self.priority = priority
+        self.cleanup = cleanup
         self.get_update_every = get_update_every
         self.charts = dict()
 
@@ -119,8 +120,11 @@ class Charts:
         """
         params = [self.job_name()] + params
         new_chart = Chart(params)
+
         new_chart.params['update_every'] = self.get_update_every()
         new_chart.params['priority'] = self.priority
+        new_chart.params['cleanup'] = self.cleanup
+
         self.priority += 1
         self.charts[new_chart.id] = new_chart
 

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -203,7 +203,8 @@ class Chart:
         dimensions = ''.join([dimension.create() for dimension in self.dimensions])
         variables = ''.join([var.set(var.value) for var in self.variables if var])
 
-        self.flags.create = False
+        self.flags.push = False
+        self.flags.created = True
 
         safe_print(chart + dimensions + variables)
 
@@ -221,30 +222,30 @@ class Chart:
                 updated_variables += var.set(value)
 
         if updated_dimensions:
-            since_last = 0 if self.flags.new else interval
+            since_last = interval if self.flags.updated else 0
 
-            if self.flags.create:
+            if self.flags.push:
                 self.create()
 
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
             safe_print(chart_begin, updated_dimensions, updated_variables, 'END\n')
 
-            self.flags.new = False
+            self.flags.updated = True
             self.penalty = 0
         else:
             self.penalty += 1
-            self.flags.new = True
+            self.flags.updated = False
 
         return bool(updated_dimensions)
 
     def obsolete(self):
         self.flags.obsoleted = True
-        if not self.flags.new:
+        if self.flags.created:
             safe_print(CHART_OBSOLETE.format(**self.params))
 
     def refresh(self):
         self.penalty = 0
-        self.flags.create = True
+        self.flags.push = True
         self.flags.obsoleted = False
 
 
@@ -355,6 +356,7 @@ class ChartVariable:
 
 class ChartFlags:
     def __init__(self):
-        self.new = True
-        self.create = True
+        self.push = True
+        self.created = False
+        self.updated = False
         self.obsoleted = False

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -221,10 +221,11 @@ class Chart:
                 updated_variables += var.set(value)
 
         if updated_dimensions:
+            since_last = 0 if self.flags.new else interval
+
             if self.flags.create:
                 self.create()
 
-            since_last = 0 if self.flags.new else interval
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
             safe_print(chart_begin, updated_dimensions, updated_variables, 'END\n')
 

--- a/python.d/python_modules/bases/charts.py
+++ b/python.d/python_modules/bases/charts.py
@@ -228,6 +228,7 @@ class Chart:
 
             chart_begin = CHART_BEGIN.format(type=self.type, id=self.id, since_last=since_last)
             safe_print(chart_begin, updated_dimensions, updated_variables, 'END\n')
+            self.flags.new = False
 
         return bool(updated_dimensions)
 

--- a/python.d/python_modules/bases/collection.py
+++ b/python.d/python_modules/bases/collection.py
@@ -52,12 +52,12 @@ def static_vars(**kwargs):
 
 
 @on_try_except_finally(on_except=(exit, 1))
-def safe_print(msg):
+def safe_print(*msg):
     """
-    :param msg: <str>
+    :param msg:
     :return:
     """
-    print(msg)
+    print(''.join(msg))
 
 
 def find_binary(binary):

--- a/python.d/redis.chart.py
+++ b/python.d/redis.chart.py
@@ -143,7 +143,6 @@ class Service(SocketService):
                 data[t[0]] = t[1]
             except (IndexError, ValueError):
                 self.debug("invalid line received: " + str(line))
-                pass
 
         if not data:
             self.error("received data doesn't have any records")

--- a/python.d/varnish.chart.py
+++ b/python.d/varnish.chart.py
@@ -2,7 +2,7 @@
 # Description:  varnish netdata python.d module
 # Author: l2isbad
 
-from re import compile
+import re
 from subprocess import Popen, PIPE
 
 from bases.collection import find_binary
@@ -15,71 +15,89 @@ retries = 60
 
 ORDER = ['session', 'hit_rate', 'chit_rate', 'expunge', 'threads', 'backend_health', 'memory_usage', 'bad', 'uptime']
 
-CHARTS = {'backend_health': 
-             {'lines': [['backend_conn', 'conn', 'incremental', 1, 1],
-                       ['backend_unhealthy', 'unhealthy', 'incremental', 1, 1],
-                       ['backend_busy', 'busy', 'incremental', 1, 1],
-                       ['backend_fail', 'fail', 'incremental', 1, 1],
-                       ['backend_reuse', 'reuse', 'incremental', 1, 1],
-                       ['backend_recycle', 'resycle', 'incremental', 1, 1],
-                       ['backend_toolate', 'toolate', 'incremental', 1, 1],
-                       ['backend_retry', 'retry', 'incremental', 1, 1],
-                       ['backend_req', 'req', 'incremental', 1, 1]],
-              'options': [None, 'Backend health', 'connections', 'Backend health', 'varnish.backend_traf', 'line']},
-          'bad': 
-             {'lines': [['sess_drop_b', None, 'incremental', 1, 1],
-                       ['backend_unhealthy_b', None, 'incremental', 1, 1],
-                       ['fetch_failed', None, 'incremental', 1, 1],
-                       ['backend_busy_b', None, 'incremental', 1, 1],
-                       ['threads_failed_b', None, 'incremental', 1, 1],
-                       ['threads_limited_b', None, 'incremental', 1, 1],
-                       ['threads_destroyed_b', None, 'incremental', 1, 1],
-                       ['thread_queue_len_b', 'queue_len', 'absolute', 1, 1],
-                       ['losthdr_b', None, 'incremental', 1, 1],
-                       ['esi_errors_b', None, 'incremental', 1, 1],
-                       ['esi_warnings_b', None, 'incremental', 1, 1],
-                       ['sess_fail_b', None, 'incremental', 1, 1],
-                       ['sc_pipe_overflow_b', None, 'incremental', 1, 1],
-                       ['sess_pipe_overflow_b', None, 'incremental', 1, 1]],
-              'options': [None, 'Misbehavior', 'problems', 'Problems summary', 'varnish.bad', 'line']},
-          'expunge':
-             {'lines': [['n_expired', 'expired', 'incremental', 1, 1],
-                       ['n_lru_nuked', 'lru_nuked', 'incremental', 1, 1]],
-              'options': [None, 'Object expunging', 'objects', 'Cache performance', 'varnish.expunge', 'line']},
-          'hit_rate': 
-             {'lines': [['cache_hit_perc', 'hit', 'absolute', 1, 100],
-                       ['cache_miss_perc', 'miss', 'absolute', 1, 100],
-                       ['cache_hitpass_perc', 'hitpass', 'absolute', 1, 100]],
-              'options': [None, 'All history hit rate ratio','percent', 'Cache performance',
-                          'varnish.hit_rate', 'stacked']},
-          'chit_rate': 
-             {'lines': [['cache_hit_cperc', 'hit', 'absolute', 1, 100],
-                       ['cache_miss_cperc', 'miss', 'absolute', 1, 100],
-                       ['cache_hitpass_cperc', 'hitpass', 'absolute', 1, 100]],
-              'options': [None, 'Current poll hit rate ratio','percent', 'Cache performance',
-                          'varnish.chit_rate', 'stacked']},
-          'memory_usage': 
-             {'lines': [['s0.g_space', 'available', 'absolute', 1, 1048576],
-                       ['s0.g_bytes', 'allocated', 'absolute', -1, 1048576]],
-              'options': [None, 'Memory usage', 'megabytes', 'Memory usage', 'varnish.memory_usage', 'stacked']},
-          'session': 
-             {'lines': [['sess_conn', 'sess_conn', 'incremental', 1, 1],
-                       ['client_req', 'client_requests', 'incremental', 1, 1],
-                       ['client_conn', 'client_conn', 'incremental', 1, 1],
-                       ['client_drop', 'client_drop', 'incremental', 1, 1],
-                       ['sess_dropped', 'sess_dropped', 'incremental', 1, 1]],
-              'options': [None, 'Sessions', 'units', 'Client metrics', 'varnish.session', 'line']},
-          'threads': 
-             {'lines': [['threads', None, 'absolute', 1, 1],
-                       ['threads_created', 'created', 'incremental', 1, 1],
-                       ['threads_failed', 'failed', 'incremental', 1, 1],
-                       ['threads_limited', 'limited', 'incremental', 1, 1],
-                       ['thread_queue_len', 'queue_len', 'incremental', 1, 1],
-                       ['sess_queued', 'sess_queued', 'incremental', 1, 1]],
-              'options': [None, 'Thread status', 'threads', 'Thread-related metrics', 'varnish.threads', 'line']},
-          'uptime': 
-             {'lines': [['uptime', None, 'absolute', 1, 1]],
-              'options': [None, 'Varnish uptime', 'seconds', 'Uptime', 'varnish.uptime', 'line']}
+CHARTS = {
+    'backend_health': {
+        'lines': [
+            ['backend_conn', 'conn', 'incremental', 1, 1],
+            ['backend_unhealthy', 'unhealthy', 'incremental', 1, 1],
+            ['backend_busy', 'busy', 'incremental', 1, 1],
+            ['backend_fail', 'fail', 'incremental', 1, 1],
+            ['backend_reuse', 'reuse', 'incremental', 1, 1],
+            ['backend_recycle', 'resycle', 'incremental', 1, 1],
+            ['backend_toolate', 'toolate', 'incremental', 1, 1],
+            ['backend_retry', 'retry', 'incremental', 1, 1],
+            ['backend_req', 'req', 'incremental', 1, 1]],
+        'options': [None, 'Backend Health', 'connections/s', 'backend health', 'varnish.backend_health', 'line']
+    },
+    'bad': {
+        'lines': [
+            ['sess_drop_b', None, 'incremental', 1, 1],
+            ['backend_unhealthy_b', None, 'incremental', 1, 1],
+            ['fetch_failed', None, 'incremental', 1, 1],
+            ['backend_busy_b', None, 'incremental', 1, 1],
+            ['threads_failed_b', None, 'incremental', 1, 1],
+            ['threads_limited_b', None, 'incremental', 1, 1],
+            ['threads_destroyed_b', None, 'incremental', 1, 1],
+            ['thread_queue_len_b', 'queue_len', 'absolute', 1, 1],
+            ['losthdr_b', None, 'incremental', 1, 1],
+            ['esi_errors_b', None, 'incremental', 1, 1],
+            ['esi_warnings_b', None, 'incremental', 1, 1],
+            ['sess_fail_b', None, 'incremental', 1, 1],
+            ['sc_pipe_overflow_b', None, 'incremental', 1, 1],
+            ['sess_pipe_overflow_b', None, 'incremental', 1, 1]],
+        'options': [None, 'Misbehavior', 'problems/s', 'problems summary', 'varnish.bad', 'line']
+    },
+    'expunge': {
+        'lines': [
+            ['n_expired', 'expired', 'incremental', 1, 1],
+            ['n_lru_nuked', 'lru_nuked', 'incremental', 1, 1]],
+        'options': [None, 'Object expunging', 'objects/s', 'cache performance', 'varnish.expunge', 'line']
+    },
+    'hit_rate': {
+        'lines': [
+            ['cache_hit_perc', 'hit', 'absolute', 1, 100],
+            ['cache_miss_perc', 'miss', 'absolute', 1, 100],
+            ['cache_hitpass_perc', 'hitpass', 'absolute', 1, 100]],
+        'options': [None, 'All History Hit Rate Ratio', 'percent', 'cache performance', 'varnish.hit_rate', 'stacked']
+    },
+    'chit_rate': {
+        'lines': [
+            ['cache_hit_cperc', 'hit', 'absolute', 1, 100],
+            ['cache_miss_cperc', 'miss', 'absolute', 1, 100],
+            ['cache_hitpass_cperc', 'hitpass', 'absolute', 1, 100]],
+        'options': [None, 'Current Poll Hit Rate Ratio', 'percent', 'cache performance', 'varnish.chit_rate', 'stacked']
+    },
+    'memory_usage': {
+        'lines': [
+            ['s0.g_space', 'available', 'absolute', 1, 1 << 20],
+            ['s0.g_bytes', 'allocated', 'absolute', -1, 1 << 20]],
+        'options': [None, 'Memory Usage', 'megabytes', 'memory usage', 'varnish.memory_usage', 'stacked']
+    },
+    'session': {
+        'lines': [
+            ['sess_conn', 'sess_conn', 'incremental', 1, 1],
+            ['client_req', 'client_requests', 'incremental', 1, 1],
+            ['client_conn', 'client_conn', 'incremental', 1, 1],
+            ['client_drop', 'client_drop', 'incremental', 1, 1],
+            ['sess_dropped', 'sess_dropped', 'incremental', 1, 1]],
+        'options': [None, 'Sessions', 'units/s', 'client metrics', 'varnish.session', 'line']
+    },
+    'threads': {
+        'lines': [
+            ['threads', None, 'absolute', 1, 1],
+            ['threads_created', 'created', 'incremental', 1, 1],
+            ['threads_failed', 'failed', 'incremental', 1, 1],
+            ['threads_limited', 'limited', 'incremental', 1, 1],
+            ['thread_queue_len', 'queue_len', 'incremental', 1, 1],
+            ['sess_queued', 'sess_queued', 'incremental', 1, 1]],
+        'options': [None, 'Thread Status', 'threads/s', 'thread related metrics', 'varnish.threads', 'line']
+    },
+    'uptime': {
+        'lines': [
+            ['uptime', None, 'absolute', 1, 1]
+        ],
+        'options': [None, 'Uptime', 'seconds', 'uptime', 'varnish.uptime', 'line']
+    }
 }
 
 
@@ -93,8 +111,8 @@ class Service(SimpleService):
         # or
         # VBE.default2(127.0.0.2,,81).bereq_bodybytes (old)
         # Regex result: [('super_backend', 'beresp_hdrbytes', '0'), ('super_backend', 'beresp_bodybytes', '0')]
-        self.rgx_bck = (compile(r'VBE.([\d\w_.]+)\(.*?\).(beresp[\w_]+)\s+(\d+)'),
-                        compile(r'VBE\.[\d\w-]+\.([\w\d_]+).(beresp[\w_]+)\s+(\d+)'))
+        self.rgx_bck = (re.compile(r'VBE.([\d\w_.]+)\(.*?\).(beresp[\w_]+)\s+(\d+)'),
+                        re.compile(r'VBE\.[\d\w-]+\.([\w\d_]+).(beresp[\w_]+)\s+(\d+)'))
         self.cache_prev = list()
 
     def check(self):
@@ -107,7 +125,7 @@ class Service(SimpleService):
         # 1. STDOUT is not empty
         reply = self._get_raw_data()
         if not reply:
-            self.error('No output from \'varnishstat\' (not enough privileges?)')
+            self.error("No output from 'varnishstat' (not enough privileges?)")
             return False
 
         # 2. Output is parsable (list is not empty after regex findall)
@@ -124,10 +142,9 @@ class Service(SimpleService):
             self.backend_list = self.rgx_bck[1].findall(reply)[::2]
             self.rgx_bck = self.rgx_bck[1]
 
-        # We are about to start!
         self.create_charts()
         return True
-     
+
     def _get_raw_data(self):
         try:
             reply = Popen([self.varnish, '-1'], stdout=PIPE, stderr=PIPE, shell=False)

--- a/python.d/varnish.chart.py
+++ b/python.d/varnish.chart.py
@@ -105,6 +105,8 @@ class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.varnish = find_binary('varnishstat')
+        self.order = ORDER[:]
+        self.definitions = dict(CHARTS)
         self.regex_all = re.compile(r'([A-Z]+\.)?([\d\w_.]+)\s+(\d+)')
         self.regex_backend = None
         self.cache_prev = list()
@@ -218,10 +220,6 @@ class Service(SimpleService):
         return to_netdata
 
     def create_charts(self):
-        self.order = ORDER[:]
-        self.definitions = CHARTS
- 
-        # Create dynamic backend charts
         if self.backend_list:
             for backend in self.backend_list:
                 self.order.insert(0, ''.join([backend[0], '_resp_stats']))

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -639,18 +639,18 @@ class Web:
         # requests per http method
         if match_dict.get('method'):
             if match_dict['method'] not in self.data:
-                self.charts['http_method'].add_dimension_and_push_chart([match_dict['method'],
-                                                                         match_dict['method'],
-                                                                         'incremental'])
+                self.charts['http_method'].add_dimension([match_dict['method'],
+                                                          match_dict['method'],
+                                                          'incremental'])
                 self.data[match_dict['method']] = 0
             self.data[match_dict['method']] += 1
         # requests per http version
         if match_dict.get('http_version'):
             dim_id = match_dict['http_version'].replace('.', '_')
             if dim_id not in self.data:
-                self.charts['http_version'].add_dimension_and_push_chart([dim_id,
-                                                                         match_dict['http_version'],
-                                                                         'incremental'])
+                self.charts['http_version'].add_dimension([dim_id,
+                                                           match_dict['http_version'],
+                                                           'incremental'])
                 self.data[dim_id] = 0
             self.data[dim_id] += 1
 
@@ -662,12 +662,12 @@ class Web:
         """
         if code not in self.data:
             if self.configuration.get('detailed_response_aggregate', True):
-                self.charts['detailed_response_codes'].add_dimension_and_push_chart([code, code, 'incremental'])
+                self.charts['detailed_response_codes'].add_dimension([code, code, 'incremental'])
                 self.data[code] = 0
             else:
                 code_index = int(code[0]) if int(code[0]) < 6 else 6
                 chart_key = 'detailed_response_codes' + DET_RESP_AGGR[code_index]
-                self.charts[chart_key].add_dimension_and_push_chart([code, code, 'incremental'])
+                self.charts[chart_key].add_dimension([code, code, 'incremental'])
                 self.data[code] = 0
         self.data[code] += 1
 
@@ -835,9 +835,9 @@ class Squid:
                     dimension_id = values['func_dim_id'](match[key]) if values['func_dim_id'] else match[key]
                     if dimension_id not in self.data:
                         dimension = values['func_dim'](match[key]) if values['func_dim'] else dimension_id
-                        self.charts[values['chart']].add_dimension_and_push_chart([dimension_id,
-                                                                                   dimension,
-                                                                                   'incremental'])
+                        self.charts[values['chart']].add_dimension([dimension_id,
+                                                                    dimension,
+                                                                    'incremental'])
                         self.data[dimension_id] = 0
                     self.data[dimension_id] += 1
             else:
@@ -872,7 +872,7 @@ class Squid:
         :return:
         """
         if code not in self.data:
-            self.charts['squid_code'].add_dimension_and_push_chart([code, code, 'incremental'])
+            self.charts['squid_code'].add_dimension([code, code, 'incremental'])
             self.data[code] = 0
         self.data[code] += 1
 
@@ -883,7 +883,7 @@ class Squid:
                 continue
             dimension_id = '_'.join(['code_detailed', tag])
             if dimension_id not in self.data:
-                self.charts[chart_key].add_dimension_and_push_chart([dimension_id, tag, 'incremental'])
+                self.charts[chart_key].add_dimension([dimension_id, tag, 'incremental'])
                 self.data[dimension_id] = 0
             self.data[dimension_id] += 1
 


### PR DESCRIPTION
~~WIP~~
~~not really tested~~
~~only tube stats for now~~

fixes #2831 
fixes #2820 

> Ideally this should be configurable per module job. For example, user A knows that its tubes are permanent, so no cleanup. But user B knows that its app creates tubes for some time and then it closes them. So, a job configuration like:
> 
> cleanup: 0 to disable or false, or N seconds

[global variable](https://github.com/l2isbad/netdata/blob/beanstalk_module/plugins.d/python.d.plugin#L40-L45) `chart_cleanup` option added. Can be specified per module/job.
