### PR TITLE
dashboard scroll improvement and more

### DIFF
--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -44,6 +44,8 @@ body {
     display: inline-block;
     overflow: hidden;
 
+    transform: translate3d(0,0,0);
+
     /* required for child elements to have absolute position */
     position: relative;
 
@@ -53,6 +55,8 @@ body {
 .netdata-container-gauge {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* required for child elements to have absolute position */
     position: relative;
@@ -69,6 +73,8 @@ body {
 .netdata-container-easypiechart {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* required for child elements to have absolute position */
     position: relative;
@@ -92,6 +98,8 @@ body {
 .netdata-container-with-legend {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* fix minimum scrollbar issue in firefox */
     min-height: 99px;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -146,7 +146,7 @@ var NETDATA = window.NETDATA || {};
     NETDATA.themes = {
         white: {
             bootstrap_css: NETDATA.serverDefault + 'css/bootstrap-3.3.7.css',
-            dashboard_css: NETDATA.serverDefault + 'dashboard.css?v20171111-5',
+            dashboard_css: NETDATA.serverDefault + 'dashboard.css?v20171127-1',
             background: '#FFFFFF',
             foreground: '#000000',
             grid: '#F0F0F0',
@@ -164,7 +164,7 @@ var NETDATA = window.NETDATA || {};
         },
         slate: {
             bootstrap_css: NETDATA.serverDefault + 'css/bootstrap-slate-flat-3.3.7.css?v20161229-1',
-            dashboard_css: NETDATA.serverDefault + 'dashboard.slate.css?v20171111-5',
+            dashboard_css: NETDATA.serverDefault + 'dashboard.slate.css?v20171127-1',
             background: '#272b30',
             foreground: '#C8C8C8',
             grid: '#283236',
@@ -2712,7 +2712,6 @@ var NETDATA = window.NETDATA || {};
                     showRendering();
                     that.element_chart.style.display = 'none';
                     that.element.style.willChange = 'auto';
-                    that.element.style.transform = '';
                     if(that.element_legend !== null) that.element_legend.style.display = 'none';
                     if(that.element_legend_childs.toolbox !== null) that.element_legend_childs.toolbox.style.display = 'none';
                     if(that.element_legend_childs.resize_handler !== null) that.element_legend_childs.resize_handler.style.display = 'none';
@@ -2746,7 +2745,6 @@ var NETDATA = window.NETDATA || {};
             else {
                 // that.log('unhideChart()');
                 that.element.style.willChange = 'transform';
-                that.element.style.transform = 'translateZ(0)';
                 that.tm.last_unhidden = Date.now();
                 that.element_chart.style.display = '';
                 if(that.element_legend !== null) that.element_legend.style.display = '';

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -58,6 +58,8 @@ code {
     display: inline-block;
     overflow: hidden;
 
+    transform: translate3d(0,0,0);
+
     /* required for child elements to have absolute position */
     position: relative;
 
@@ -67,6 +69,8 @@ code {
 .netdata-container-gauge {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* required for child elements to have absolute position */
     position: relative;
@@ -83,6 +87,8 @@ code {
 .netdata-container-easypiechart {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* required for child elements to have absolute position */
     position: relative;
@@ -106,6 +112,8 @@ code {
 .netdata-container-with-legend {
     display: inline-block;
     overflow: hidden;
+
+    transform: translate3d(0,0,0);
 
     /* fix minimum scrollbar issue in firefox */
     min-height: 99px;

--- a/web/index.html
+++ b/web/index.html
@@ -729,6 +729,9 @@
 
             clearHighlight: function() {
                 NETDATA.globalChartUnderlay.clear();
+
+                if(NETDATA.globalPanAndZoom.isActive() === true)
+                    NETDATA.globalPanAndZoom.clearMaster();
             },
 
             showHighlight: function() {
@@ -3554,76 +3557,74 @@
                         $('#saveSnapshotExport').removeClass('disabled');
                     }
 
-                    NETDATA.pause(function () {
-                        NETDATA.globalSelectionSync.stop();
-                        NETDATA.options.force_data_points = saveData.data_points;
-                        NETDATA.options.fake_chart_rendering = true;
-                        NETDATA.onscroll_updater_enabled = false;
-                        NETDATA.abort_all_refreshes();
+                    NETDATA.globalSelectionSync.stop();
+                    NETDATA.options.force_data_points = saveData.data_points;
+                    NETDATA.options.fake_chart_rendering = true;
+                    NETDATA.onscroll_updater_enabled = false;
+                    NETDATA.abort_all_refreshes();
 
-                        var size = 0;
-                        var info = ' Resolution: <b>' + saveSnapshotSelectedSecondsPerPoint.toString() + ((saveSnapshotSelectedSecondsPerPoint === 1)?' second ':' seconds ').toString() + 'per point</b>.';
+                    var size = 0;
+                    var info = ' Resolution: <b>' + saveSnapshotSelectedSecondsPerPoint.toString() + ((saveSnapshotSelectedSecondsPerPoint === 1)?' second ':' seconds ').toString() + 'per point</b>.';
 
-                        function update_chart(idx) {
-                            if (saveSnapshotStop === true) {
-                                saveSnapshotModalLog('info', 'Cancelled!');
-                                saveSnapshotRestore();
-                                return;
-                            }
-
-                            var state = NETDATA.options.targets[--idx];
-
-                            var pcent = (NETDATA.options.targets.length - idx) * 100 / NETDATA.options.targets.length;
-                            $(el).css('width', pcent + '%').attr('aria-valuenow', pcent);
-                            eltxt.innerText = Math.round(pcent).toString() + '%, ' + state.id;
-
-                            setTimeout(function () {
-                                charts_count++;
-                                state.isVisible(true);
-                                state.current.force_after_ms = saveData.after_ms;
-                                state.current.force_before_ms = saveData.before_ms;
-
-                                state.updateChart(function (status, reason) {
-                                    state.current.force_after_ms = null;
-                                    state.current.force_before_ms = null;
-
-                                    if (status === true) {
-                                        charts_ok++;
-                                        // state.log('ok');
-                                        size += pack_api1_v1_chart_data(state);
-                                    }
-                                    else {
-                                        charts_failed++;
-                                        state.log('failed to be updated: ' + reason);
-                                    }
-
-                                    saveSnapshotModalLog((charts_failed) ? 'danger' : 'info', 'Generated snapshot data size <b>' + (Math.round(size * 100 / 1024 / 1024) / 100).toString() + ' MB</b>. ' + ((charts_failed) ? (charts_failed.toString() + ' charts have failed to be downloaded') : '').toString() + info);
-
-                                    if (idx > 0) {
-                                        update_chart(idx);
-                                    }
-                                    else {
-                                        saveData.charts_ok = charts_ok;
-                                        saveData.charts_failed = charts_failed;
-                                        saveData.data_size = size;
-                                        // console.log(saveData.compression + ': ' + (size / (options.data.dimensions_count * Math.round(saveSnapshotViewDuration / saveSnapshotSelectedSecondsPerPoint))).toString());
-
-                                        // save it
-                                        // console.log(saveData);
-                                        saveObjectToClient(saveData, filename);
-
-                                        if (charts_failed > 0)
-                                            alert(charts_failed.toString() + ' failed to be downloaded');
-
-                                        saveSnapshotRestore();
-                                        saveData = null;
-                                    }
-                                })
-                            }, 0);
+                    function update_chart(idx) {
+                        if (saveSnapshotStop === true) {
+                            saveSnapshotModalLog('info', 'Cancelled!');
+                            saveSnapshotRestore();
+                            return;
                         }
 
-                        update_chart(NETDATA.options.targets.length);
-                    });
+                        var state = NETDATA.options.targets[--idx];
+
+                        var pcent = (NETDATA.options.targets.length - idx) * 100 / NETDATA.options.targets.length;
+                        $(el).css('width', pcent + '%').attr('aria-valuenow', pcent);
+                        eltxt.innerText = Math.round(pcent).toString() + '%, ' + state.id;
+
+                        setTimeout(function () {
+                            charts_count++;
+                            state.isVisible(true);
+                            state.current.force_after_ms = saveData.after_ms;
+                            state.current.force_before_ms = saveData.before_ms;
+
+                            state.updateChart(function (status, reason) {
+                                state.current.force_after_ms = null;
+                                state.current.force_before_ms = null;
+
+                                if (status === true) {
+                                    charts_ok++;
+                                    // state.log('ok');
+                                    size += pack_api1_v1_chart_data(state);
+                                }
+                                else {
+                                    charts_failed++;
+                                    state.log('failed to be updated: ' + reason);
+                                }
+
+                                saveSnapshotModalLog((charts_failed) ? 'danger' : 'info', 'Generated snapshot data size <b>' + (Math.round(size * 100 / 1024 / 1024) / 100).toString() + ' MB</b>. ' + ((charts_failed) ? (charts_failed.toString() + ' charts have failed to be downloaded') : '').toString() + info);
+
+                                if (idx > 0) {
+                                    update_chart(idx);
+                                }
+                                else {
+                                    saveData.charts_ok = charts_ok;
+                                    saveData.charts_failed = charts_failed;
+                                    saveData.data_size = size;
+                                    // console.log(saveData.compression + ': ' + (size / (options.data.dimensions_count * Math.round(saveSnapshotViewDuration / saveSnapshotSelectedSecondsPerPoint))).toString());
+
+                                    // save it
+                                    // console.log(saveData);
+                                    saveObjectToClient(saveData, filename);
+
+                                    if (charts_failed > 0)
+                                        alert(charts_failed.toString() + ' failed to be downloaded');
+
+                                    saveSnapshotRestore();
+                                    saveData = null;
+                                }
+                            })
+                        }, 0);
+                    }
+
+                    update_chart(NETDATA.options.targets.length);
                 });
             });
         }
@@ -3631,18 +3632,71 @@
         // --------------------------------------------------------------------
         // activate netdata on the page
 
-        function finalizePage() {
-            // resize all charts - without starting the background thread
-            // this has to be done while NETDATA is paused
-            // if we ommit this, the affix menu will be wrong, since all
-            // the Dom elements are initially zero-sized
-            NETDATA.parseDom();
+        var runOnceOnDashboardLastRun = 0;
+        function runOnceOnDashboardWithjQuery() {
+            if(runOnceOnDashboardLastRun !== 0)
+                return;
 
-            if(urlOptions.pan_and_zoom === true && NETDATA.options.targets.length > 0)
-                NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], urlOptions.after, urlOptions.before);
+            runOnceOnDashboardLastRun = Date.now();
+
+            // prevent bootstrap modals from scrolling the page
+            // maintains the current scroll position
+            // https://stackoverflow.com/a/34754029/4525767
+
+            var scrollPos = 0;
+            var modal_shown = false;
+            var netdata_paused_on_modal = false;
+            $('.modal')
+                .on('show.bs.modal', function () {
+                    scrollPos = window.scrollY;
+
+                    $('body').css({
+                        overflow: 'hidden',
+                        position: 'fixed',
+                        top: -scrollPos
+                    });
+
+                    modal_shown = true;
+
+                    if(NETDATA.options.pauseCallback === null) {
+                        NETDATA.pause(function() {});
+                        netdata_paused_on_modal = true;
+                    }
+                    else
+                        netdata_paused_on_modal = false;
+                })
+                .on('hide.bs.modal', function () {
+
+                    $('body')
+                        .css({
+                            overflow: '',
+                            position: '',
+                            top: ''
+                        });
+
+                    $('html, body')
+                        .animate({ scrollTop: scrollPos }, 0);
+
+                    modal_shown = false;
+
+                    if(netdata_paused_on_modal === true) {
+                        NETDATA.unpause();
+                        netdata_paused_on_modal = false;
+                    }
+                });
+
+            // ------------------------------------------------------------------------
+            // fix bootstrap affix click bug
+            // https://stackoverflow.com/a/37847981/4525767
+
+            $( '#sidebar' ).on( 'affix-top.bs.affix', function() {
+                if(modal_shown) return false;
+            } );
+
 
             // ------------------------------------------------------------------------
             // https://github.com/viralpatel/jquery.shorten/blob/master/src/jquery.shorten.js
+
             $.fn.shorten = function(settings) {
                 "use strict";
 
@@ -3763,17 +3817,33 @@
                         }
 
                         var html = '<div class="shortcontent">' + c +
-                                '</div><div class="allcontent">' + content +
-                                '</div><span><a href="javascript://nop/" class="morelink">' + config.moreText + '</a></span>';
+                            '</div><div class="allcontent">' + content +
+                            '</div><span><a href="javascript://nop/" class="morelink">' + config.moreText + '</a></span>';
 
                         $this.html(html);
                         $this.find(".allcontent").hide(); // Hide all text
                         $('.shortcontent p:last', $this).css('margin-bottom', 0); //Remove bottom margin on last paragraph as it's likely shortened
                     }
                 });
-
             };
+        }
+
+        function finalizePage() {
+            runOnceOnDashboardWithjQuery();
+
+            // resize all charts - without starting the background thread
+            // this has to be done while NETDATA is paused
+            // if we ommit this, the affix menu will be wrong, since all
+            // the Dom elements are initially zero-sized
+            NETDATA.parseDom();
+
+            if(urlOptions.pan_and_zoom === true && NETDATA.options.targets.length > 0)
+                NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], urlOptions.after, urlOptions.before);
+
+            // ------------------------------------------------------------------------
+
             $(".shorten").shorten();
+
             // ------------------------------------------------------------------------
 
             // callback for us to track PanAndZoom operations
@@ -3989,11 +4059,10 @@
 
             var $alarmsModal = $('#alarmsModal');
             $alarmsModal.on('shown.bs.modal', function() {
-                NETDATA.pause(alarmsUpdateModal);
+                alarmsUpdateModal();
             });
 
             $alarmsModal.on('hidden.bs.modal', function() {
-                NETDATA.unpause();
                 document.getElementById('alarms_active').innerHTML =
                         document.getElementById('alarms_all').innerHTML =
                         document.getElementById('alarms_log').innerHTML =
@@ -4185,7 +4254,6 @@
         // var netdataStarted = performance.now();
 
         var netdataCallback = initializeDynamicDashboard;
-
     </script>
 </head>
 
@@ -4252,9 +4320,7 @@
         </div>
     </nav>
     <div class="navbar-highlight">
-        <div id="navbar-highlight-content" class="navbar-highlight-content">
-            hello world
-        </div>
+        <div id="navbar-highlight-content" class="navbar-highlight-content"></div>
     </div>
 
     <div id="masthead" style="display: none;">


### PR DESCRIPTION
Browsers (especially chrome) throttle `setTimeout()` when intensive page work is in place. This often results in a 2-second timeout to load a chart when scrolling.

To work-around this issue, netdata now uses a custom `setTimeout()` function that works with `requestAnimationFrame()`, which is guaranteed to fire 60 times per second (60 fps).

So now, as far as the browser fires this event, netdata charts get updated on time.

This change allowed the `sync` scrolling function of netdata to work mid-scrolling. So, while the page is scrolled, charts get updated. On firefox, it seems the browser disables javascript during scroll, so this is not entirely achieved (it seems it depends on the speed of the scrolling).

To improve things even more, netdata now provides a few hints to the browser about the visible charts, in hope that the browser will move each chart at its own compositing space at the GPU. My (visual) tests on slow computers showed that this improved hover significantly.

---

Under Linux GPU accelerated rendering is disabled by default on chrome. This is quite a big issue, especially when the browser is fullscreen on HiDPi screens. There is no workaround. Scrolling on such a display is problematic, until GPU acceleration is enabled.

It can be enabled by `chrome://flags` and setting:

1. Override software rendering list `ignore-gpu-blacklist`
2. GPU rasterization `enable-gpu-rasterization`

There is also "Zero-copy rasterizer" `enable-zero-copy`, which seems unsupported (compile time).

You can verify your settings at `chrome://gpu`:

![screenshot from 2017-11-27 02-07-50](https://user-images.githubusercontent.com/2662304/33245966-ce39462e-d317-11e7-969b-d03b517fc341.png)

---

Page scrolling is now prevented when a modal is open.

---

netdata now stops updating the charts, while a modal is open.
