### PR TITLE
switched default compression to pako.deflate.base64, since lzstring.utf16 generates faulty data on safari

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2981,7 +2981,7 @@
 
         var snapshotOptions = {
             bytes_per_chart: 2048,
-            compressionDefault: 'lzstring.utf16',
+            compressionDefault: 'pako.deflate.base64',
 
             compressions: {
                 'none': {
@@ -5326,6 +5326,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171118-6"></script>
+    <script type="text/javascript" src="dashboard.js?v20171120-1"></script>
 </body>
 </html>


### PR DESCRIPTION
netdata snapshots exported on safari with `lzstring.utf16` encoding, are corrupted. https://github.com/pieroxy/lz-string/issues/60

The next best compression is `pako.deflate.base64` which is now the default. https://github.com/firehol/netdata/pull/3015

Added some code to get better logs about errors during decompression.