### PR TITLE
do not match a zero value with null color; 

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1000,6 +1000,7 @@ int main(int argc, char **argv) {
         // --------------------------------------------------------------------
         // create the listening sockets
 
+        web_client_api_v1_init();
         web_server_threading_selection();
 
         if(web_server_mode != WEB_SERVER_MODE_NONE)

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -61,6 +61,7 @@
 #define RRDR_OPTION_LABEL_QUOTES    0x00000400 // in CSV output, wrap header labels in double quotes
 #define RRDR_OPTION_PERCENTAGE      0x00000800 // give values as percentage of total
 #define RRDR_OPTION_NOT_ALIGNED     0x00001000 // do not align charts for persistant timeframes
+#define RRDR_OPTION_DISPLAY_ABS     0x00002000 // for badges, display the absolute value, but calculate colors with sign
 
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb);

--- a/src/web_api_v1.h
+++ b/src/web_api_v1.h
@@ -18,4 +18,6 @@ extern int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
 extern int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url);
 
+extern void web_client_api_v1_init(void);
+
 #endif //NETDATA_WEB_API_V1_H

--- a/src/web_buffer_svg.c
+++ b/src/web_buffer_svg.c
@@ -382,7 +382,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
         calculated_number abs = value;
         if(isless(value, 0)) {
             lstop = 1;
-            abs = -value;
+            abs = calculated_number_fabs(value);
         }
 
         if(isgreaterequal(abs, 1000)) {
@@ -752,7 +752,7 @@ static inline void calc_colorz(const char *color, char *final, size_t len, calcu
 // colors
 #define COLOR_STRING_SIZE 100
 
-void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision) {
+void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision, uint32_t options) {
     char      label_buffer[LABEL_STRING_SIZE + 1]
             , value_color_buffer[COLOR_STRING_SIZE + 1]
             , value_string[VALUE_STRING_SIZE + 1]
@@ -770,7 +770,7 @@ void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const ch
         value_color = (isnan(value) || isinf(value))?"#999":"#4c1";
 
     calc_colorz(value_color, value_color_buffer, COLOR_STRING_SIZE, value);
-    format_value_and_unit(value_string, VALUE_STRING_SIZE, value, units, precision);
+    format_value_and_unit(value_string, VALUE_STRING_SIZE, (options & RRDR_OPTION_DISPLAY_ABS)?calculated_number_fabs(value):value, units, precision);
 
     // we need to copy the label, since verdana11_width may write to it
     strncpyz(label_buffer, label, LABEL_STRING_SIZE);

--- a/src/web_buffer_svg.h
+++ b/src/web_buffer_svg.h
@@ -1,7 +1,7 @@
 #ifndef NETDATA_WEB_BUFFER_SVG_H
 #define NETDATA_WEB_BUFFER_SVG_H 1
 
-extern void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision);
+extern void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision, uint32_t options);
 extern char *format_value_and_unit(char *value_string, size_t value_string_len, calculated_number value, const char *units, int precision);
 
 #endif /* NETDATA_WEB_BUFFER_SVG_H */

--- a/web/netdata-swagger.json
+++ b/web/netdata-swagger.json
@@ -314,6 +314,7 @@
                             "enum": [
                                 "abs",
                                 "absolute",
+                                "display-absolute",
                                 "absolute-sum",
                                 "null2zero",
                                 "percentage",

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -204,7 +204,7 @@ paths:
           type: array
           items:
             type: string
-            enum: [ 'abs', 'absolute', 'absolute-sum', 'null2zero', 'percentage', 'unaligned' ]
+            enum: [ 'abs', 'absolute', 'display-absolute', 'absolute-sum', 'null2zero', 'percentage', 'unaligned' ]
             collectionFormat: pipes
           default: ['absolute']
           allowEmptyValue: true


### PR DESCRIPTION
Before this PR badge colors were incorrectly matching zero values as `null`.

fixes #3124

Also added equal comparison with `=` (was using only `:`) and not equal comparison with `!=` and `<>`.

---

Added API option `display-absolute` (and `display_absolute`) to use the signed value at color calculation, but display the absolute value on the badge.

fixes #3123 