### PR TITLE
added -x for radclient binary call

### DIFF
--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -82,7 +82,7 @@ class Service(SimpleService):
         self.echo = find_binary('echo')
         self.radclient = find_binary('radclient')
         self.sub_echo = [self.echo, RADIUS_MSG]
-        self.sub_radclient = [self.radclient, '-r', '1', '-t', '1',
+        self.sub_radclient = [self.radclient, '-r', '1', '-t', '1', '-x',
                               ':'.join([self.host, self.port]), 'status', self.secret]
 
     def check(self):

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -91,6 +91,7 @@ class Service(SimpleService):
             return False
         if not self.secret:
             self.error('"secret" not set')
+            return None
 
         if self._get_raw_data():
             return True


### PR DESCRIPTION
There are not stats from radiusd with freeradius 3.x server if -x is missing.