### PR TITLE
simple pattern enhancements and pattern based statsd synthetic charts dimensions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -771,18 +771,19 @@ int main(int argc, char **argv) {
 
                             const char *heystack = argv[optind];
                             const char *needle = argv[optind + 1];
+                            size_t len = strlen(needle) + 1;
+                            char wildcarded[len];
 
-                            SIMPLE_PATTERN *p = simple_pattern_create(heystack
-                                                                      , SIMPLE_PATTERN_EXACT);
-                            int ret = simple_pattern_matches(p, needle);
+                            SIMPLE_PATTERN *p = simple_pattern_create(heystack, SIMPLE_PATTERN_EXACT);
+                            int ret = simple_pattern_matches_extract(p, needle, wildcarded, len);
                             simple_pattern_free(p);
 
                             if(ret) {
-                                fprintf(stdout, "RESULT: MATCHED - pattern '%s' matches '%s'\n", heystack, needle);
+                                fprintf(stdout, "RESULT: MATCHED - pattern '%s' matches '%s', wildcarded '%s'\n", heystack, needle, wildcarded);
                                 return 0;
                             }
                             else {
-                                fprintf(stdout, "RESULT: NOT MATCHED - pattern '%s' does not match '%s'\n", heystack, needle);
+                                fprintf(stdout, "RESULT: NOT MATCHED - pattern '%s' does not match '%s', wildcarded '%s'\n", heystack, needle, wildcarded);
                                 return 1;
                             }
                         }

--- a/src/simple_pattern.c
+++ b/src/simple_pattern.c
@@ -144,10 +144,10 @@ static inline char *add_wildcarded(const char *matched, size_t matched_size, cha
     //    fprintf(stderr, "ADD WILDCARDED '%s' of length %zu\n", buf, matched_size);
     //}
 
-    if(matched && *matched && matched_size && wildcarded && *wildcarded_size) {
+    if(unlikely(wildcarded && *wildcarded_size && matched && *matched && matched_size)) {
         size_t wss = *wildcarded_size - 1;
         size_t len = (matched_size < wss)?matched_size:wss;
-        if(len) {
+        if(likely(len)) {
             strncpyz(wildcarded, matched, len);
 
             *wildcarded_size -= len;
@@ -158,37 +158,36 @@ static inline char *add_wildcarded(const char *matched, size_t matched_size, cha
     return wildcarded;
 }
 
-static inline int match_pattern(struct simple_pattern *m, const char *str, size_t len, char *wildcarded, const size_t *wildcarded_size) {
-    char *s, *ws = wildcarded;
-    size_t wss = *wildcarded_size;
+static inline int match_pattern(struct simple_pattern *m, const char *str, size_t len, char *wildcarded, size_t *wildcarded_size) {
+    char *s;
 
     if(m->len <= len) {
         switch(m->mode) {
             case SIMPLE_PATTERN_SUBSTRING:
                 if(!m->len) return 1;
                 if((s = strstr(str, m->match))) {
-                    ws = add_wildcarded(str, s - str, ws, &wss);
+                    wildcarded = add_wildcarded(str, s - str, wildcarded, wildcarded_size);
                     if(!m->child) {
-                        ws = add_wildcarded(&s[m->len], len - (&s[m->len] - str), ws, &wss);
+                        wildcarded = add_wildcarded(&s[m->len], len - (&s[m->len] - str), wildcarded, wildcarded_size);
                         return 1;
                     }
-                    return match_pattern(m->child, &s[m->len], len - (s - str) - m->len, ws, &wss);
+                    return match_pattern(m->child, &s[m->len], len - (s - str) - m->len, wildcarded, wildcarded_size);
                 }
                 break;
 
             case SIMPLE_PATTERN_PREFIX:
                 if(unlikely(strncmp(str, m->match, m->len) == 0)) {
                     if(!m->child) {
-                        ws = add_wildcarded(&str[m->len], len - m->len, ws, &wss);
+                        wildcarded = add_wildcarded(&str[m->len], len - m->len, wildcarded, wildcarded_size);
                         return 1;
                     }
-                    return match_pattern(m->child, &str[m->len], len - m->len, ws, &wss);
+                    return match_pattern(m->child, &str[m->len], len - m->len, wildcarded, wildcarded_size);
                 }
                 break;
 
             case SIMPLE_PATTERN_SUFFIX:
                 if(unlikely(strcmp(&str[len - m->len], m->match) == 0)) {
-                    ws = add_wildcarded(str, len - m->len, ws, &wss);
+                    wildcarded = add_wildcarded(str, len - m->len, wildcarded, wildcarded_size);
                     if(!m->child) return 1;
                     return 0;
                 }
@@ -229,10 +228,6 @@ int simple_pattern_matches_extract(SIMPLE_PATTERN *list, const char *str, char *
     }
 
     return 0;
-}
-
-int simple_pattern_matches(SIMPLE_PATTERN *list, const char *str) {
-    return simple_pattern_matches_extract(list, str, NULL, 0);
 }
 
 static inline void free_pattern(struct simple_pattern *m) {

--- a/src/simple_pattern.h
+++ b/src/simple_pattern.h
@@ -15,11 +15,11 @@ typedef void SIMPLE_PATTERN;
 // should be considered PREFIX matches.
 extern SIMPLE_PATTERN *simple_pattern_create(const char *list, SIMPLE_PREFIX_MODE default_mode);
 
-// test if string str is matched from the pattern
-extern int simple_pattern_matches(SIMPLE_PATTERN *list, const char *str);
-
 // test if string str is matched from the pattern and fill 'wildcarded' with the parts matched by '*'
 extern int simple_pattern_matches_extract(SIMPLE_PATTERN *list, const char *str, char *wildcarded, size_t wildcarded_size);
+
+// test if string str is matched from the pattern
+#define simple_pattern_matches(list, str) simple_pattern_matches_extract(list, str, NULL, 0)
 
 // free a simple_pattern that was created with simple_pattern_create()
 // list can be NULL, in which case, this does nothing.

--- a/src/simple_pattern.h
+++ b/src/simple_pattern.h
@@ -18,6 +18,9 @@ extern SIMPLE_PATTERN *simple_pattern_create(const char *list, SIMPLE_PREFIX_MOD
 // test if string str is matched from the pattern
 extern int simple_pattern_matches(SIMPLE_PATTERN *list, const char *str);
 
+// test if string str is matched from the pattern and fill 'wildcarded' with the parts matched by '*'
+extern int simple_pattern_matches_extract(SIMPLE_PATTERN *list, const char *str, char *wildcarded, size_t wildcarded_size);
+
 // free a simple_pattern that was created with simple_pattern_create()
 // list can be NULL, in which case, this does nothing.
 extern void simple_pattern_free(SIMPLE_PATTERN *list);


### PR DESCRIPTION
- [x] Use `\ ` (backslash + space) to match a space in simple patterns.
- [x] Simple patterns can now extract the wildcarded part from from the matched string. This means that `string.*` can extract the string that the `*` matches.
- [x] Statsd synthetic charts now support pattern based dimensions. Prepend the keyword `pattern` as the first parameter of the `dimension` line (the rest of the parameters remain the same). The metric name will now be considered a simple pattern list.

   Example:

```
dimension = pattern my.*.counter '' last 1 1
```

  The above will match `my.little.counter` and name it `little`, `my.big.counter` and name it `big`, etc.

fixes #2785 

- [x] Statsd synthetic charts now support a dictionary for naming dimensions. So, if you need to name statsd metric `my.little.counter` to `key events` on all synthetic charts, you can add it at the `[dictionary]` section, like this:

```
[app]
   ...

[dictionary]
   my.little.counter = key events

[chart1]
   ...
   dimension = my.little.counter '' last 1 1

[chart2]
   ...
   dimension = my.little.counter '' events 1 1
```
   
   The dimensions of both charts will be named `key events`.
