### PR TITLE
custom server for static content

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -632,8 +632,10 @@
                     }
                 }
 
-                if(urlOptions.server !== null && urlOptions.server !== '')
+                if(urlOptions.server !== null && urlOptions.server !== '') {
+                    netdataServerStatic = document.location.origin.toString() + document.location.pathname.toString();
                     netdataServer = urlOptions.server;
+                }
                 else
                     urlOptions.server = null;
 
@@ -4251,17 +4253,17 @@
         // parallel javascript downloader in netdata
         var netdataPrepCallback = function() {
             NETDATA.requiredCSS.push({
-                url: NETDATA.serverDefault + 'css/bootstrap-toggle-2.2.2.min.css',
+                url: NETDATA.serverStatic + 'css/bootstrap-toggle-2.2.2.min.css',
                 isAlreadyLoaded: function() { return false; }
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'lib/bootstrap-toggle-2.2.2.min.js',
+                url: NETDATA.serverStatic + 'lib/bootstrap-toggle-2.2.2.min.js',
                 isAlreadyLoaded: function() { return false; }
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverDefault + 'dashboard_info.js?v20171107-1',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20171107-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });
@@ -5541,6 +5543,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171130-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20171205-4"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR:

1. allows setting a different server for all static content of the dashboard

    netdata support *impersonating* a dashboard: append `;server=http://another.netdata.ip:19999/` to a netdata url hash to view the data of that server (target), using the dashboard features of the current netdata (origin). This had the problem that chart libraries and other static content were loaded from the target server, while index.html and dashboard.js from the origin server. If the target server did not have the javascript files the origin server wanted, the dashboard appeared broken.

   fixed it. Now all static files, except `custom_dashboard_info.js` are loaded from the origin server.

2. initializes the dashboard when it is loaded on a tab that does not have focus.

