### PR TITLE
Switch from pd-send to curl for pagerduty notifications

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -346,10 +346,6 @@ KAFKA_SENDER_IP=""
 
 #------------------------------------------------------------------------------
 # pagerduty.com notification options
-#
-# pagerduty.com notifications require the pagerduty agent to be installed and 
-# a "Generic API" pagerduty service.
-# https://www.pagerduty.com/docs/guides/agent-install-guide/
 
 # multiple recipients can be given like this:
 #              "<pd_service_key_1> <pd_service_key_2> ..."


### PR DESCRIPTION
Currently uses pd-send which needs to be installed on the server to work, now this works with just curl and using the pager duty WebAPI.

https://v2.developer.pagerduty.com/v2/docs/trigger-events
