### PR TITLE
fixed units scaling discrepancies

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -5514,13 +5514,19 @@ var NETDATA = window.NETDATA || {};
                         var v = state.legendFormatValue(y);
                         var new_units = state.units_current;
 
-                        if(new_units !== old_units) {
+                        if(state.units_desired === 'auto' && typeof old_units !== 'undefined' && new_units !== old_units && !NETDATA.chartLibraries.dygraph.isSparkline(state)) {
                             // console.log(this);
                             // state.log('units discrepancy: old = ' + old_units + ', new = ' + new_units);
                             var len = this.plugins_.length;
                             while(len--) {
                                 // console.log(this.plugins_[len]);
-                                if(typeof this.plugins_[len].plugin.ylabel_div_ !== 'undefined') {
+                                if(typeof this.plugins_[len].plugin.ylabel_div_ !== 'undefined'
+                                    && this.plugins_[len].plugin.ylabel_div_ !== null
+                                    && typeof this.plugins_[len].plugin.ylabel_div_.children !== 'undefined'
+                                    && this.plugins_[len].plugin.ylabel_div_.children !== null
+                                    && typeof this.plugins_[len].plugin.ylabel_div_.children[0].children !== 'undefined'
+                                    && this.plugins_[len].plugin.ylabel_div_.children[0].children !== null
+                                ) {
                                     this.plugins_[len].plugin.ylabel_div_.children[0].children[0].innerHTML = new_units;
                                     this.user_attrs_.ylabel = new_units;
                                     break;
@@ -5529,7 +5535,6 @@ var NETDATA = window.NETDATA || {};
 
                             if(len < 0)
                                 state.log('units discrepancy, but cannot find dygraphs div to change: old = ' + old_units + ', new = ' + new_units);
-
                         }
 
                         return v;

--- a/web/index.html
+++ b/web/index.html
@@ -3657,6 +3657,15 @@
                     if(self.prop('checked') !== (NETDATA.getOption('units') === 'auto')) {
                         self.bootstrapToggle(NETDATA.getOption('units') === 'auto' ? 'on' : 'off');
                     }
+
+                    if(self.prop('checked') === true) {
+                        $('#settingsLocaleTempRow').show();
+                        $('#settingsLocaleTimeRow').show();
+                    }
+                    else {
+                        $('#settingsLocaleTempRow').hide();
+                        $('#settingsLocaleTimeRow').hide();
+                    }
                 };
                 var temp_sync_option = function(option) {
                     var self = $('#' + option);
@@ -4634,14 +4643,14 @@
                                                 </small>
                                             </td>
                                         </tr>
-                                        <tr class="option-row">
+                                        <tr id="settingsLocaleTempRow" class="option-row">
                                             <td class="option-control"><input id="units_temp" type="checkbox" checked data-toggle="toggle"  data-on="Celsius" data-off="Fahrenheit" data-width="110px"></td>
                                             <td class="option-info"><strong>Which units to use for temperatures?</strong><br/>
                                                 <small>Set the temperature units of the dashboard.
                                                 </small>
                                             </td>
                                         </tr>
-                                        <tr class="option-row">
+                                        <tr id="settingsLocaleTimeRow" class="option-row">
                                             <td class="option-control"><input id="seconds_as_time" type="checkbox" checked data-toggle="toggle"  data-on="Time" data-off="Seconds" data-onstyle="success" data-width="110px"></td>
                                             <td class="option-info"><strong>Convert seconds to time?</strong><br/>
                                                 <small>When set to <b>Time</b>, charts that present <code>seconds</code> will show <code>DDd:HH:MM:SS</code>.
@@ -5156,6 +5165,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171115-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20171116-2"></script>
 </body>
 </html>


### PR DESCRIPTION
units scaling had a few discrepancies, like the following:

![image](https://user-images.githubusercontent.com/2662304/32916760-af9ab346-cb25-11e7-8803-ffd2133172a8.png)

(the legend on the left says MB, the legend on the right say GB).

The problem is that dynamic units scaling uses the rendered chart to find out how the units should be scaled. The legend on the left is decided before the chart is rendered (this legend is rendered by dygraphs), while the legend on the right is handled by the dashboard and is updated after the chart has been rendered.

The same was happening when chart dimensions were selected.

This PR fixes these issues. Now the dashboard uses unofficial dygraphs structures to update the units at the left of the chart, on the fly.