### PR TITLE
isc_dhcpd epoch

### DIFF
--- a/conf.d/python.d/bind_rndc.conf
+++ b/conf.d/python.d/bind_rndc.conf
@@ -82,7 +82,7 @@
 # chown bind bind/
 #
 # 4. RELOAD (NOT restart) BIND
-# systemctl reload bind9.serice
+# systemctl reload bind9.service
 #
 # 5. Run as a root 'rndc stats' to dump (BIND will create named.stats in new directory)
 # 

--- a/python.d/isc_dhcpd.chart.py
+++ b/python.d/isc_dhcpd.chart.py
@@ -150,7 +150,7 @@ def binding_active(lease_end_time, current_time):
     if lease_end_time.startswith('epoch'):
         epoch = int(lease_end_time.split()[1].replace(';',''))
         return epoch - current_time > 0
-    # max. int for lease-time causes lease to expire in year 2038. 
+    # max. int for lease-time causes lease to expire in year 2038.
     # dhcpd puts 'never' in the ends section of active lease
     elif lease_end_time == 'never':
         return True

--- a/python.d/isc_dhcpd.chart.py
+++ b/python.d/isc_dhcpd.chart.py
@@ -56,7 +56,6 @@ class Service(SimpleService):
 
         # Will work only with 'default' db-time-format (weekday year/month/day hour:minute:second)
         # TODO: update algorithm to parse correctly 'local' db-time-format
-        # (epoch <seconds-since-epoch>; # <day-name> <month-name> <day-number> <hours>:<minutes>:<seconds> <year>)
         # Also only ipv4 supported
 
     def check(self):
@@ -147,7 +146,16 @@ class Service(SimpleService):
 
 
 def binding_active(lease_end_time, current_time):
-    return mktime(strptime(lease_end_time, '%w %Y/%m/%d %H:%M:%S')) - current_time > 0
+    # lease_end_time might be epoch
+    if lease_end_time.startswith('epoch'):
+        epoch = int(lease_end_time.split()[1].replace(';',''))
+        return epoch - current_time > 0
+    # max. int for lease-time causes lease to expire in year 2038. 
+    # dhcpd puts 'never' in the ends section of active lease
+    elif lease_end_time == 'never':
+        return True
+    else:
+        return mktime(strptime(lease_end_time, '%w %Y/%m/%d %H:%M:%S')) - current_time > 0
 
 
 def find_lease(value):


### PR DESCRIPTION
Something to scratch off to-do list:
- lease_end_time in epoch is now correctly parsed
- infinite lease time (0xFFFFFFFF) causes dhcpd to output "ends: never" in the lease block