### PR TITLE
Dynamic highlight of time-frames using the ALT or Control key

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -2326,6 +2326,7 @@ var NETDATA = window.NETDATA || {};
             that.element_chart = null; // the element with the chart
             that.element_legend = null; // the element with the legend of the chart (if created by us)
             that.element_legend_childs = {
+                content: null,
                 hidden: null,
                 title_date: null,
                 title_time: null,
@@ -2499,6 +2500,16 @@ var NETDATA = window.NETDATA || {};
             if(isHidden() === true) return;
 
             if(that.chart_created === true) {
+                if(NETDATA.options.current.show_help === true) {
+                    $(that.element_legend_childs.toolbox_left).popover('hide');
+                    $(that.element_legend_childs.toolbox_reset).popover('hide');
+                    $(that.element_legend_childs.toolbox_right).popover('hide');
+                    $(that.element_legend_childs.toolbox_zoomin).popover('hide');
+                    $(that.element_legend_childs.toolbox_zoomout).popover('hide');
+                    $(that.element_legend_childs.resize_handler).popover('hide');
+                    $(that.element_legend_childs.content).popover('hide');
+                }
+
                 if(NETDATA.options.current.destroy_on_hide === true) {
                     // that.log('hideChart() init');
 
@@ -3829,6 +3840,8 @@ var NETDATA = window.NETDATA || {};
 
                 content.className = 'netdata-legend-series-content';
                 this.element_legend_childs.perfect_scroller.appendChild(content);
+
+                this.element_legend_childs.content = content;
 
                 if(NETDATA.options.current.show_help === true)
                     $(content).popover({

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -728,6 +728,7 @@ var NETDATA = window.NETDATA || {};
                 });
                 window.addEventListener("test", null, opts);
             } catch (e) {
+                console.log('browser does not support passive events');
             }
 
             NETDATA.options.passive_events = supportsPassive;
@@ -4995,7 +4996,7 @@ var NETDATA = window.NETDATA || {};
 
         len = parallel.length;
         while(len--) {
-            var state = parallel[len];
+            state = parallel[len];
             // console.log('auto-refresher executing in parallel for ' + parallel.length.toString() + ' charts');
             // this will execute the jobs in parallel
             setTimeout(state.autoRefresh, 0);

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -310,6 +310,8 @@ var NETDATA = window.NETDATA || {};
         highlight_after: null,          // highlight after this time
         highlight_before: null,         // highlight before this time
 
+        passive_events: null,           // true if the browser supports passive events
+
         // the current profile
         // we may have many...
         current: {
@@ -632,6 +634,8 @@ var NETDATA = window.NETDATA || {};
         if(NETDATA.onscroll_updater_enabled === false)
             return;
 
+        //console.log('onscroll_updater() begin');
+
         NETDATA.globalSelectionSync.stop();
 
         NETDATA.onscroll_updater_count++;
@@ -646,11 +650,18 @@ var NETDATA = window.NETDATA || {};
         if(NETDATA.options.abort_ajax_on_scroll === true)
             NETDATA.abort_all_refreshes();
 
-        // find which charts are visible
         var targets = NETDATA.options.targets;
         var len = targets.length;
-        while (len--)
-            targets[len].isVisible();
+
+        function onscroll_updater_chart_is_visible() {
+            if(len--) {
+                targets[len].isVisible();
+                NETDATA.onscroll_updater_timeout_id = setTimeout(onscroll_updater_chart_is_visible, 0);
+            }
+            else
+                NETDATA.onscroll_updater_timeout_id = 0;
+        }
+        onscroll_updater_chart_is_visible();
 
         var end = Date.now();
         // console.log('scroll No ' + NETDATA.onscroll_updater_count + ' calculation took ' + (end - start).toString() + ' ms');
@@ -674,13 +685,15 @@ var NETDATA = window.NETDATA || {};
         }
 
         NETDATA.onscroll_updater_timeout_id = 0;
+        //console.log('onscroll_updater() done in ' + (end - start).toString() + ' ms');
     };
 
     NETDATA.scrollUp = false;
     NETDATA.scrollY = window.scrollY;
     NETDATA.onscroll = function() {
-        // console.log('onscroll');
+        //console.log('onscroll() begin');
 
+        NETDATA.chartRefresherReschedule();
         NETDATA.scrollUp = (window.scrollY > NETDATA.scrollY);
         NETDATA.scrollY = window.scrollY;
 
@@ -700,10 +713,34 @@ var NETDATA = window.NETDATA || {};
             // sync
             NETDATA.onscroll_updater();
         }
+
+        //console.log('onscroll() end');
     };
 
-    window.onresize = NETDATA.onresize;
-    window.onscroll = NETDATA.onscroll;
+    NETDATA.supportsPassiveEvents = function() {
+        if(NETDATA.options.passive_events === null) {
+            var supportsPassive = false;
+            try {
+                var opts = Object.defineProperty({}, 'passive', {
+                    get: function () {
+                        supportsPassive = true;
+                    }
+                });
+                window.addEventListener("test", null, opts);
+            } catch (e) {
+            }
+
+            NETDATA.options.passive_events = supportsPassive;
+        }
+
+        // console.log('passive ' + NETDATA.options.passive_events);
+        return NETDATA.options.passive_events;
+    };
+
+    window.addEventListener('resize', NETDATA.onresize, NETDATA.supportsPassiveEvents() ? { passive: true } : false);
+    window.addEventListener('scroll', NETDATA.onscroll, NETDATA.supportsPassiveEvents() ? { passive: true } : false);
+    // window.onresize = NETDATA.onresize;
+    // window.onscroll = NETDATA.onscroll;
 
     // ----------------------------------------------------------------------------------------------------------------
     // Error Handling
@@ -2563,13 +2600,14 @@ var NETDATA = window.NETDATA || {};
             }
         };
 
-        var canBeRendered = function() {
+        var canBeRendered = function(uncached_visibility) {
             return (
                 (
                     NETDATA.options.page_is_visible === true ||
-                    NETDATA.options.current.stop_updates_when_focus_is_lost === false
+                    NETDATA.options.current.stop_updates_when_focus_is_lost === false ||
+                    that.updates_since_last_unhide === 0
                 )
-                && isHidden() === false && that.isVisible(true) === true
+                && isHidden() === false && that.isVisible(uncached_visibility) === true
             );
         };
 
@@ -2577,11 +2615,15 @@ var NETDATA = window.NETDATA || {};
         var callChartLibraryUpdateSafely = function(data) {
             var status;
 
-            if(canBeRendered() === false)
+            if(canBeRendered(true) === false)
                 return false;
 
             if(NETDATA.options.fake_chart_rendering === true)
                 return true;
+
+            that.updates_counter++;
+            that.updates_since_last_unhide++;
+            that.updates_since_last_creation++;
 
             if(NETDATA.options.debug.chart_errors === true)
                 status = that.library.update(that, data);
@@ -2606,11 +2648,15 @@ var NETDATA = window.NETDATA || {};
         var callChartLibraryCreateSafely = function(data) {
             var status;
 
-            if(canBeRendered() === false)
+            if(canBeRendered(true) === false)
                 return false;
 
             if(NETDATA.options.fake_chart_rendering === true)
                 return true;
+
+            that.updates_counter++;
+            that.updates_since_last_unhide++;
+            that.updates_since_last_creation++;
 
             if(NETDATA.options.debug.chart_errors === true)
                 status = that.library.create(that, data);
@@ -4096,9 +4142,6 @@ var NETDATA = window.NETDATA || {};
             resizeChart();
 
             this.data = data;
-            this.updates_counter++;
-            this.updates_since_last_unhide++;
-            this.updates_since_last_creation++;
 
             var started = Date.now();
             var view_update_every = data.view_update_every * 1000;
@@ -4290,6 +4333,7 @@ var NETDATA = window.NETDATA || {};
                 else {
                     ok = false;
                     error('data not found in snapshot for key: ' + key);
+                    that.tm.last_autorefreshed = Date.now();
                 }
 
                 NETDATA.statistics.refreshes_active--;
@@ -4394,18 +4438,16 @@ var NETDATA = window.NETDATA || {};
         };
 
         this.canBeAutoRefreshed = function() {
-            var now = Date.now();
-
-            if(this.running === true) {
+            if(this.enabled === false) {
                 if(this.debug === true)
-                    this.log('I am already running');
+                    this.log('canBeAutoRefreshed() -> not enabled');
 
                 return false;
             }
 
-            if(this.enabled === false) {
+            if(this.running === true) {
                 if(this.debug === true)
-                    this.log('I am not enabled');
+                    this.log('canBeAutoRefreshed() -> already running');
 
                 return false;
             }
@@ -4413,88 +4455,101 @@ var NETDATA = window.NETDATA || {};
             if(this.library === null || this.library.enabled === false) {
                 error('charting library "' + this.library_name + '" is not available');
                 if(this.debug === true)
-                    this.log('My chart library ' + this.library_name + ' is not available');
+                    this.log('canBeAutoRefreshed() -> chart library ' + this.library_name + ' is not available');
 
                 return false;
             }
 
             if(this.isVisible() === false) {
                 if(NETDATA.options.debug.visibility === true || this.debug === true)
-                    this.log('I am not visible');
+                    this.log('canBeAutoRefreshed() -> not visible');
 
                 return false;
             }
 
+            var now = Date.now();
+
             if(this.current.force_update_at !== 0 && this.current.force_update_at < now) {
                 if(this.debug === true)
-                    this.log('timed force update detected - allowing this update');
+                    this.log('canBeAutoRefreshed() -> timed force update - allowing this update');
 
                 this.current.force_update_at = 0;
                 return true;
             }
 
-            if(this.isAutoRefreshable() === true) {
-                // allow the first update, even if the page is not visible
-                if(this.updates_counter && this.updates_since_last_unhide && NETDATA.options.page_is_visible === false) {
-                    // if(NETDATA.options.debug.focus === true || this.debug === true)
-                    //    this.log('canBeAutoRefreshed(): page does not have focus');
+            if(this.isAutoRefreshable() === false) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed() -> not auto-refreshable');
 
-                    return false;
-                }
+                return false;
+            }
 
-                if(this.needsRecreation() === true) {
+            // allow the first update, even if the page is not visible
+            if(NETDATA.options.page_is_visible === false && this.updates_counter && this.updates_since_last_unhide) {
+                if(NETDATA.options.debug.focus === true || this.debug === true)
+                    this.log('canBeAutoRefreshed() -> not the first update, and page does not have focus');
+
+                return false;
+            }
+
+            if(this.needsRecreation() === true) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed() -> needs re-creation.');
+
+                return true;
+            }
+
+            if(NETDATA.options.auto_refresher_stop_until >= now) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed() -> stopped until is in future.');
+
+                return false;
+            }
+
+            // options valid only for autoRefresh()
+            if(NETDATA.globalPanAndZoom.isActive()) {
+                if(NETDATA.globalPanAndZoom.shouldBeAutoRefreshed(this)) {
                     if(this.debug === true)
-                        this.log('canBeAutoRefreshed(): needs re-creation.');
+                        this.log('canBeAutoRefreshed(): global panning: I need an update.');
 
                     return true;
                 }
+                else {
+                    if(this.debug === true)
+                        this.log('canBeAutoRefreshed(): global panning: I am already up to date.');
 
-                // options valid only for autoRefresh()
-                if(NETDATA.options.auto_refresher_stop_until < now) {
-                    if(NETDATA.globalPanAndZoom.isActive()) {
-                        if(NETDATA.globalPanAndZoom.shouldBeAutoRefreshed(this)) {
-                            if(this.debug === true)
-                                this.log('canBeAutoRefreshed(): global panning: I need an update.');
-
-                            return true;
-                        }
-                        else {
-                            if(this.debug === true)
-                                this.log('canBeAutoRefreshed(): global panning: I am already up to date.');
-
-                            return false;
-                        }
-                    }
-
-                    if(this.selected === true) {
-                        if(this.debug === true)
-                            this.log('canBeAutoRefreshed(): I have a selection in place.');
-
-                        return false;
-                    }
-
-                    if(this.paused === true) {
-                        if(this.debug === true)
-                            this.log('canBeAutoRefreshed(): I am paused.');
-
-                        return false;
-                    }
-
-                    if(now - this.tm.last_autorefreshed >= this.data_update_every) {
-                        if(this.debug === true)
-                            this.log('canBeAutoRefreshed(): It is time to update me.');
-
-                        return true;
-                    }
+                    return false;
                 }
+            }
+
+            if(this.selected === true) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed(): I have a selection in place.');
+
+                return false;
+            }
+
+            if(this.paused === true) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed(): I am paused.');
+
+                return false;
+            }
+
+            if(now - this.tm.last_autorefreshed >= this.data_update_every) {
+                if(this.debug === true)
+                    this.log('canBeAutoRefreshed(): It is time to update me.');
+
+                return true;
             }
 
             return false;
         };
 
         this.autoRefresh = function(callback) {
-            if(this.canBeAutoRefreshed() === true && this.running === false) {
-                var state = this;
+            var state = that;
+
+            if(state.canBeAutoRefreshed() === true && state.running === false) {
 
                 state.running = true;
                 state.updateChart(function() {
@@ -4806,14 +4861,14 @@ var NETDATA = window.NETDATA || {};
 
     // this is purely sequential charts refresher
     // it is meant to be autonomous
-    NETDATA.chartRefresherNoParallel = function(index) {
+    NETDATA.chartRefresherNoParallel = function(index, callback) {
         if(NETDATA.options.debug.main_loop === true)
             console.log('NETDATA.chartRefresherNoParallel(' + index + ')');
 
         if(NETDATA.options.updated_dom === true) {
             // the dom has been updated
             // get the dom parts again
-            NETDATA.parseDom(NETDATA.chartRefresher);
+            NETDATA.parseDom(callback);
             return;
         }
         if(index >= NETDATA.options.targets.length) {
@@ -4821,10 +4876,7 @@ var NETDATA = window.NETDATA || {};
                 console.log('waiting to restart main loop...');
 
             NETDATA.options.auto_refresher_fast_weight = 0;
-
-            setTimeout(function() {
-                NETDATA.chartRefresher();
-            }, NETDATA.options.current.idle_between_loops);
+            callback();
         }
         else {
             var state = NETDATA.options.targets[index];
@@ -4835,7 +4887,7 @@ var NETDATA = window.NETDATA || {};
 
                 setTimeout(function() {
                     state.autoRefresh(function () {
-                        NETDATA.chartRefresherNoParallel(++index);
+                        NETDATA.chartRefresherNoParallel(++index, callback);
                     });
                 }, 0);
             }
@@ -4845,7 +4897,7 @@ var NETDATA = window.NETDATA || {};
 
                 setTimeout(function() {
                     state.autoRefresh(function() {
-                        NETDATA.chartRefresherNoParallel(++index);
+                        NETDATA.chartRefresherNoParallel(++index, callback);
                     });
                 }, NETDATA.options.current.idle_between_charts);
             }
@@ -4857,20 +4909,32 @@ var NETDATA = window.NETDATA || {};
     };
 
     // the default refresher
-    NETDATA.chartRefresher = function() {
-        // console.log('auto-refresher...');
+    NETDATA.chartRefresherLastRun = 0;
+    NETDATA.chartRefresherTimeoutId = 0;
 
+    NETDATA.chartRefresherReschedule = function() {
+        clearTimeout(NETDATA.chartRefresherTimeoutId);
+        NETDATA.chartRefresherTimeoutId = setTimeout(NETDATA.chartRefresher, NETDATA.chartRefresherWaitTime());
+        //console.log('chartRefresherReschedule()');
+    };
+
+    NETDATA.chartRefresher = function() {
         var now = Date.now();
+        //console.log('chartRefresher() begin ' + (now - NETDATA.chartRefresherLastRun).toString() + ' ms since last run');
+        NETDATA.chartRefresherLastRun = now;
+
         if( now < NETDATA.options.on_scroll_refresher_stop_until ) {
-            setTimeout(NETDATA.chartRefresher,
+            NETDATA.chartRefresherTimeoutId = setTimeout(NETDATA.chartRefresher,
                 NETDATA.chartRefresherWaitTime());
+            //console.log('chartRefresher() end1 will run in ' + NETDATA.chartRefresherWaitTime().toString() + ' ms');
             return;
         }
 
         if(NETDATA.options.pause === true) {
             // console.log('auto-refresher is paused');
-            setTimeout(NETDATA.chartRefresher,
+            NETDATA.chartRefresherTimeoutId = setTimeout(NETDATA.chartRefresher,
                 NETDATA.chartRefresherWaitTime());
+            //console.log('chartRefresher() end2 will run in ' + NETDATA.chartRefresherWaitTime().toString() + ' ms');
             return;
         }
 
@@ -4879,12 +4943,18 @@ var NETDATA = window.NETDATA || {};
             NETDATA.options.pause = true;
             NETDATA.options.pauseCallback();
             NETDATA.chartRefresher();
+            //console.log('chartRefresher() end3 (nested)');
             return;
         }
 
         if(NETDATA.options.current.parallel_refresher === false) {
             // console.log('auto-refresher is calling chartRefresherNoParallel(0)');
-            NETDATA.chartRefresherNoParallel(0);
+            NETDATA.chartRefresherNoParallel(0, function() {
+                NETDATA.chartRefresherTimeoutId = setTimeout(function() {
+                    NETDATA.chartRefresher();
+                }, NETDATA.options.current.idle_between_loops);
+            });
+            //console.log('chartRefresher() end4 (no parallel, nested)');
             return;
         }
 
@@ -4893,6 +4963,7 @@ var NETDATA = window.NETDATA || {};
             // get the dom parts again
             // console.log('auto-refresher is calling parseDom()');
             NETDATA.parseDom(NETDATA.chartRefresher);
+            //console.log('chartRefresher() end5 (parseDom)');
             return;
         }
 
@@ -4908,6 +4979,7 @@ var NETDATA = window.NETDATA || {};
             if(state.library.initialized === false) {
                 if(state.library.enabled === true) {
                     state.library.initialize(NETDATA.chartRefresher);
+                    //console.log('chartRefresher() end6 (library init)');
                     return;
                 }
                 else {
@@ -4916,28 +4988,32 @@ var NETDATA = window.NETDATA || {};
             }
 
             if(NETDATA.scrollUp === true)
-                parallel.push(state);
-            else
                 parallel.unshift(state);
+            else
+                parallel.push(state);
         }
 
-        if(parallel.length > 0) {
+        len = parallel.length;
+        while(len--) {
+            var state = parallel[len];
             // console.log('auto-refresher executing in parallel for ' + parallel.length.toString() + ' charts');
             // this will execute the jobs in parallel
-            $(parallel).each(function() {
-                this.autoRefresh();
-            })
+            setTimeout(state.autoRefresh, 0);
         }
         //else {
         //    console.log('auto-refresher nothing to do');
         //}
 
         // run the next refresh iteration
-        setTimeout(NETDATA.chartRefresher,
+        NETDATA.chartRefresherTimeoutId = setTimeout(NETDATA.chartRefresher,
             NETDATA.chartRefresherWaitTime());
+
+        //console.log('chartRefresher() completed in ' + (Date.now() - now).toString() + ' ms');
     };
 
     NETDATA.parseDom = function(callback) {
+        //console.log('parseDom()');
+
         NETDATA.options.last_page_scroll = Date.now();
         NETDATA.options.updated_dom = false;
 
@@ -4959,8 +5035,14 @@ var NETDATA = window.NETDATA || {};
     };
 
     // this is the main function - where everything starts
+    NETDATA.started = false;
     NETDATA.start = function() {
         // this should be called only once
+
+        if(NETDATA.started === true)
+            console.log('netdata is already started');
+
+        NETDATA.started = true;
 
         NETDATA.options.page_is_visible = true;
 

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -5674,17 +5674,19 @@ var NETDATA = window.NETDATA || {};
                     state.tmp.dygraph_mouse_down = true;
                     context.initializeMouseDown(event, dygraph, context);
 
-                    // console.log(event);
+                    //console.log(event);
                     if(event.button && event.button === 1) {
                         if (event.shiftKey) {
-                            // middle mouse button dragging (PAN)
+                            //console.log('middle mouse button dragging (PAN)');
+
                             state.setMode('pan');
                             // NETDATA.globalSelectionSync.delay();
-                            state.tmp.dygraph_highlight_after = undefined;
+                            state.tmp.dygraph_highlight_after = null;
                             Dygraph.startPan(event, dygraph, context);
                         }
                         else if(event.altKey || event.ctrlKey || event.metaKey) {
-                            // middle mouse button highlight
+                            //console.log('middle mouse button highlight');
+
                             if (!(event.offsetX && event.offsetY)) {
                                 event.offsetX = event.layerX - event.target.offsetLeft;
                                 event.offsetY = event.layerY - event.target.offsetTop;
@@ -5693,23 +5695,26 @@ var NETDATA = window.NETDATA || {};
                             Dygraph.startZoom(event, dygraph, context);
                         }
                         else {
-                            // middle mouse button selection for zoom (ZOOM)
+                            //console.log('middle mouse button selection for zoom (ZOOM)');
+
                             state.setMode('zoom');
                             // NETDATA.globalSelectionSync.delay();
-                            state.tmp.dygraph_highlight_after = undefined;
+                            state.tmp.dygraph_highlight_after = null;
                             Dygraph.startZoom(event, dygraph, context);
                         }
                     }
                     else {
                         if (event.shiftKey) {
-                            // left mouse button selection for zoom (ZOOM)
+                            //console.log('left mouse button selection for zoom (ZOOM)');
+
                             state.setMode('zoom');
                             // NETDATA.globalSelectionSync.delay();
-                            state.tmp.dygraph_highlight_after = undefined;
+                            state.tmp.dygraph_highlight_after = null;
                             Dygraph.startZoom(event, dygraph, context);
                         }
                         else if(event.altKey || event.ctrlKey || event.metaKey) {
-                            // left mouse button highlight
+                            //console.log('left mouse button highlight');
+
                             if (!(event.offsetX && event.offsetY)) {
                                 event.offsetX = event.layerX - event.target.offsetLeft;
                                 event.offsetY = event.layerY - event.target.offsetTop;
@@ -5718,10 +5723,11 @@ var NETDATA = window.NETDATA || {};
                             Dygraph.startZoom(event, dygraph, context);
                         }
                         else {
-                            // left mouse button dragging (PAN)
+                            //console.log('left mouse button dragging (PAN)');
+
                             state.setMode('pan');
                             // NETDATA.globalSelectionSync.delay();
-                            state.tmp.dygraph_highlight_after = undefined;
+                            state.tmp.dygraph_highlight_after = null;
                             Dygraph.startPan(event, dygraph, context);
                         }
                     }
@@ -5730,12 +5736,16 @@ var NETDATA = window.NETDATA || {};
                     if(NETDATA.options.debug.dygraph === true || state.debug === true)
                         state.log('interactionModel.mousemove()');
 
-                    if(typeof state.tmp.dygraph_highlight_after !== 'undefined') {
+                    if(state.tmp.dygraph_highlight_after !== null) {
+                        //console.log('highlight selection...');
+
                         state.tmp.dygraph_user_action = true;
                         Dygraph.moveZoom(event, dygraph, context);
                         event.preventDefault();
                     }
                     else if(context.isPanning) {
+                        //console.log('panning...');
+
                         state.tmp.dygraph_user_action = true;
                         //NETDATA.globalSelectionSync.stop();
                         //NETDATA.globalSelectionSync.delay();
@@ -5744,6 +5754,8 @@ var NETDATA = window.NETDATA || {};
                         Dygraph.movePan(event, dygraph, context);
                     }
                     else if(context.isZooming) {
+                        //console.log('zooming...');
+
                         state.tmp.dygraph_user_action = true;
                         //NETDATA.globalSelectionSync.stop();
                         //NETDATA.globalSelectionSync.delay();
@@ -5757,7 +5769,9 @@ var NETDATA = window.NETDATA || {};
                     if(NETDATA.options.debug.dygraph === true || state.debug === true)
                         state.log('interactionModel.mouseup()');
 
-                    if(typeof state.tmp.dygraph_highlight_after !== 'undefined') {
+                    if(state.tmp.dygraph_highlight_after !== null) {
+                        //console.log('done highlight selection');
+
                         if (!(event.offsetX && event.offsetY)){
                             event.offsetX = event.layerX - event.target.offsetLeft;
                             event.offsetY = event.layerY - event.target.offsetTop;
@@ -5766,7 +5780,7 @@ var NETDATA = window.NETDATA || {};
                         context.isZooming = false;
                         NETDATA.options.highlight_after = state.tmp.dygraph_highlight_after;
                         NETDATA.options.highlight_before = dygraph.toDataXCoord(event.offsetX);
-                        state.tmp.dygraph_highlight_after = undefined;
+                        state.tmp.dygraph_highlight_after = null;
                         dygraph.clearZoomRect_();
                         dygraph.drawGraph_(false);
                         NETDATA.globalPanAndZoom.setMaster(state, state.view_after, state.view_before);
@@ -5775,11 +5789,15 @@ var NETDATA = window.NETDATA || {};
                             NETDATA.options.highlightCallback(true, NETDATA.options.highlight_after, NETDATA.options.highlight_before);
                     }
                     else if (context.isPanning) {
+                        //console.log('done panning');
+
                         state.tmp.dygraph_user_action = true;
                         //NETDATA.globalSelectionSync.delay();
                         Dygraph.endPan(event, dygraph, context);
                     }
                     else if (context.isZooming) {
+                        //console.log('done zomming');
+
                         state.tmp.dygraph_user_action = true;
                         //NETDATA.globalSelectionSync.delay();
                         Dygraph.endZoom(event, dygraph, context);
@@ -6020,6 +6038,7 @@ var NETDATA = window.NETDATA || {};
         state.tmp.dygraph_force_zoom = false;
         state.tmp.dygraph_user_action = false;
         state.tmp.dygraph_last_rendered = Date.now();
+        state.tmp.dygraph_highlight_after = null;
 
         if(state.tmp.dygraph_options.valueRange[0] === null && state.tmp.dygraph_options.valueRange[1] === null) {
             if (typeof state.tmp.dygraph_instance.axes_[0].extremeRange !== 'undefined') {

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -5674,6 +5674,7 @@ var NETDATA = window.NETDATA || {};
                     state.tmp.dygraph_mouse_down = true;
                     context.initializeMouseDown(event, dygraph, context);
 
+                    // console.log(event);
                     if(event.button && event.button === 1) {
                         if (event.shiftKey) {
                             // middle mouse button dragging (PAN)
@@ -5682,7 +5683,7 @@ var NETDATA = window.NETDATA || {};
                             state.tmp.dygraph_highlight_after = undefined;
                             Dygraph.startPan(event, dygraph, context);
                         }
-                        else if(event.altKey) {
+                        else if(event.altKey || event.ctrlKey || event.metaKey) {
                             // middle mouse button highlight
                             if (!(event.offsetX && event.offsetY)) {
                                 event.offsetX = event.layerX - event.target.offsetLeft;
@@ -5707,7 +5708,7 @@ var NETDATA = window.NETDATA || {};
                             state.tmp.dygraph_highlight_after = undefined;
                             Dygraph.startZoom(event, dygraph, context);
                         }
-                        else if(event.altKey) {
+                        else if(event.altKey || event.ctrlKey || event.metaKey) {
                             // left mouse button highlight
                             if (!(event.offsetX && event.offsetY)) {
                                 event.offsetX = event.layerX - event.target.offsetLeft;

--- a/web/index.html
+++ b/web/index.html
@@ -74,6 +74,7 @@
         text-align: center;
         overflow: hidden;
         z-index: 30;
+        pointer-events: none !important;
     }
 
     .navbar-highlight-content {
@@ -89,6 +90,11 @@
         padding-right: 15px;
         border-radius:10px;
         color: lightgrey;
+        pointer-events: auto !important;
+    }
+
+    .navbar-highlight-content-close {
+        cursor: pointer;
     }
 
     .modal-wide .modal-dialog {
@@ -686,7 +692,7 @@
                     var d1 = NETDATA.dateTime.localeDateString(after);
                     var d2 = NETDATA.dateTime.localeDateString(before);
                     if(d1 === d2) d2 = '';
-                    document.getElementById('navbar-highlight-content').innerHTML = 'Highlighted timeframe <b>' + d1 + ' <code>' + NETDATA.dateTime.localeTimeString(after) + '</code></b> to <b>' + d2 + ' <code>' + NETDATA.dateTime.localeTimeString(before) + '</code></b>, duration <b>' + NETDATA.seconds4human(Math.round((before - after) / 1000)) + '</b> <span onclick="urlOptions.clearHighlight();" style="padding-left: 10px;"><i class="fa fa-times" aria-hidden="true"></i></span>';
+                    document.getElementById('navbar-highlight-content').innerHTML = 'Highlighted timeframe <b>' + d1 + ' <code>' + NETDATA.dateTime.localeTimeString(after) + '</code></b> to <b>' + d2 + ' <code>' + NETDATA.dateTime.localeTimeString(before) + '</code></b>, duration <b>' + NETDATA.seconds4human(Math.round((before - after) / 1000)) + '</b> <span class="navbar-highlight-content-close" onclick="urlOptions.clearHighlight();" style="padding-left: 10px;"><i class="fa fa-times" aria-hidden="true"></i></span>';
                     $('.navbar-highlight').show();
                 }
                 else
@@ -5312,6 +5318,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171118-2"></script>
+    <script type="text/javascript" src="dashboard.js?v20171118-3"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -895,8 +895,8 @@
                         icon = "window-restore";
                     }
 
-                    el += '<li id="registry_server_hosted_' + len.toString() + '"><a class="registry_link" href="' + url + '" onClick="return gotoHostedModalHandler(\'' + url + '\');">' + hostname + '</a></li>';
-                    a1 += '<li id="registry_action_hosted_' + len.toString() + '"><a class="registry_link" href="' + url + '" onClick="return gotoHostedModalHandler(\'' + url + '\');"><i class="fa fa-' + icon + '" aria-hidden="true" style="color: #999;"></i></a></li>';
+                    el += '<li id="registry_server_hosted_' + len.toString() + '"><a class="registry_link" href="' + url + '#" onClick="return gotoHostedModalHandler(\'' + url + '\');">' + hostname + '</a></li>';
+                    a1 += '<li id="registry_action_hosted_' + len.toString() + '"><a class="registry_link" href="' + url + '#" onClick="return gotoHostedModalHandler(\'' + url + '\');"><i class="fa fa-' + icon + '" aria-hidden="true" style="color: #999;"></i></a></li>';
                     hosted++;
                     i++;
                 }
@@ -925,7 +925,7 @@
                 while(len--) {
                     var u = machines[i++];
                     found++;
-                    el += '<li id="registry_server_' + u.guid + '"><a class="registry_link" href="' + u.url + '" onClick="return gotoServerModalHandler(\'' + u.guid + '\');">' + u.name + '</a></li>';
+                    el += '<li id="registry_server_' + u.guid + '"><a class="registry_link" href="' + u.url + '#" onClick="return gotoServerModalHandler(\'' + u.guid + '\');">' + u.name + '</a></li>';
                     a1 += '<li id="registry_action_' + u.guid + '"><a href="#" onclick="deleteRegistryModalHandler(\'' + u.guid + '\',\'' + u.name + '\',\'' + u.url + '\'); return false;"><i class="fa fa-trash-o" aria-hidden="true" style="color: #999;"></i></a></li>';
                 }
             }
@@ -3928,6 +3928,11 @@
 
             $('#myNetdataDropdownParent')
                 .on('show.bs.dropdown', function () {
+                    var hash = urlOptions.genHash();
+                    $('.registry_link').each(function(idx) {
+                       this.setAttribute('href', this.getAttribute("href").replace(/#.*$/, hash));
+                    });
+
                     NETDATA.pause(function() {});
                 })
                 .on('shown.bs.dropdown', function () {

--- a/web/index.html
+++ b/web/index.html
@@ -5288,6 +5288,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171118-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20171118-2"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -65,6 +65,32 @@
         text-align: center;
     }
 
+    .navbar-highlight {
+        display: none;
+        position: fixed;
+        margin-top: 5px;
+        height: 26px;
+        width: 100%;
+        text-align: center;
+        overflow: hidden;
+        z-index: 30;
+    }
+
+    .navbar-highlight-content {
+        position: relative;
+        display: inline-block;
+        margin: 0 auto;
+        height: 26px;
+        min-width: 500px;
+        background-color:rgba(0, 0, 0, 0.7);
+        padding-top: 2px;
+        padding-bottom: 2px;
+        padding-left: 15px;
+        padding-right: 15px;
+        border-radius:10px;
+        color: lightgrey;
+    }
+
     .modal-wide .modal-dialog {
         width: 80%;
     }
@@ -496,6 +522,9 @@
             server: null,
             after: 0,
             before: 0,
+            highlight: false,
+            highlight_after: 0,
+            highlight_before: 0,
             nowelcome: false,
             show_alarms: false,
             chart: null,
@@ -515,7 +544,12 @@
 
                 if(urlOptions.pan_and_zoom === true) {
                     hash += ';after='  + urlOptions.after.toString() +
-                            ';before=' + urlOptions.before.toString();
+                        ';before=' + urlOptions.before.toString();
+                }
+
+                if(urlOptions.highlight === true) {
+                    hash += ';highlight_after='  + urlOptions.highlight_after.toString() +
+                        ';highlight_before=' + urlOptions.highlight_before.toString();
                 }
 
                 if(urlOptions.theme !== null)
@@ -551,7 +585,7 @@
                     }
                 }
 
-                var booleans = [ 'nowelcome', 'show_alarms', 'pan_and_zoom', 'update_always' ];
+                var booleans = [ 'nowelcome', 'show_alarms', 'update_always' ];
                 len = booleans.length;
                 while(len--) {
                     if(urlOptions[booleans[len]] === 'true' || urlOptions[booleans[len]] === true || urlOptions[booleans[len]] === '1' || urlOptions[booleans[len]] === 1)
@@ -577,6 +611,12 @@
                 }
                 else
                     urlOptions.pan_and_zoom = false;
+
+                if(urlOptions.highlight_before > 0 && urlOptions.highlight_after > 0) {
+                    urlOptions.highlight = true;
+                }
+                else
+                    urlOptions.highlight = false
 
                 switch(urlOptions.mode) {
                     case 'print':
@@ -616,6 +656,33 @@
                     urlOptions.before = before;
                     urlOptions.hashUpdate();
                 }
+            },
+
+            netdataHighlightCallback: function(status, after, before) {
+                urlOptions.highlight = status;
+                urlOptions.highlight_after = Math.round(after);
+                urlOptions.highlight_before = Math.round(before);
+                urlOptions.hashUpdate();
+
+                if(status === true) {
+                    var d1 = NETDATA.dateTime.localeDateString(urlOptions.highlight_after);
+                    var d2 = NETDATA.dateTime.localeDateString(urlOptions.highlight_before);
+                    if(d1 === d2) d2 = '';
+                    document.getElementById('navbar-highlight-content').innerHTML = 'Highlighted timeframe <b>' + d1 + ' <code>' + NETDATA.dateTime.localeTimeString(urlOptions.highlight_after) + '</code></b> to <b>' + d2 + ' <code>' + NETDATA.dateTime.localeTimeString(urlOptions.highlight_before) + '</code></b>, duration <b>' + NETDATA.seconds4human(Math.round((urlOptions.highlight_before - urlOptions.highlight_after) / 1000)) + '</b> <span onclick="urlOptions.clearHighlight();" style="padding-left: 10px;"><i class="fa fa-times" aria-hidden="true"></i></span>';
+                    $('.navbar-highlight').show();
+                }
+                else
+                    $('.navbar-highlight').hide();
+            },
+
+            clearHighlight: function() {
+                NETDATA.options.highlight_after = null;
+                NETDATA.options.highlight_before = null;
+
+                if(NETDATA.globalPanAndZoom.isActive() === true)
+                    NETDATA.globalPanAndZoom.clearMaster();
+
+                urlOptions.netdataHighlightCallback(false, 0, 0);
             }
 
         };
@@ -3569,6 +3636,13 @@
 
             // callback for us to track PanAndZoom operations
             NETDATA.globalPanAndZoom.callback = urlOptions.netdataPanAndZoomCallback;
+            NETDATA.options.highlightCallback = urlOptions.netdataHighlightCallback;
+
+            if(urlOptions.highlight === true) {
+                NETDATA.options.highlight_after = urlOptions.highlight_after;
+                NETDATA.options.highlight_before = urlOptions.highlight_before;
+                urlOptions.netdataHighlightCallback(urlOptions.highlight, urlOptions.highlight_after, urlOptions.highlight_before);
+            }
 
             // let it run (update the charts)
             NETDATA.unpause();
@@ -4030,6 +4104,11 @@
             </nav>
         </div>
     </nav>
+    <div class="navbar-highlight">
+        <div id="navbar-highlight-content" class="navbar-highlight-content">
+            hello world
+        </div>
+    </div>
 
     <div id="masthead" style="display: none;">
         <div class="container">
@@ -4374,7 +4453,7 @@
                             <hr/>
                             <div class="p">
                                 <h4>Drag Chart Contents</h4>
-                                Drag the contents of a chart to pan it horizontally.
+                                Drag the contents of a chart, by pressing the left mouse button and moving the mouse, to pan it horizontally.
                                 <br/>
                                 All the charts will follow soon after you let the chart alone (this little delay is by design: it speeds up your browser and lets you focus on what you are exploring).
                                 <br/>
@@ -4388,7 +4467,7 @@
                             <hr/>
                             <div class="p">
                                 <h4>SHIFT + Drag</h4>
-                                While pressing the shift key, click on the contents of a chart and move the mouse to select an area, to zoom in. The other charts will follow too. Zooming is performed in two phases:
+                                While pressing the <code>SHIFT</code> key, press the left mouse button on the contents of a chart and move the mouse to select an area, to zoom in. The other charts will follow too. Zooming is performed in two phases:
                                 <ul>
                                     <li>The already loaded chart contents are zoomed (low resolution)</li>
                                     <li>New data are transferred from the netdata server, to refresh the chart with possibly more detail.</li>
@@ -4397,8 +4476,13 @@
                             </div>
                             <hr/>
                             <div class="p">
+                                <h4>Highlight Timeframe</h4>
+                                While pressing the <code>ALT</code> key, press the left mouse button on the contents of a chart and move the mouse to select an area. The selected are will be highlighted on all charts.
+                            </div>
+                            <hr/>
+                            <div class="p">
                                 <h4>SHIFT + Mouse Wheel</h4>
-                                While pressing the shift key and the mouse pointer is over the contents of a chart, scroll the mouse wheel to zoom in or out. This kind of zooming is aligned to center below the mouse pointer. The other charts will follow too.
+                                While pressing the <code>SHIFT</code> key and the mouse pointer is over the contents of a chart, scroll the mouse wheel to zoom in or out. This kind of zooming is aligned to center below the mouse pointer. The other charts will follow too.
                                 <br/>
                                 Once a chart is zoomed, auto refreshing stops for all charts. To enable it again, <b>double click</b> a zoomed chart.
                             </div>
@@ -5165,6 +5249,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171117-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20171118-1"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -3083,6 +3083,17 @@
                     else
                         urlOptions.hash = '#';
 
+                    if( typeof tmpSnapshotData.highlight_after_ms !== 'undefined' && tmpSnapshotData.highlight_after_ms !== null && typeof tmpSnapshotData.highlight_before_ms !== 'undefined' && tmpSnapshotData.highlight_before_ms !== null) {
+                        urlOptions.highlight = true;
+                        urlOptions.highlight_after = tmpSnapshotData.highlight_after_ms;
+                        urlOptions.highlight_before = tmpSnapshotData.highlight_before_ms;
+                    }
+                    else {
+                        urlOptions.highlight = false;
+                        urlOptions.highlight_after = 0;
+                        urlOptions.highlight_before = 0;
+                    }
+
                     if (typeof tmpSnapshotData.info !== 'undefined') {
                         var info = jsonParseFn(tmpSnapshotData.info);
                         if (typeof info.menu !== 'undefined')
@@ -3333,6 +3344,8 @@
                         snapshot_version: 1,
                         after_ms: Date.now() - options.duration * 1000,
                         before_ms: Date.now(),
+                        highlight_after_ms: urlOptions.highlight_after,
+                        highlight_before_ms: urlOptions.highlight_before,
                         duration_ms: options.duration * 1000,
                         update_every_ms: options.update_every * 1000,
                         data_points: 0,

--- a/web/index.html
+++ b/web/index.html
@@ -1860,6 +1860,12 @@
             div.innerHTML = html;
             document.getElementById('sidebar').innerHTML = sidebar;
 
+            if(urlOptions.highlight === true) {
+                NETDATA.options.highlight_after = urlOptions.highlight_after;
+                NETDATA.options.highlight_before = urlOptions.highlight_before;
+                urlOptions.netdataHighlightCallback(urlOptions.highlight, urlOptions.highlight_after, urlOptions.highlight_before);
+            }
+
             if(urlOptions.mode === 'print')
                 printPage();
             else
@@ -3700,12 +3706,6 @@
             NETDATA.globalPanAndZoom.callback = urlOptions.netdataPanAndZoomCallback;
             NETDATA.options.highlightCallback = urlOptions.netdataHighlightCallback;
 
-            if(urlOptions.highlight === true) {
-                NETDATA.options.highlight_after = urlOptions.highlight_after;
-                NETDATA.options.highlight_before = urlOptions.highlight_before;
-                urlOptions.netdataHighlightCallback(urlOptions.highlight, urlOptions.highlight_after, urlOptions.highlight_before);
-            }
-
             // let it run (update the charts)
             NETDATA.unpause();
 
@@ -4696,7 +4696,7 @@
                                     <tr class="option-row">
                                         <td class="option-control"><input id="async_on_scroll" type="checkbox" data-toggle="toggle" data-on="Async" data-off="Sync" data-width="110px"></td>
                                         <td class="option-info"><strong>Page scroll handling?</strong><br/>
-                                            <small>When set to <b>Sync</b>, charts will be examined for their visibility synchronously. On slow computers this may impact the smoothness of page scrolling. To work asynchronously set it to <b>Async</b>. When set to <b>Sync</b>, the performance of page scrolling is monitored and this setting switches automatically to <b>Async</b> if the browser is found slow. Set it to <b>Sync</b> for best visual experience. Set it to <b>Async</b> for smoother page scrolling.</small>
+                                            <small>When set to <b>Sync</b>, charts will be examined for their visibility immediately after scrolling. On slow computers this may impact the smoothness of page scrolling. To update the page when scrolling ends, set it to <b>Async</b>. Set it to <b>Sync</b> for immediate chart updates when scrolling. Set it to <b>Async</b> for smoother page scrolling on slower computers.</small>
                                         </td>
                                         </tr>
                                     </table>
@@ -5318,6 +5318,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171118-3"></script>
+    <script type="text/javascript" src="dashboard.js?v20171118-5"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -673,12 +673,14 @@
                     before = 0;
                 }
 
-                if(netdataSnapshotData === null) {
+                if(netdataSnapshotData === null)
                     urlOptions.highlight = status;
-                    urlOptions.highlight_after = Math.round(after);
-                    urlOptions.highlight_before = Math.round(before);
-                    urlOptions.hashUpdate();
-                }
+                else
+                    urlOptions.highlight = false;
+
+                urlOptions.highlight_after = Math.round(after);
+                urlOptions.highlight_before = Math.round(before);
+                urlOptions.hashUpdate();
 
                 if(status === true && after > 0 && before > 0 && after < before) {
                     var d1 = NETDATA.dateTime.localeDateString(after);

--- a/web/index.html
+++ b/web/index.html
@@ -3412,6 +3412,7 @@
 
                         NETDATA.options.force_data_points = 0;
                         NETDATA.options.fake_chart_rendering = false;
+                        NETDATA.onscroll_updater_enabled = true;
                         NETDATA.onresize();
                         NETDATA.unpause();
                     }
@@ -3420,6 +3421,9 @@
                         NETDATA.globalSelectionSync.stop();
                         NETDATA.options.force_data_points = saveData.data_points;
                         NETDATA.options.fake_chart_rendering = true;
+                        NETDATA.onscroll_updater_enabled = false;
+                        NETDATA.abort_all_refreshes();
+
                         var size = 0;
 
                         function update_chart(idx) {

--- a/web/index.html
+++ b/web/index.html
@@ -594,11 +594,19 @@
                         urlOptions[booleans[len]] = false;
                 }
 
-                if(typeof urlOptions.after === 'string')
-                    urlOptions.after = parseInt(urlOptions.after);
-
-                if(typeof urlOptions.before === 'string')
-                    urlOptions.before = parseInt(urlOptions.before);
+                var numeric = [ 'after', 'before', 'highlight_after', 'highlight_before' ];
+                len = numeric.length;
+                while(len--) {
+                    if(typeof urlOptions[numeric[len]] === 'string') {
+                        try {
+                            urlOptions[numeric[len]] = parseInt(urlOptions[numeric[len]]);
+                        }
+                        catch(e) {
+                            console.log('failed to parse URL hash parameter ' + numeric[len]);
+                            urlOptions[numeric[len]] = 0;
+                        }
+                    }
+                }
 
                 if(urlOptions.server !== null && urlOptions.server !== '')
                     netdataServer = urlOptions.server;
@@ -3684,7 +3692,7 @@
             NETDATA.globalPanAndZoom.callback = urlOptions.netdataPanAndZoomCallback;
             NETDATA.options.highlightCallback = urlOptions.netdataHighlightCallback;
 
-            if(netdataSnapshotData !== null && urlOptions.highlight === true) {
+            if(urlOptions.highlight === true) {
                 NETDATA.options.highlight_after = urlOptions.highlight_after;
                 NETDATA.options.highlight_before = urlOptions.highlight_before;
                 urlOptions.netdataHighlightCallback(urlOptions.highlight, urlOptions.highlight_after, urlOptions.highlight_before);

--- a/web/index.html
+++ b/web/index.html
@@ -659,7 +659,7 @@
             },
 
             netdataHighlightCallback: function(status, after, before) {
-                if(status === true && (after === null || before === null || after <= 0 || before <= 0 || after < before)) {
+                if(status === true && (after === null || before === null || after <= 0 || before <= 0 || after >= before)) {
                     status = false;
                     after = 0;
                     before = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -659,16 +659,18 @@
             },
 
             netdataHighlightCallback: function(status, after, before) {
-                urlOptions.highlight = status;
-                urlOptions.highlight_after = Math.round(after);
-                urlOptions.highlight_before = Math.round(before);
-                urlOptions.hashUpdate();
+                if(netdataSnapshotData === null) {
+                    urlOptions.highlight = status;
+                    urlOptions.highlight_after = Math.round(after);
+                    urlOptions.highlight_before = Math.round(before);
+                    urlOptions.hashUpdate();
+                }
 
                 if(status === true) {
-                    var d1 = NETDATA.dateTime.localeDateString(urlOptions.highlight_after);
-                    var d2 = NETDATA.dateTime.localeDateString(urlOptions.highlight_before);
+                    var d1 = NETDATA.dateTime.localeDateString(after);
+                    var d2 = NETDATA.dateTime.localeDateString(before);
                     if(d1 === d2) d2 = '';
-                    document.getElementById('navbar-highlight-content').innerHTML = 'Highlighted timeframe <b>' + d1 + ' <code>' + NETDATA.dateTime.localeTimeString(urlOptions.highlight_after) + '</code></b> to <b>' + d2 + ' <code>' + NETDATA.dateTime.localeTimeString(urlOptions.highlight_before) + '</code></b>, duration <b>' + NETDATA.seconds4human(Math.round((urlOptions.highlight_before - urlOptions.highlight_after) / 1000)) + '</b> <span onclick="urlOptions.clearHighlight();" style="padding-left: 10px;"><i class="fa fa-times" aria-hidden="true"></i></span>';
+                    document.getElementById('navbar-highlight-content').innerHTML = 'Highlighted timeframe <b>' + d1 + ' <code>' + NETDATA.dateTime.localeTimeString(after) + '</code></b> to <b>' + d2 + ' <code>' + NETDATA.dateTime.localeTimeString(before) + '</code></b>, duration <b>' + NETDATA.seconds4human(Math.round((before - after) / 1000)) + '</b> <span onclick="urlOptions.clearHighlight();" style="padding-left: 10px;"><i class="fa fa-times" aria-hidden="true"></i></span>';
                     $('.navbar-highlight').show();
                 }
                 else
@@ -2642,7 +2644,7 @@
                 if(netdataSnapshotData !== null) {
                     $('#alarmsButton').hide();
                     $('#updateButton').hide();
-                    $('#loadButton').hide();
+                    // $('#loadButton').hide();
                     $('#saveButton').hide();
                     $('#printButton').hide();
                 }
@@ -3060,6 +3062,8 @@
 
         var tmpSnapshotData = null;
         function loadSnapshot() {
+            $('#loadSnapshotImport').addClass('disabled');
+
             if(tmpSnapshotData === null) {
                 loadSnapshotModalLog('danger', 'no data have been loaded');
                 return;
@@ -3083,17 +3087,6 @@
                     else
                         urlOptions.hash = '#';
 
-                    if( typeof tmpSnapshotData.highlight_after_ms !== 'undefined' && tmpSnapshotData.highlight_after_ms !== null && typeof tmpSnapshotData.highlight_before_ms !== 'undefined' && tmpSnapshotData.highlight_before_ms !== null) {
-                        urlOptions.highlight = true;
-                        urlOptions.highlight_after = tmpSnapshotData.highlight_after_ms;
-                        urlOptions.highlight_before = tmpSnapshotData.highlight_before_ms;
-                    }
-                    else {
-                        urlOptions.highlight = false;
-                        urlOptions.highlight_after = 0;
-                        urlOptions.highlight_before = 0;
-                    }
-
                     if (typeof tmpSnapshotData.info !== 'undefined') {
                         var info = jsonParseFn(tmpSnapshotData.info);
                         if (typeof info.menu !== 'undefined')
@@ -3115,10 +3108,20 @@
                     }
 
                     tmpSnapshotData.uncompress = snapshotOptions.compressions[tmpSnapshotData.compression].uncompress;
-
                     netdataSnapshotData = tmpSnapshotData;
-                    initializeDynamicDashboard(netdataSnapshotData.url);
 
+                    if( typeof tmpSnapshotData.highlight_after_ms !== 'undefined' && tmpSnapshotData.highlight_after_ms !== null && typeof tmpSnapshotData.highlight_before_ms !== 'undefined' && tmpSnapshotData.highlight_before_ms !== null) {
+                        NETDATA.options.highlight_after = tmpSnapshotData.highlight_after_ms;
+                        NETDATA.options.highlight_before = tmpSnapshotData.highlight_before_ms;
+                        urlOptions.netdataHighlightCallback(true, tmpSnapshotData.highlight_after_ms, tmpSnapshotData.highlight_before_ms);
+                    }
+                    else {
+                        NETDATA.options.highlight_after = null;
+                        NETDATA.options.highlight_before = null;
+                        urlOptions.netdataHighlightCallback(false, 0, 0);
+                    }
+
+                    initializeDynamicDashboard(netdataSnapshotData.url);
                     $('#loadSnapshotModal').modal('hide');
                 });
             });
@@ -3127,6 +3130,14 @@
         function loadSnapshotPreflight() {
             var files = document.getElementById('loadSnapshotSelectFiles').files;
             if (files.length <= 0) {
+                document.getElementById('loadSnapshotFilename').innerHTML = '';
+                document.getElementById('loadSnapshotHostname').innerHTML = '';
+                document.getElementById('loadSnapshotURL').innerHTML = '';
+                document.getElementById('loadSnapshotCharts').innerHTML = '';
+                document.getElementById('loadSnapshotInfo').innerHTML = '';
+                document.getElementById('loadSnapshotTimeRange').innerHTML = '';
+                document.getElementById('loadSnapshotComments').innerHTML = '';
+                $('#loadSnapshotImport').addClass('disabled');
                 loadSnapshotModalLog('danger', 'No file selected');
                 return;
             }
@@ -3165,8 +3176,7 @@
                     document.getElementById('loadSnapshotTimeRange').innerHTML = '<b>' + NETDATA.dateTime.localeDateString(date_after) + ' ' + NETDATA.dateTime.localeTimeString(date_after) + '</b> to <b>' + NETDATA.dateTime.localeDateString(date_before) + ' ' + NETDATA.dateTime.localeTimeString(date_before) + '</b>';
                     document.getElementById('loadSnapshotComments').innerHTML = ((result.comments)?result.comments:'').toString();
                     loadSnapshotModalLog('success', 'File loaded, click <b>Import</b> to render it!');
-                    $('#loadSnapshotImport').prop('disabled', false);
-                    $('#loadSnapshotImport').removeAttr('disabled');
+                    $('#loadSnapshotImport').removeClass('disabled');
 
                     tmpSnapshotData = result;
                 }
@@ -3174,6 +3184,7 @@
                     console.log(e);
                     document.getElementById('loadSnapshotStatus').className = "alert alert-danger";
                     document.getElementById('loadSnapshotStatus').innerHTML = "Failed to parse this file!";
+                    $('#loadSnapshotImport').addClass('disabled');
                 }
             }
 
@@ -3239,6 +3250,7 @@
             $('#saveSnapshotModalProgressSection').hide();
             $('#saveSnapshotResolutionRadio').show();
             saveSnapshotModalLog('info', 'Select resolution and click <b>Save</b>');
+            $('#saveSnapshotExport').removeClass('disabled');
 
             loadBootstrapSlider(function() {
                 saveSnapshotViewDuration = options.duration;
@@ -3307,6 +3319,8 @@
                     saveSnapshotStop = false;
                     $('#saveSnapshotModalProgressSection').show();
                     $('#saveSnapshotResolutionRadio').hide();
+                    $('#saveSnapshotExport').addClass('disabled');
+
                     var filename = document.getElementById('saveSnapshotFilename').value;
                     // console.log(filename);
                     saveSnapshotModalLog('info', 'Generating snapshot as <code>' + filename.toString() + '</code>');
@@ -3428,6 +3442,8 @@
                         NETDATA.onscroll_updater_enabled = true;
                         NETDATA.onresize();
                         NETDATA.unpause();
+
+                        $('#saveSnapshotExport').removeClass('disabled');
                     }
 
                     NETDATA.pause(function () {
@@ -3438,6 +3454,7 @@
                         NETDATA.abort_all_refreshes();
 
                         var size = 0;
+                        var info = ' Resolution: <b>' + saveSnapshotSelectedSecondsPerPoint.toString() + ((saveSnapshotSelectedSecondsPerPoint === 1)?' second ':' seconds ').toString() + 'per point</b>.';
 
                         function update_chart(idx) {
                             if (saveSnapshotStop === true) {
@@ -3472,7 +3489,7 @@
                                         state.log('failed to be updated: ' + reason);
                                     }
 
-                                    saveSnapshotModalLog((charts_failed) ? 'danger' : 'info', 'Generated size ' + (Math.round(size * 100 / 1024 / 1024) / 100).toString() + ' MB. ' + ((charts_failed) ? (charts_failed.toString() + ' charts have failed to be downloaded') : '').toString());
+                                    saveSnapshotModalLog((charts_failed) ? 'danger' : 'info', 'Generated snapshot data size <b>' + (Math.round(size * 100 / 1024 / 1024) / 100).toString() + ' MB</b>. ' + ((charts_failed) ? (charts_failed.toString() + ' charts have failed to be downloaded') : '').toString() + info);
 
                                     if (idx > 0) {
                                         update_chart(idx);
@@ -3655,7 +3672,7 @@
             NETDATA.globalPanAndZoom.callback = urlOptions.netdataPanAndZoomCallback;
             NETDATA.options.highlightCallback = urlOptions.netdataHighlightCallback;
 
-            if(urlOptions.highlight === true) {
+            if(netdataSnapshotData !== null && urlOptions.highlight === true) {
                 NETDATA.options.highlight_after = urlOptions.highlight_after;
                 NETDATA.options.highlight_before = urlOptions.highlight_before;
                 urlOptions.netdataHighlightCallback(urlOptions.highlight, urlOptions.highlight_after, urlOptions.highlight_before);
@@ -4310,7 +4327,7 @@
                     </p>
                 </div>
                 <div class="modal-footer">
-                    <a id="loadSnapshotImport" href="#" onclick="loadSnapshot(); return false;" type="button" class="btn btn-success btn-disabled" disabled>Import</a>
+                    <a id="loadSnapshotImport" href="#" onclick="loadSnapshot(); return false;" type="button" class="btn btn-success disabled">Import</a>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>

--- a/web/index.html
+++ b/web/index.html
@@ -659,6 +659,12 @@
             },
 
             netdataHighlightCallback: function(status, after, before) {
+                if(status === true && (after === null || before === null || after <= 0 || before <= 0 || after < before)) {
+                    status = false;
+                    after = 0;
+                    before = 0;
+                }
+
                 if(netdataSnapshotData === null) {
                     urlOptions.highlight = status;
                     urlOptions.highlight_after = Math.round(after);
@@ -666,7 +672,7 @@
                     urlOptions.hashUpdate();
                 }
 
-                if(status === true) {
+                if(status === true && after > 0 && before > 0 && after < before) {
                     var d1 = NETDATA.dateTime.localeDateString(after);
                     var d2 = NETDATA.dateTime.localeDateString(before);
                     if(d1 === d2) d2 = '';
@@ -3110,7 +3116,13 @@
                     tmpSnapshotData.uncompress = snapshotOptions.compressions[tmpSnapshotData.compression].uncompress;
                     netdataSnapshotData = tmpSnapshotData;
 
-                    if( typeof tmpSnapshotData.highlight_after_ms !== 'undefined' && tmpSnapshotData.highlight_after_ms !== null && typeof tmpSnapshotData.highlight_before_ms !== 'undefined' && tmpSnapshotData.highlight_before_ms !== null) {
+                    if( typeof tmpSnapshotData.highlight_after_ms !== 'undefined'
+                        && tmpSnapshotData.highlight_after_ms !== null
+                        && tmpSnapshotData.highlight_after_ms > 0
+                        && typeof tmpSnapshotData.highlight_before_ms !== 'undefined'
+                        && tmpSnapshotData.highlight_before_ms !== null
+                        && tmpSnapshotData.highlight_before_ms > 0
+                    ) {
                         NETDATA.options.highlight_after = tmpSnapshotData.highlight_after_ms;
                         NETDATA.options.highlight_before = tmpSnapshotData.highlight_before_ms;
                         urlOptions.netdataHighlightCallback(true, tmpSnapshotData.highlight_after_ms, tmpSnapshotData.highlight_before_ms);

--- a/web/index.html
+++ b/web/index.html
@@ -3720,9 +3720,11 @@
             });
 
             /* activate bootstrap scrollspy (needed for sidebar) */
-            var scrollspyOffset = $(window).height() / 5;
-            if(scrollspyOffset > 200) scrollspyOffset = 200;
-            if(scrollspyOffset < 50) scrollspyOffset = 50;
+            var scrollspyOffset = $(window).height() / 3;
+            if(scrollspyOffset > 250) scrollspyOffset = 250;
+            if(scrollspyOffset < 75) scrollspyOffset = 75;
+            document.body.setAttribute('data-offset', scrollspyOffset);
+            // console.log(scrollspyOffset);
             $(document.body).scrollspy({
                 target: '#sidebar',
                 offset: scrollspyOffset // controls the diff of the <hX> element to the top, to select it
@@ -4093,7 +4095,7 @@
     </script>
 </head>
 
-<body data-spy="scroll" data-target="#sidebar">
+<body data-spy="scroll" data-target="#sidebar" data-offset="100">
     <div id="loadOverlay" class="loadOverlay" style="background-color: #888; color: #888;">
         netdata<br/><div style="font-size: 3vh;">Real-time performance monitoring, done right!</div>
     </div>


### PR DESCRIPTION
Pressing the ALT key and selecting a timeframe at a chart, highlights the same area on all charts, and shows at the top the selected timeframe.

The selected timeframe:

1. is added at the URL hash, so that hitting F5 will preserve it.
2. is transferred among netdata servers, via the registry
3. is maintained when panning and zooming, even if the timeframe is not visible
4. can be dismissed by hitting the X at the overlay

![screenshot from 2017-11-18 03-42-15](https://user-images.githubusercontent.com/2662304/32975692-a5843a06-cc12-11e7-804b-9d39161c8f4d.png)

![screenshot from 2017-11-18 03-44-32](https://user-images.githubusercontent.com/2662304/32975702-d18f5a04-cc12-11e7-92b1-2d27c4c45841.png)

---

Fixes a bug in scrollspy that was selecting the wrong menu item; fixes #2356 

---

Rewrote the page scroll handlers to support passive events. There is still an issue with chrome that is somehow randomly delaying events by 2 seconds.

Now netdata renders the charts when the window does not have focus, but the page is scrolled.

Scrolling `sync` and `async` modes have been reworked. netdata scrolling is amazing again! Especially on firefox v57, `sync` scrolling is wow!

---

Registry items now change URL every time the `my-netdata` menu is pressed. This allows propagating the URL hash (pan and zoom, highlighted timeframe, etc) to other netdata servers, by pressing right mouse button on a registry item and selecting `open in new window/tab`.

---

many snapshot improvements:

1. now it allows only one snapshot save at a time (previously a double click on the **Export** button triggered 2 saves at the same time.

2. now it allows only one snapshot load at a time (like before)

3. fixed an issue in snapshots that prevented certain charts to be saved in the snapshot if they had outstanding network connections to be refreshed (now the connections are aborted)
