### PR TITLE
do not skip chart updates

### DIFF
--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -2769,8 +2769,12 @@ var NETDATA = window.NETDATA || {};
         var callChartLibraryUpdateSafely = function(data) {
             var status;
 
-            if(canBeRendered(true) === false)
-                return false;
+            // we should not do this here
+            // if we prevent rendering the chart then:
+            // 1. globalSelectionSync will be wrong
+            // 2. globalPanAndZoom will be wrong
+            //if(canBeRendered(true) === false)
+            //    return false;
 
             if(NETDATA.options.fake_chart_rendering === true)
                 return true;
@@ -2802,8 +2806,12 @@ var NETDATA = window.NETDATA || {};
         var callChartLibraryCreateSafely = function(data) {
             var status;
 
-            if(canBeRendered(true) === false)
-                return false;
+            // we should not do this here
+            // if we prevent rendering the chart then:
+            // 1. globalSelectionSync will be wrong
+            // 2. globalPanAndZoom will be wrong
+            //if(canBeRendered(true) === false)
+            //    return false;
 
             if(NETDATA.options.fake_chart_rendering === true)
                 return true;


### PR DESCRIPTION
Recently, in an attempt to optimize scrolling, I added a check that prevents a chart to be updated, if at the time of rendering the chart is no longer visible (page is scrolling too fast).

When the chart comes into the view again, it has 2 issues (both a due to the fact that un-hiding a chart does not re-render it):

1. global selection sync (hover on charts) is faulty when this happens, since the rendered chart and the data linked to it are not longer aligned.

2. global pan and zoom believes the chart is updated (the structures are), but visually the chart is behind reality.

So, I am getting back this optimization.

Another solution would be to destroy the chart when this happens. This will force a full update when the chart becomes visible again, but it won't help scrolling. The opposite. Scrolling will become slower, since a DOM element will change significantly.
