### PR TITLE
Add an armv7hf docker build

### DIFF
--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -1,12 +1,11 @@
 # author  : titpetric
 # original: https://github.com/titpetric/netdata
 
-FROM debian:jessie
+FROM resin/armv7hf-debian:jessie
+
+RUN [ "cross-build-start"]
 
 ADD . /netdata.git
-
-RUN echo "deb http://ftp.nl.debian.org/debian/ jessie main" > /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
 
 RUN cd ./netdata.git && chmod +x ./docker-build.sh && sync && sleep 1 && ./docker-build.sh
 
@@ -16,3 +15,5 @@ ENV NETDATA_PORT 19999
 EXPOSE $NETDATA_PORT
 
 CMD /usr/sbin/netdata -D -s /host -p ${NETDATA_PORT}
+
+RUN [ "cross-build-end"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -8,9 +8,6 @@ DEBIAN_FRONTEND=noninteractive
 
 # some mirrors have issues, i skipped httpredir in favor of an eu mirror
 
-echo "deb http://ftp.nl.debian.org/debian/ jessie main" > /etc/apt/sources.list
-echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
-
 # install dependencies for build
 
 apt-get -qq update


### PR DESCRIPTION
Added a `Dockerfile.armv7hf` that can build on Docker Hub and runs on armv7hf devices (RPI1/2/3, etc).

Tested with a build run on OSX and Dockerhub and running on an Asus Tinkerboard.

Autobuild for testing is available as [justin8/netdata:armv7hf](https://hub.docker.com/r/justin8/netdata/)