### PR TITLE
snapshots improvements

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2592,7 +2592,7 @@
                 NETDATA.chartRegistry.downloadAll(netdata_url, function(data) {
                     if(data !== null) {
                         if(typeof data.custom_info !== 'undefined' && data.custom_info !== "") {
-                            loadJs(data.custom_info, function () {
+                            loadJs(NETDATA.serverDefault + data.custom_info, function () {
                                 $.extend(true, netdataDashboard, customDashboard);
                                 initializeDynamicDashboardWithData(data);
                             });
@@ -2938,7 +2938,7 @@
                 }
 
                 var start_date = new Date(start_ms);
-                var yyyymmddhhssmm = start_date.getFullYear() + NETDATA.zeropad(start_date.getMonth() + 1) + NETDATA.zeropad(start_date.getDate()) + NETDATA.zeropad(start_date.getHours()) + NETDATA.zeropad(start_date.getMinutes()) + NETDATA.zeropad(start_date.getSeconds());
+                var yyyymmddhhssmm = start_date.getFullYear() + NETDATA.zeropad(start_date.getMonth() + 1) + NETDATA.zeropad(start_date.getDate()) + '-' + NETDATA.zeropad(start_date.getHours()) + NETDATA.zeropad(start_date.getMinutes()) + NETDATA.zeropad(start_date.getSeconds());
 
                 document.getElementById('saveSnapshotFilename').value = 'netdata-' + options.hostname.toString() + '-' + yyyymmddhhssmm.toString() + '-' +  view_duration.toString() + '.snapshot'
 

--- a/web/index.html
+++ b/web/index.html
@@ -3074,7 +3074,7 @@
                 duration_ms: options.duration * 1000,
                 update_every_ms: options.update_every * 1000,
                 data_points: 0,
-                url: document.location.origin.toString() + document.location.search.toString(),
+                url: ((urlOptions.server !== null)?urlOptions.server:document.location.origin.toString() + document.location.search.toString()).toString(),
                 comments: document.getElementById('saveSnapshotComments').value.toString(),
                 hash: urlOptions.hash,
                 charts: options.data,
@@ -3083,6 +3083,8 @@
                     submenu: netdataDashboard.submenu,
                     context: netdataDashboard.context
                 }),
+                charts_ok: 0,
+                charts_failed: 0,
                 data: {}
             };
 
@@ -3095,8 +3097,12 @@
                 data.state = null;
                 str = JSON.stringify(data);
 
-                saveData.data[state.chartDataUniqueID()] = str;
-                return str.length;
+                if(typeof str === 'string') {
+                    saveData.data[state.chartDataUniqueID()] = str;
+                    return str.length;
+                }
+                else
+                    return 0;
             }
 
             var clearPanAndZoom = false;
@@ -3112,7 +3118,7 @@
             saveSnapshotModalLog('info', 'Generating snapshot with ' + saveData.data_points.toString() + ' data points per dimension...');
 
             var charts_count = 0;
-            var charts_fetched = 0;
+            var charts_ok = 0;
             var charts_failed = 0;
 
             function saveSnapshotRestore() {
@@ -3167,15 +3173,14 @@
                             state.current.force_before_ms = null;
 
                             if(status === true) {
-                                charts_fetched++;
+                                charts_ok++;
                                 // state.log('ok');
+                                size += pack_api1_v1_chart_data(state);
                             }
                             else {
                                 charts_failed++;
                                 state.log('failed to be updated: ' + reason);
                             }
-
-                            size += pack_api1_v1_chart_data(state);
 
                             saveSnapshotModalLog((charts_failed)?'danger':'info', 'Generated size ' + (Math.round(size  * 100 / 1024 / 1024) / 100).toString() + ' MB. ' + ((charts_failed)?(charts_failed.toString() + ' charts have failed to be downloaded'):'').toString());
 
@@ -3183,9 +3188,15 @@
                                 update_chart(idx);
                             }
                             else {
+                                saveData.charts_ok = charts_ok;
+                                saveData.charts_failed = charts_failed;
+
                                 // save it
                                 // console.log(saveData);
                                 saveObjectToClient(saveData, filename);
+
+                                if(charts_failed > 0)
+                                    alert(charts_failed.toString() + ' failed to be downloaded');
 
                                 saveSnapshotRestore();
                                 saveData = null;

--- a/web/index.html
+++ b/web/index.html
@@ -2593,7 +2593,7 @@
                 // download all the charts the server knows
                 NETDATA.chartRegistry.downloadAll(netdata_url, function(data) {
                     if(data !== null) {
-                        if(typeof data.custom_info !== 'undefined' && data.custom_info !== "") {
+                        if(typeof data.custom_info !== 'undefined' && data.custom_info !== "" && netdataSnapshotData === null) {
                             loadJs(NETDATA.serverDefault + data.custom_info, function () {
                                 $.extend(true, netdataDashboard, customDashboard);
                                 initializeDynamicDashboardWithData(data);
@@ -2834,6 +2834,21 @@
         }
 
         // --------------------------------------------------------------------
+
+        function jsonStringifyFn(obj) {
+            return JSON.stringify(obj, function (key, value) {
+                return (typeof value === 'function' ) ? value.toString() : value;
+            });
+        }
+
+        function jsonParseFn(str) {
+            return JSON.parse(str, function (key, value) {
+                if (typeof value != 'string') return value;
+                return ( value.substring(0, 8) == 'function') ? eval('(' + value + ')') : value;
+            });
+        }
+
+        // --------------------------------------------------------------------
         // loading snapshots
 
         function loadSnapshotModalLog(priority, msg) {
@@ -2862,6 +2877,10 @@
                 urlOptions.hash = tmpSnapshotData.hash;
             else
                 urlOptions.hash = '#';
+
+            if(typeof tmpSnapshotData.info !== 'undefined') {
+                $.extend(true, netdataDashboard, jsonParseFn(tmpSnapshotData.info));
+            }
 
             netdataSnapshotData = tmpSnapshotData;
             initializeDynamicDashboard(netdataSnapshotData.url);
@@ -3051,6 +3070,11 @@
                 comments: document.getElementById('saveSnapshotComments').value.toString(),
                 hash: urlOptions.hash,
                 charts: options.data,
+                info: jsonStringifyFn({
+                    menu: netdataDashboard.menu,
+                    submenu: netdataDashboard.submenu,
+                    context: netdataDashboard.context
+                }),
                 data: {}
             };
 

--- a/web/index.html
+++ b/web/index.html
@@ -510,7 +510,7 @@
                 return typeof this[property] !== 'undefined';
             },
 
-            genHash: function() {
+            genHash: function(forReload) {
                 var hash = urlOptions.hash;
 
                 if(urlOptions.pan_and_zoom === true) {
@@ -527,7 +527,7 @@
                 if(urlOptions.update_always === true)
                     hash += ';update_always=true';
 
-                if(urlOptions.server !== null)
+                if(forReload === true && urlOptions.server !== null)
                     hash += ';server=' + urlOptions.server.toString();
 
                 if(urlOptions.mode !== 'live')
@@ -606,7 +606,7 @@
             },
 
             hashUpdate: function() {
-                history.replaceState(null, '', urlOptions.genHash());
+                history.replaceState(null, '', urlOptions.genHash(true));
             },
 
             netdataPanAndZoomCallback: function(status, after, before) {
@@ -920,14 +920,14 @@
             return this_is_demo;
         }
 
-        function netdataURL(url) {
+        function netdataURL(url, forReload) {
             if(typeof url === 'undefined')
                 url = document.location.toString();
 
             if(url.indexOf('#') !== -1)
                 url = url.substring(0, url.indexOf('#'));
 
-            var hash = urlOptions.genHash();
+            var hash = urlOptions.genHash(forReload);
 
             // console.log('netdataURL: ' + url + hash);
 
@@ -935,7 +935,7 @@
         }
 
         function netdataReload(url) {
-            document.location = netdataURL(url);
+            document.location = netdataURL(url, true);
 
             // since we play with hash
             // this is needed to reload the page

--- a/web/index.html
+++ b/web/index.html
@@ -566,8 +566,10 @@
                 if(typeof urlOptions.before === 'string')
                     urlOptions.before = parseInt(urlOptions.before);
 
-                if(urlOptions.server !== null)
+                if(urlOptions.server !== null && urlOptions.server !== '')
                     netdataServer = urlOptions.server;
+                else
+                    urlOptions.server = null;
 
                 if(urlOptions.before > 0 && urlOptions.after > 0) {
                     urlOptions.pan_and_zoom = true;

--- a/web/index.html
+++ b/web/index.html
@@ -2858,6 +2858,11 @@
             document.getElementById('sidebar').innerHTML = '';
             NETDATA.globalReset();
 
+            if(typeof tmpSnapshotData.hash !== 'undefined')
+                urlOptions.hash = tmpSnapshotData.hash;
+            else
+                urlOptions.hash = '#';
+
             netdataSnapshotData = tmpSnapshotData;
             initializeDynamicDashboard(netdataSnapshotData.url);
 
@@ -3044,6 +3049,7 @@
                 data_points: 0,
                 url: document.location.origin.toString() + document.location.search.toString(),
                 comments: document.getElementById('saveSnapshotComments').value.toString(),
+                hash: urlOptions.hash,
                 charts: options.data,
                 data: {}
             };

--- a/web/index.html
+++ b/web/index.html
@@ -2887,6 +2887,7 @@
                     document.getElementById('loadSnapshotURL').innerHTML = result.url;
                     document.getElementById('loadSnapshotCharts').innerHTML = result.charts.charts_count.toString() + ' charts, ' + result.charts.dimensions_count.toString() + ' dimensions, ' + result.data_points.toString() + ' points per dimension, ' + Math.round(result.duration_ms / result.data_points).toString() + ' ms per point';
                     document.getElementById('loadSnapshotTimeRange').innerHTML = '<b>' + NETDATA.dateTime.localeDateString(date_after) + ' ' + NETDATA.dateTime.localeTimeString(date_after) + '</b> to <b>' + NETDATA.dateTime.localeDateString(date_before) + ' ' + NETDATA.dateTime.localeTimeString(date_before) + '</b>';
+                    document.getElementById('loadSnapshotComments').innerHTML = ((result.comments)?result.comments:'').toString();
                     loadSnapshotModalLog('success', 'File loaded, click <b>Import</b> to render it!');
                     $('#loadSnapshotImport').prop('disabled', false);
                     $('#loadSnapshotImport').removeAttr('disabled');
@@ -2936,7 +2937,10 @@
                     start_ms = NETDATA.globalPanAndZoom.force_after_ms;
                 }
 
-                document.getElementById('saveSnapshotFilename').value = 'netdata-dashboard-' + options.hostname.toString() + '-' + start_ms.toString() + '.json'
+                var start_date = new Date(start_ms);
+                var yyyymmddhhssmm = start_date.getFullYear() + NETDATA.zeropad(start_date.getMonth() + 1) + NETDATA.zeropad(start_date.getDate()) + NETDATA.zeropad(start_date.getHours()) + NETDATA.zeropad(start_date.getMinutes()) + NETDATA.zeropad(start_date.getSeconds());
+
+                document.getElementById('saveSnapshotFilename').value = 'netdata-' + options.hostname.toString() + '-' + yyyymmddhhssmm.toString() + '-' +  view_duration.toString() + '.snapshot'
 
                 var min = options.update_every;
                 var max = Math.round(view_duration / 100);
@@ -3037,6 +3041,7 @@
                 update_every_ms: options.update_every * 1000,
                 data_points: 0,
                 url: document.location.origin.toString() + document.location.search.toString(),
+                comments: document.getElementById('saveSnapshotComments').value.toString(),
                 charts: options.data,
                 data: {}
             };
@@ -3918,7 +3923,8 @@
                             <tr><th>Hostname</th><td id="loadSnapshotHostname"></td></tr>
                             <tr><th>Origin URL</th><td id="loadSnapshotURL"></td></tr>
                             <tr><th>Time Range</th><td id="loadSnapshotTimeRange"></td></tr>
-                            <tr><th>Charts</th><td id="loadSnapshotCharts"></td></tr>
+                            <tr><th>Chart Data</th><td id="loadSnapshotCharts"></td></tr>
+                            <tr><th>Comments</th><td id="loadSnapshotComments"></td></tr>
                         </tbody>
                         </table>
                     </p>
@@ -3931,7 +3937,7 @@
         </div>
     </div>
 
-    <div class="modal fade" id="saveSnapshotModal" tabindex="-1" role="dialog" aria-labelledby="saveSnapshotModalLabel">
+    <div class="modal fade" id="saveSnapshotModal" tabindex="-1" role="dialog" aria-labelledby="saveSnapshotModalLabel" data-keyboard="false" data-backdrop="static">
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -3960,6 +3966,10 @@
                         <div class="input-group">
                             <span class="input-group-addon" id="sizing-saveSnapshotFilename">Filename</span>
                             <input id="saveSnapshotFilename" class="form-control" placeholder="Filename of the generated snapshot" aria-describedby="sizing-saveSnapshotFilename"/>
+                        </div>
+                        <div class="input-group" style="padding-top: 10px;">
+                            <span class="input-group-addon" id="sizing-saveSnapshotComments">Comments</span>
+                            <input id="saveSnapshotComments" class="form-control" placeholder="Any comments about this snapshot?" aria-describedby="sizing-saveSnapshotComments"/>
                         </div>
                     </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -2879,7 +2879,15 @@
                 urlOptions.hash = '#';
 
             if(typeof tmpSnapshotData.info !== 'undefined') {
-                $.extend(true, netdataDashboard, jsonParseFn(tmpSnapshotData.info));
+                var info = jsonParseFn(tmpSnapshotData.info);
+                if(typeof info.menu !== 'undefined')
+                    netdataDashboard.menu = info.menu;
+
+                if(typeof info.submenu !== 'undefined')
+                    netdataDashboard.submenu = info.submenu;
+
+                if(typeof info.context !== 'undefined')
+                    netdataDashboard.context = info.context;
             }
 
             netdataSnapshotData = tmpSnapshotData;

--- a/web/index.html
+++ b/web/index.html
@@ -493,6 +493,7 @@
             mode: 'live',         // 'live', 'print'
             update_always: false,
             pan_and_zoom: false,
+            server: null,
             after: 0,
             before: 0,
             nowelcome: false,
@@ -525,6 +526,9 @@
 
                 if(urlOptions.update_always === true)
                     hash += ';update_always=true';
+
+                if(urlOptions.server !== null)
+                    hash += ';server=' + urlOptions.server.toString();
 
                 if(urlOptions.mode !== 'live')
                     hash += ';mode=' + urlOptions.mode;
@@ -561,6 +565,9 @@
 
                 if(typeof urlOptions.before === 'string')
                     urlOptions.before = parseInt(urlOptions.before);
+
+                if(urlOptions.server !== null)
+                    netdataServer = urlOptions.server;
 
                 if(urlOptions.before > 0 && urlOptions.after > 0) {
                     urlOptions.pan_and_zoom = true;
@@ -1864,9 +1871,9 @@
         function loadBootstrapTable(callback) {
             if(bootstrapTableLoaded === false) {
                 bootstrapTableLoaded = true;
-                loadJs(NETDATA.serverDefault + 'lib/bootstrap-table-1.11.0.min.js', function() {
-                    loadJs(NETDATA.serverDefault + 'lib/bootstrap-table-export-1.11.0.min.js', function() {
-                        loadJs(NETDATA.serverDefault + 'lib/tableExport-1.6.0.min.js', callback);
+                loadJs('lib/bootstrap-table-1.11.0.min.js', function() {
+                    loadJs('lib/bootstrap-table-export-1.11.0.min.js', function() {
+                        loadJs('lib/tableExport-1.6.0.min.js', callback);
                     })
                 });
             }
@@ -1877,8 +1884,8 @@
         function loadBootstrapSlider(callback) {
             if(bootstrapSliderLoaded === false) {
                 bootstrapSliderLoaded = true;
-                loadJs(NETDATA.serverDefault + 'lib/bootstrap-slider-10.0.0.min.js', function() {
-                    NETDATA._loadCSS(NETDATA.serverDefault + 'css/bootstrap-slider-10.0.0.min.css');
+                loadJs('lib/bootstrap-slider-10.0.0.min.js', function() {
+                    NETDATA._loadCSS('css/bootstrap-slider-10.0.0.min.css');
                     callback();
                 });
             }
@@ -2919,13 +2926,17 @@
 
             loadBootstrapSlider(function() {
                 var view_duration = options.duration;
+                var start_ms = Math.round(Date.now() - view_duration * 1000);
 
                 var bytes_per_chart = 2048;
                 var bytes_per_point_per_dimension = 5.3;
 
-                if(NETDATA.globalPanAndZoom.isActive() === true)
+                if(NETDATA.globalPanAndZoom.isActive() === true) {
                     view_duration = Math.round((NETDATA.globalPanAndZoom.force_before_ms - NETDATA.globalPanAndZoom.force_after_ms) / 1000);
+                    start_ms = NETDATA.globalPanAndZoom.force_after_ms;
+                }
 
+                document.getElementById('saveSnapshotFilename').value = 'netdata-dashboard-' + options.hostname.toString() + '-' + start_ms.toString() + '.json'
 
                 var min = options.update_every;
                 var max = Math.round(view_duration / 100);
@@ -2985,7 +2996,9 @@
             saveSnapshotStop = false;
             $('#saveSnapshotModalProgressSection').show();
             $('#saveSnapshotResolutionRadio').hide();
-            saveSnapshotModalLog('info', 'Generating snapshot...');
+            var filename = document.getElementById('saveSnapshotFilename').value;
+            // console.log(filename);
+            saveSnapshotModalLog('info', 'Generating snapshot as <code>' + filename.toString() + '</code>');
 
             var save_options = {
                 stop_updates_when_focus_is_lost: false,
@@ -3127,7 +3140,7 @@
                             else {
                                 // save it
                                 // console.log(saveData);
-                                saveObjectToClient(saveData, 'netdata-dashboard-' + saveData.hostname.toString() + '-' + saveData.after_ms.toString() + '-' + saveData.before_ms.toString() + '.json');
+                                saveObjectToClient(saveData, filename);
 
                                 saveSnapshotRestore();
                                 saveData = null;
@@ -3943,6 +3956,11 @@
                         &nbsp;
                         <br/>
                         <input id="saveSnapshotResolutionSlider" data-slider-id='saveSnapshotResolutionSlider' type="text" style="width: 80%;"/>
+                        <br/>&nbsp;<br/>
+                        <div class="input-group">
+                            <span class="input-group-addon" id="sizing-saveSnapshotFilename">Filename</span>
+                            <input id="saveSnapshotFilename" class="form-control" placeholder="Filename of the generated snapshot" aria-describedby="sizing-saveSnapshotFilename"/>
+                        </div>
                     </div>
 
                     &nbsp;


### PR DESCRIPTION
Snapshots can now have custom filenames and comments:

![screenshot from 2017-11-14 14-42-14](https://user-images.githubusercontent.com/2662304/32780490-1459104e-c94a-11e7-974b-c1bebe5f500e.png)

And loaded back:

![screenshot from 2017-11-14 14-43-29](https://user-images.githubusercontent.com/2662304/32780518-35bd5808-c94a-11e7-9190-ce171c49789f.png)

---

Also, any netdata can be instructed to use the API of another netdata:

```
http://localhost:19999/#menu_system;theme=slate;help=false;server=https://my-netdata.io
```

So, the dashboard static files are loaded from `http://localhost:19999`, but all API calls are sent to `server=https://my-netdata.io`.

This allows taking snapshots of older netdata servers (instruct the dashboard of a newer netdata, to use the API of the older netdata).

Of course, for this to work your web browser needs access to both netdata servers. This is purely client side.

---

snapshots now include custom dashboard info that may have been configured at the netdata that took the snapshot. This provides exactly the same dashboard view with the original netdata.

---

snapshots now respect the vertical scroll position of the dashboard. So when snapshots are restored, the current view changes to the vertical position of the browser that took the snapshot.

This combined with the comments feature, gives a very snappy look to the issue at hand.