### PR TITLE
added statsd original metric as synthetic chart dimension id

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1692,7 +1692,7 @@ static inline void statsd_update_app_chart(STATSD_APP *app, STATSD_APP_CHART *ch
     STATSD_APP_CHART_DIM *dim;
     for(dim = chart->dimensions; dim ;dim = dim->next) {
         if(unlikely(!dim->rd))
-            dim->rd = rrddim_add(chart->st, dim->name, NULL, dim->multiplier, dim->divisor, dim->algorithm);
+            dim->rd = rrddim_add(chart->st, dim->metric, dim->name, dim->multiplier, dim->divisor, dim->algorithm);
 
         if(unlikely(dim->value_ptr)) {
             debug(D_STATSD, "updating dimension '%s' (%s) of chart '%s' (%s) for app '%s' with value " COLLECTED_NUMBER_FORMAT, dim->name, dim->rd->id, chart->id, chart->st->id, app->name, *dim->value_ptr);


### PR DESCRIPTION
This PR allows searching for dimension in statsd synthetic chart dimensions, using both the statsd metric name and the synthetic chart dimension name.

Also, the id the dimension is now the statsd original metric. This means dimensions in synthetic charts can be renamed, while maintaining the original history of the dimension.