### PR TITLE
btrfs filesystem monitoring; 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(NETDATA_LINUX_FILES
         src/proc_uptime.c
         src/sys_kernel_mm_ksm.c
         src/sys_fs_cgroup.c
-        )
+        src/sys_fs_btrfs.c)
 
 set(NETDATA_COMMON_FILES
         src/adaptive_resortable_list.c

--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -75,6 +75,7 @@ dist_healthconfig_DATA = \
     health.d/backend.conf \
     health.d/beanstalkd.conf \
     health.d/bind_rndc.conf \
+    health.d/btrfs.conf \
     health.d/cpu.conf \
     health.d/couchdb.conf \
     health.d/disks.conf \

--- a/conf.d/health.d/btrfs.conf
+++ b/conf.d/health.d/btrfs.conf
@@ -1,16 +1,16 @@
 
-template: btrfs_unallocated
+template: btrfs_allocated
       on: btrfs.disk
       os: *
    hosts: *
 families: *
-    calc: $unallocated * 100 / ($unallocated + $data_used + $data_free + $meta_used + $meta_free + $sys_used + $sys_free)
+    calc: 100 - ($unallocated * 100 / ($unallocated + $data_used + $data_free + $meta_used + $meta_free + $sys_used + $sys_free))
    units: %
    every: 10s
-    warn: $this < (($status >= $WARNING)  ? (10) : (5))
-    crit: $this < (($status == $CRITICAL) ? ( 5) : (1))
+    warn: $this > (($status >= $WARNING)  ? (90) : (95))
+    crit: $this > (($status == $CRITICAL) ? (95) : (98))
    delay: up 1m down 15m multiplier 1.5 max 1h
-    info: the percentage of unallocated BTRFS physical disk space
+    info: the percentage of allocated BTRFS physical disk space
       to: sysadmin
 
 template: btrfs_data
@@ -18,13 +18,13 @@ template: btrfs_data
       os: *
    hosts: *
 families: *
-    calc: $free * 100 / ($used + $free)
+    calc: $used * 100 / ($used + $free)
    units: %
    every: 10s
-    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
-    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+    warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
+    crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
    delay: up 1m down 15m multiplier 1.5 max 1h
-    info: the percentage of free BTRFS data space
+    info: the percentage of used BTRFS data space
       to: sysadmin
 
 template: btrfs_metadata
@@ -32,13 +32,13 @@ template: btrfs_metadata
       os: *
    hosts: *
 families: *
-    calc: $free * 100 / ($used + $free + $reserved)
+    calc: ($used + $reserved) * 100 / ($used + $free + $reserved)
    units: %
    every: 10s
-    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
-    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+    warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
+    crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
    delay: up 1m down 15m multiplier 1.5 max 1h
-    info: the percentage of free BTRFS metadata space
+    info: the percentage of used BTRFS metadata space
       to: sysadmin
 
 template: btrfs_system
@@ -46,12 +46,12 @@ template: btrfs_system
       os: *
    hosts: *
 families: *
-    calc: $free * 100 / ($used + $free)
+    calc: $used * 100 / ($used + $free)
    units: %
    every: 10s
-    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
-    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+    warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
+    crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
    delay: up 1m down 15m multiplier 1.5 max 1h
-    info: the percentage of free BTRFS system space
+    info: the percentage of used BTRFS system space
       to: sysadmin
 

--- a/conf.d/health.d/btrfs.conf
+++ b/conf.d/health.d/btrfs.conf
@@ -1,0 +1,57 @@
+
+template: btrfs_unallocated
+      on: btrfs.disk
+      os: *
+   hosts: *
+families: *
+    calc: $unallocated * 100 / ($unallocated + $data_used + $data_free + $meta_used + $meta_free + $sys_used + $sys_free)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? (10) : (5))
+    crit: $this < (($status == $CRITICAL) ? ( 5) : (1))
+   delay: up 1m down 15m multiplier 1.5 max 1h
+    info: the percentage of unallocated BTRFS physical disk space
+      to: sysadmin
+
+template: btrfs_data
+      on: btrfs.data
+      os: *
+   hosts: *
+families: *
+    calc: $free * 100 / ($used + $free)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
+    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+   delay: up 1m down 15m multiplier 1.5 max 1h
+    info: the percentage of free BTRFS data space
+      to: sysadmin
+
+template: btrfs_metadata
+      on: btrfs.metadata
+      os: *
+   hosts: *
+families: *
+    calc: $free * 100 / ($used + $free + $reserved)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
+    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+   delay: up 1m down 15m multiplier 1.5 max 1h
+    info: the percentage of free BTRFS metadata space
+      to: sysadmin
+
+template: btrfs_system
+      on: btrfs.system
+      os: *
+   hosts: *
+families: *
+    calc: $free * 100 / ($used + $free)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? (10) : (5)) && $btrfs_unallocated < 1
+    crit: $this < (($status == $CRITICAL) ? ( 5) : (1)) && $btrfs_unallocated < 1
+   delay: up 1m down 15m multiplier 1.5 max 1h
+    info: the percentage of free BTRFS system space
+      to: sysadmin
+

--- a/configs.signatures
+++ b/configs.signatures
@@ -36,6 +36,7 @@ declare -A configs_signatures=(
   ['09e030d26be08a13fa3560e47fa27825']='apps_groups.conf'
   ['0a7039ecc7a86b480d9d499b12b02763']='python.d/freeradius.conf'
   ['0ad10fa896346202aee99384b0ec968d']='health.d/cpu.conf'
+  ['0b6903f981cdb018c17802ac4e295609']='health.d/btrfs.conf'
   ['0c5e0fa364d7bdf7c16e8459a0544572']='health.d/netfilter.conf'
   ['0cd4e1fb57497e4d4c2451a9e58f724d']='python.d/redis.conf'
   ['0d29fe9919a2975107db1f2583344e7a']='health.d/mdstat.conf'

--- a/configs.signatures
+++ b/configs.signatures
@@ -49,6 +49,7 @@ declare -A configs_signatures=(
   ['1112c848ef91ebb9c622020d09712d67']='health.d/net.conf'
   ['12a4c7803ae79506a14ea784fea60dce']='health.d/net.conf'
   ['13141998a5d71308d9c119834c27bfd3']='python.d.conf'
+  ['1423e4f8c25a66c316be37da0d5c9c54']='health.d/btrfs.conf'
   ['142a5b693d34b0308bb0b8aec71fad79']='python.d/postfix.conf'
   ['14783e051650442ec9e2ed38d81d667e']='charts.d/exim.conf'
   ['15d8401b56a74120f9f832873ec9c578']='health.d/postgres.conf'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,16 +79,10 @@ netdata_SOURCES = \
 	plugin_checks.h \
 	plugin_idlejitter.c \
 	plugin_idlejitter.h \
-	plugin_nfacct.c \
-	plugin_nfacct.h \
-	plugin_tc.c \
-	plugin_tc.h \
 	plugins_d.c \
 	plugins_d.h \
 	popen.c \
 	popen.h \
-	proc_self_mountinfo.c \
-	proc_self_mountinfo.h \
 	procfile.c \
 	procfile.h \
 	registry.c \
@@ -133,8 +127,6 @@ netdata_SOURCES = \
 	statsd.h \
 	storage_number.c \
 	storage_number.h \
-	sys_devices_system_edac_mc.c \
-	sys_devices_system_node.c \
 	unit_test.c \
 	unit_test.h \
 	url.c \
@@ -179,10 +171,14 @@ else
 netdata_SOURCES += \
 	ipc.c \
 	ipc.h \
+	plugin_nfacct.c \
+	plugin_nfacct.h \
 	plugin_proc.c \
 	plugin_proc.h \
 	plugin_proc_diskspace.c \
 	plugin_proc_diskspace.h \
+	plugin_tc.c \
+	plugin_tc.h \
 	proc_diskstats.c \
 	proc_interrupts.c \
 	proc_softirqs.c \
@@ -200,6 +196,8 @@ netdata_SOURCES += \
 	proc_net_softnet_stat.c \
 	proc_net_stat_conntrack.c \
 	proc_net_stat_synproxy.c \
+	proc_self_mountinfo.c \
+	proc_self_mountinfo.h \
 	zfs_common.c \
     zfs_common.h \
 	proc_spl_kstat_zfs.c \
@@ -208,7 +206,10 @@ netdata_SOURCES += \
 	proc_vmstat.c \
 	proc_uptime.c \
 	sys_kernel_mm_ksm.c \
+	sys_devices_system_edac_mc.c \
+	sys_devices_system_node.c \
 	sys_fs_cgroup.c \
+	sys_fs_btrfs.c \
 	$(NULL)
 endif
 endif

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -54,6 +54,9 @@ static struct proc_module {
         // ZFS metrics
         { .name = "/proc/spl/kstat/zfs/arcstats", .dim = "zfs_arcstats", .func = do_proc_spl_kstat_zfs_arcstats },
 
+        // BTRFS metrics
+        { .name = "/sys/fs/btrfs", .dim = "btrfs", .func = do_sys_fs_btrfs },
+
         // IPC metrics
         { .name = "ipc", .dim = "ipc", .func = do_ipc },
 

--- a/src/plugin_proc.h
+++ b/src/plugin_proc.h
@@ -26,6 +26,7 @@ extern int do_proc_uptime(int update_every, usec_t dt);
 extern int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt);
 extern int do_proc_sys_devices_system_node(int update_every, usec_t dt);
 extern int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt);
+extern int do_sys_fs_btrfs(int update_every, usec_t dt);
 extern int do_proc_net_sockstat(int update_every, usec_t dt);
 extern int do_proc_net_sockstat6(int update_every, usec_t dt);
 

--- a/src/proc_net_rpc_nfs.c
+++ b/src/proc_net_rpc_nfs.c
@@ -288,7 +288,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                     , "operations/s"
                     , "proc"
                     , "net/rpc/nfs"
-                    , 5007
+                    , 2207
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -328,7 +328,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfs"
-                    , 5008
+                    , 2208
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -361,7 +361,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfs"
-                    , 5009
+                    , 2209
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -394,7 +394,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfs"
-                    , 5010
+                    , 2210
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -427,7 +427,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfs"
-                    , 5011
+                    , 2211
                     , update_every
                     , RRDSET_TYPE_STACKED
             );

--- a/src/proc_net_rpc_nfsd.c
+++ b/src/proc_net_rpc_nfsd.c
@@ -517,7 +517,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "reads/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5000
+                    , 2100
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -555,7 +555,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "handles/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5001
+                    , 2101
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -595,7 +595,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "kilobytes/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5002
+                    , 2102
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -628,7 +628,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                         , "threads"
                         , "proc"
                         , "net/rpc/nfsd"
-                        , 5003
+                        , 2103
                         , update_every
                         , RRDSET_TYPE_LINE
                 );
@@ -656,7 +656,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                         , "ops/s"
                         , "proc"
                         , "net/rpc/nfsd"
-                        , 5004
+                        , 2104
                         , update_every
                         , RRDSET_TYPE_LINE
                 );
@@ -693,7 +693,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                         , "percentage"
                         , "proc"
                         , "net/rpc/nfsd"
-                        , 5005
+                        , 2105
                         , update_every
                         , RRDSET_TYPE_LINE
                 );
@@ -752,7 +752,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "percentage"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5005
+                    , 2105
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -806,7 +806,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "packets/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5007
+                    , 2107
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -845,7 +845,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5008
+                    , 2108
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -881,7 +881,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5009
+                    , 2109
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -914,7 +914,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5010
+                    , 2110
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -947,7 +947,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "calls/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5011
+                    , 2111
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -980,7 +980,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                     , "operations/s"
                     , "proc"
                     , "net/rpc/nfsd"
-                    , 5012
+                    , 2112
                     , update_every
                     , RRDSET_TYPE_STACKED
             );

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -11,9 +11,9 @@ typedef struct btrfs_node {
 
     char label[BTRFS_MAX_LABEL_LENGTH + 1];
 
-    unsigned long long int sectorsize;
-    unsigned long long int nodesize;
-    unsigned long long int quota_override;
+    // unsigned long long int sectorsize;
+    // unsigned long long int nodesize;
+    // unsigned long long int quota_override;
 
     #define declare_btrfs_allocation_section_field(SECTION, FIELD) \
         char *allocation_ ## SECTION ## _ ## FIELD ## _filename; \
@@ -138,26 +138,26 @@ static inline int find_all_btrfs_pools(const char *path) {
         if(!node->label[0])
             strncpyz(node->label, node->id, BTRFS_MAX_LABEL_LENGTH);
 
-        snprintfz(filename, FILENAME_MAX, "%s/%s/sectorsize", path, de->d_name);
-        if(read_single_number_file(filename, &node->sectorsize) != 0) {
-            error("BTRFS: failed to read '%s'", filename);
-            btrfs_free_node(node);
-            continue;
-        }
+        //snprintfz(filename, FILENAME_MAX, "%s/%s/sectorsize", path, de->d_name);
+        //if(read_single_number_file(filename, &node->sectorsize) != 0) {
+        //    error("BTRFS: failed to read '%s'", filename);
+        //    btrfs_free_node(node);
+        //    continue;
+        //}
 
-        snprintfz(filename, FILENAME_MAX, "%s/%s/nodesize", path, de->d_name);
-        if(read_single_number_file(filename, &node->nodesize) != 0) {
-            error("BTRFS: failed to read '%s'", filename);
-            btrfs_free_node(node);
-            continue;
-        }
+        //snprintfz(filename, FILENAME_MAX, "%s/%s/nodesize", path, de->d_name);
+        //if(read_single_number_file(filename, &node->nodesize) != 0) {
+        //    error("BTRFS: failed to read '%s'", filename);
+        //    btrfs_free_node(node);
+        //    continue;
+        //}
 
-        snprintfz(filename, FILENAME_MAX, "%s/%s/quota_override", path, de->d_name);
-        if(read_single_number_file(filename, &node->quota_override) != 0) {
-            error("BTRFS: failed to read '%s'", filename);
-            btrfs_free_node(node);
-            continue;
-        }
+        //snprintfz(filename, FILENAME_MAX, "%s/%s/quota_override", path, de->d_name);
+        //if(read_single_number_file(filename, &node->quota_override) != 0) {
+        //    error("BTRFS: failed to read '%s'", filename);
+        //    btrfs_free_node(node);
+        //    continue;
+        //}
 
         // --------------------------------------------------------------------
         // macros to simplify our life

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -167,7 +167,13 @@ static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
             snprintfz(filename, FILENAME_MAX, "%s/%s/size", path, de->d_name);
             d->size_filename = strdupz(filename);
 
+            // for disks
             snprintfz(filename, FILENAME_MAX, "%s/%s/queue/hw_sector_size", path, de->d_name);
+            struct stat sb;
+            if(stat(filename, &sb) == -1)
+                // for partitions
+                snprintfz(filename, FILENAME_MAX, "%s/%s/../queue/hw_sector_size", path, de->d_name);
+
             d->hw_sector_size_filename = strdupz(filename);
 
             // link it

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -1,0 +1,525 @@
+#include "common.h"
+
+#define BTRFS_MAX_ID_LENGTH 50
+#define BTRFS_MAX_LABEL_LENGTH 200
+
+typedef struct btrfs_node {
+    int exists;
+
+    char id[BTRFS_MAX_ID_LENGTH + 1];
+    uint32_t hash;
+
+    char label[BTRFS_MAX_LABEL_LENGTH + 1];
+
+    unsigned long long int sectorsize;
+    unsigned long long int nodesize;
+    unsigned long long int quota_override;
+
+    #define declare_btrfs_allocation_section_field(SECTION, FIELD) \
+        char *allocation_ ## SECTION ## _ ## FIELD ## _filename; \
+        unsigned long long int allocation_ ## SECTION ## _ ## FIELD; \
+        RRDDIM *rd_allocation_ ## SECTION ## _ ## FIELD;
+
+    #define declare_btrfs_allocation_field(FIELD) \
+        char *allocation_ ## FIELD ## _filename; \
+        unsigned long long int allocation_ ## FIELD; \
+        RRDDIM *rd_allocation_ ## FIELD;
+
+    RRDSET *st_allocation_system;
+    declare_btrfs_allocation_section_field(system, total_bytes)
+    declare_btrfs_allocation_section_field(system, bytes_used)
+    declare_btrfs_allocation_section_field(system, disk_total)
+    declare_btrfs_allocation_section_field(system, disk_used)
+
+    RRDSET *st_allocation_data;
+    declare_btrfs_allocation_section_field(data, total_bytes)
+    declare_btrfs_allocation_section_field(data, bytes_used)
+    declare_btrfs_allocation_section_field(data, disk_total)
+    declare_btrfs_allocation_section_field(data, disk_used)
+
+    RRDSET *st_allocation_metadata;
+    declare_btrfs_allocation_section_field(metadata, total_bytes)
+    declare_btrfs_allocation_section_field(metadata, bytes_used)
+    declare_btrfs_allocation_section_field(metadata, disk_total)
+    declare_btrfs_allocation_section_field(metadata, disk_used)
+
+    RRDSET *st_allocation_global_rsv;
+    declare_btrfs_allocation_field(global_rsv_reserved)
+    declare_btrfs_allocation_field(global_rsv_size)
+
+    struct btrfs_node *next;
+} BTRFS_NODE;
+
+static BTRFS_NODE *nodes = NULL;
+
+static inline void btrfs_free_node(BTRFS_NODE *node) {
+    // info("BTRFS: destroying '%s'", node->id);
+
+    if(node->st_allocation_system)
+        rrdset_is_obsolete(node->st_allocation_system);
+
+    if(node->st_allocation_data)
+        rrdset_is_obsolete(node->st_allocation_data);
+
+    if(node->st_allocation_metadata)
+        rrdset_is_obsolete(node->st_allocation_metadata);
+
+    freez(node->allocation_system_bytes_used_filename);
+    freez(node->allocation_system_total_bytes_filename);
+
+    freez(node->allocation_data_bytes_used_filename);
+    freez(node->allocation_data_total_bytes_filename);
+
+    freez(node->allocation_metadata_bytes_used_filename);
+    freez(node->allocation_metadata_total_bytes_filename);
+
+    freez(node);
+}
+
+static inline int find_all_btrfs_pools(const char *path) {
+    static int logged_error = 0;
+    char filename[FILENAME_MAX + 1];
+
+    BTRFS_NODE *node;
+    for(node = nodes ; node ; node = node->next)
+        node->exists = 0;
+
+    DIR *dir = opendir(path);
+    if (!dir) {
+        if(!logged_error) {
+            error("BTRFS: Cannot open directory '%s'.", path);
+            logged_error = 1;
+        }
+        return 1;
+    }
+    logged_error = 0;
+
+    struct dirent *de = NULL;
+    while ((de = readdir(dir))) {
+        if(de->d_type != DT_DIR
+           || !strcmp(de->d_name, ".")
+           || !strcmp(de->d_name, "..")
+           || !strcmp(de->d_name, "features")
+                ) {
+            // info("BTRFS: ignoring '%s'", de->d_name);
+            continue;
+        }
+
+        uint32_t hash = simple_hash(de->d_name);
+
+        // search for it
+        for(node = nodes ; node ; node = node->next) {
+            if(hash == node->hash && !strcmp(de->d_name, node->id))
+                break;
+        }
+
+        // did we find it?
+        if(node) {
+            // info("BTRFS: already exists '%s'", de->d_name);
+            node->exists = 1;
+            break;
+        }
+
+        // info("BTRFS: adding '%s'", de->d_name);
+
+        // not found, create it
+        node = callocz(sizeof(BTRFS_NODE), 1);
+
+        strncpyz(node->id, de->d_name, BTRFS_MAX_ID_LENGTH);
+        node->hash = simple_hash(node->id);
+        node->exists = 1;
+
+        snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
+        if(read_file(filename, node->label, sizeof(node->label)) != 0) {
+            error("BTRFS: failed to read '%s'", filename);
+            btrfs_free_node(node);
+            continue;
+        }
+        if(!node->label[0])
+            strncpyz(node->label, node->id, BTRFS_MAX_LABEL_LENGTH);
+
+        snprintfz(filename, FILENAME_MAX, "%s/%s/sectorsize", path, de->d_name);
+        if(read_single_number_file(filename, &node->sectorsize) != 0) {
+            error("BTRFS: failed to read '%s'", filename);
+            btrfs_free_node(node);
+            continue;
+        }
+
+        snprintfz(filename, FILENAME_MAX, "%s/%s/nodesize", path, de->d_name);
+        if(read_single_number_file(filename, &node->nodesize) != 0) {
+            error("BTRFS: failed to read '%s'", filename);
+            btrfs_free_node(node);
+            continue;
+        }
+
+        snprintfz(filename, FILENAME_MAX, "%s/%s/quota_override", path, de->d_name);
+        if(read_single_number_file(filename, &node->quota_override) != 0) {
+            error("BTRFS: failed to read '%s'", filename);
+            btrfs_free_node(node);
+            continue;
+        }
+
+        // --------------------------------------------------------------------
+        // macros to simplify our life
+
+        #define init_btrfs_allocation_field(FIELD) {\
+            snprintfz(filename, FILENAME_MAX, "%s/%s/allocation/" #FIELD, path, de->d_name); \
+            if(read_single_number_file(filename, &node->allocation_ ## FIELD) != 0) {\
+                error("BTRFS: failed to read '%s'", filename);\
+                btrfs_free_node(node);\
+                continue;\
+            }\
+            if(!node->allocation_ ## FIELD ## _filename)\
+                node->allocation_ ## FIELD ## _filename = strdupz(filename);\
+        }
+
+        #define init_btrfs_allocation_section_field(SECTION, FIELD) {\
+            snprintfz(filename, FILENAME_MAX, "%s/%s/allocation/" #SECTION "/" #FIELD, path, de->d_name); \
+            if(read_single_number_file(filename, &node->allocation_ ## SECTION ## _ ## FIELD) != 0) {\
+                error("BTRFS: failed to read '%s'", filename);\
+                btrfs_free_node(node);\
+                continue;\
+            }\
+            if(!node->allocation_ ## SECTION ## _ ## FIELD ## _filename)\
+                node->allocation_ ## SECTION ## _ ## FIELD ## _filename = strdupz(filename);\
+        }
+
+        // --------------------------------------------------------------------
+        // allocation/data
+
+        init_btrfs_allocation_section_field(data, total_bytes);
+        init_btrfs_allocation_section_field(data, bytes_used);
+        init_btrfs_allocation_section_field(data, disk_total);
+        init_btrfs_allocation_section_field(data, disk_used);
+
+        // --------------------------------------------------------------------
+        // allocation/metadata
+
+        init_btrfs_allocation_section_field(metadata, total_bytes);
+        init_btrfs_allocation_section_field(metadata, bytes_used);
+        init_btrfs_allocation_section_field(metadata, disk_total);
+        init_btrfs_allocation_section_field(metadata, disk_used);
+
+
+        // --------------------------------------------------------------------
+        // allocation/system
+
+        init_btrfs_allocation_section_field(system, total_bytes);
+        init_btrfs_allocation_section_field(system, bytes_used);
+        init_btrfs_allocation_section_field(system, disk_total);
+        init_btrfs_allocation_section_field(system, disk_used);
+
+
+        // --------------------------------------------------------------------
+        // allocation/global_rsv
+
+        init_btrfs_allocation_field(global_rsv_size);
+        init_btrfs_allocation_field(global_rsv_reserved);
+
+
+        // --------------------------------------------------------------------
+        // link it
+
+        // info("BTRFS: linking '%s'", node->id);
+        node->next = nodes;
+        nodes = node;
+    }
+    closedir(dir);
+
+
+    // ------------------------------------------------------------------------
+    // cleanup
+
+    BTRFS_NODE *last = NULL;
+    node = nodes;
+
+    while(node) {
+        if(unlikely(!node->exists)) {
+            if(unlikely(nodes == node)) {
+                nodes = node->next;
+                btrfs_free_node(node);
+                node = nodes;
+                last = NULL;
+            }
+            else {
+                last->next = node->next;
+                btrfs_free_node(node);
+                node = last->next;
+            }
+
+            continue;
+        }
+
+        last = node;
+        node = node->next;
+    }
+
+    return 0;
+}
+
+int do_sys_fs_btrfs(int update_every, usec_t dt) {
+    static int initialized = 0, do_allocation_system = 1, do_allocation_data = 1, do_allocation_metadata = 1, do_allocation_global_rsv = 1;
+    static usec_t refresh_delta = 0, refresh_every = 60 * USEC_PER_SEC;
+    static char *btrfs_path = NULL;
+
+    (void)dt;
+
+    if(unlikely(!initialized)) {
+        initialized = 1;
+
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/fs/btrfs");
+        btrfs_path = config_get("plugin:proc:/sys/fs/btrfs", "path to monitor", filename);
+
+        refresh_every = config_get_number("plugin:proc:/sys/fs/btrfs", "check for btrfs changes every", refresh_every / USEC_PER_SEC) * USEC_PER_SEC;
+        refresh_delta = refresh_every;
+
+        do_allocation_data = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "data allocation", CONFIG_BOOLEAN_AUTO);
+        do_allocation_metadata = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "metadata allocation", CONFIG_BOOLEAN_AUTO);
+        do_allocation_system = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "system allocation", CONFIG_BOOLEAN_AUTO);
+        do_allocation_global_rsv = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "global reserve", CONFIG_BOOLEAN_AUTO);
+    }
+
+    refresh_delta += dt;
+    if(refresh_delta >= refresh_every) {
+        refresh_delta = 0;
+        find_all_btrfs_pools(btrfs_path);
+    }
+
+    BTRFS_NODE *node;
+    for(node = nodes; node ; node = node->next) {
+        // --------------------------------------------------------------------
+        // allocation/system
+
+        #define collect_btrfs_allocation_field(FIELD) \
+            read_single_number_file(node->allocation_ ## FIELD ## _filename, &node->allocation_ ## FIELD)
+
+        #define collect_btrfs_allocation_section_field(SECTION, FIELD) \
+            read_single_number_file(node->allocation_ ## SECTION ## _ ## FIELD ## _filename, &node->allocation_ ## SECTION ## _ ## FIELD)
+
+        if(do_allocation_data != CONFIG_BOOLEAN_NO) {
+            if (collect_btrfs_allocation_section_field(data, total_bytes) != 0
+                || collect_btrfs_allocation_section_field(data, bytes_used) != 0
+                || collect_btrfs_allocation_section_field(data, disk_total) != 0
+                || collect_btrfs_allocation_section_field(data, disk_used) != 0) {
+                error("BTRFS: failed to collect allocation/data for '%s'", node->id);
+                // make it refresh btrfs at the next iteration
+                refresh_delta = refresh_every;
+                continue;
+            }
+        }
+
+        if(do_allocation_metadata != CONFIG_BOOLEAN_NO) {
+            if (collect_btrfs_allocation_section_field(metadata, total_bytes) != 0
+                || collect_btrfs_allocation_section_field(metadata, bytes_used) != 0
+                || collect_btrfs_allocation_section_field(metadata, disk_total) != 0
+                || collect_btrfs_allocation_section_field(metadata, disk_used) != 0) {
+                error("BTRFS: failed to collect allocation/metadata for '%s'", node->id);
+                // make it refresh btrfs at the next iteration
+                refresh_delta = refresh_every;
+                continue;
+            }
+        }
+
+        if(do_allocation_system != CONFIG_BOOLEAN_NO) {
+            if (collect_btrfs_allocation_section_field(system, total_bytes) != 0
+                || collect_btrfs_allocation_section_field(system, bytes_used) != 0
+                || collect_btrfs_allocation_section_field(system, disk_total) != 0
+                || collect_btrfs_allocation_section_field(system, disk_used) != 0) {
+                error("BTRFS: failed to collect allocation/system for '%s'", node->id);
+                // make it refresh btrfs at the next iteration
+                refresh_delta = refresh_every;
+                continue;
+            }
+        }
+
+        if(do_allocation_global_rsv != CONFIG_BOOLEAN_NO) {
+            if(collect_btrfs_allocation_field(global_rsv_reserved) != 0
+               || collect_btrfs_allocation_field(global_rsv_size) != 0) {
+                error("BTRFS: failed to collect global reserve for '%s'", node->id);
+                // make it refresh btrfs at the next iteration
+                refresh_delta = refresh_every;
+                continue;
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // allocation/data
+
+        if(do_allocation_data == CONFIG_BOOLEAN_YES || (do_allocation_data == CONFIG_BOOLEAN_AUTO && (node->allocation_data_total_bytes || node->allocation_data_bytes_used))) {
+            do_allocation_data = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!node->st_allocation_data)) {
+                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
+
+                snprintf(id, RRD_ID_LENGTH_MAX, "data_bytes_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "data_bytes_%s", node->label);
+                snprintf(title, 200, "BTRFS Data Allocation for %s", node->label);
+
+                netdata_fix_chart_id(id);
+                netdata_fix_chart_name(name);
+
+                node->st_allocation_data = rrdset_create_localhost(
+                        "btrfs"
+                        , id
+                        , name
+                        , node->label
+                        , "btrfs.system_bytes"
+                        , title
+                        , "MB"
+                        , "proc"
+                        , "sys/fs/btrfs"
+                        , 2300
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                );
+
+                node->rd_allocation_data_total_bytes = rrddim_add(node->st_allocation_data, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_data_bytes_used = rrddim_add(node->st_allocation_data, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_data_disk_total = rrddim_add(node->st_allocation_data, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_data_disk_used = rrddim_add(node->st_allocation_data, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            }
+            else rrdset_next(node->st_allocation_data);
+
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_total_bytes, node->allocation_data_total_bytes);
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_bytes_used, node->allocation_data_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_disk_total, node->allocation_data_disk_total);
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_disk_used, node->allocation_data_disk_used);
+            rrdset_done(node->st_allocation_data);
+        }
+
+        // --------------------------------------------------------------------
+        // allocation/system
+
+        if(do_allocation_system == CONFIG_BOOLEAN_YES || (do_allocation_system == CONFIG_BOOLEAN_AUTO && (node->allocation_system_total_bytes || node->allocation_system_bytes_used))) {
+            do_allocation_system = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!node->st_allocation_system)) {
+                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
+
+                snprintf(id, RRD_ID_LENGTH_MAX, "system_bytes_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "system_bytes_%s", node->label);
+                snprintf(title, 200, "BTRFS System Allocation for %s", node->label);
+
+                netdata_fix_chart_id(id);
+                netdata_fix_chart_name(name);
+
+                node->st_allocation_system = rrdset_create_localhost(
+                        "btrfs"
+                        , id
+                        , name
+                        , node->label
+                        , "btrfs.system_bytes"
+                        , title
+                        , "MB"
+                        , "proc"
+                        , "sys/fs/btrfs"
+                        , 2301
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                );
+
+                node->rd_allocation_system_total_bytes = rrddim_add(node->st_allocation_system, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_system_bytes_used = rrddim_add(node->st_allocation_system, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_system_disk_total = rrddim_add(node->st_allocation_system, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_system_disk_used = rrddim_add(node->st_allocation_system, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            }
+            else rrdset_next(node->st_allocation_system);
+
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_total_bytes, node->allocation_system_total_bytes);
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_bytes_used, node->allocation_system_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_disk_total, node->allocation_system_disk_total);
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_disk_used, node->allocation_system_disk_used);
+            rrdset_done(node->st_allocation_system);
+        }
+
+        // --------------------------------------------------------------------
+        // allocation/metadata
+
+        if(do_allocation_metadata == CONFIG_BOOLEAN_YES || (do_allocation_metadata == CONFIG_BOOLEAN_AUTO && (node->allocation_metadata_total_bytes || node->allocation_metadata_bytes_used))) {
+            do_allocation_metadata = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!node->st_allocation_metadata)) {
+                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
+
+                snprintf(id, RRD_ID_LENGTH_MAX, "metadata_bytes_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "metadata_bytes_%s", node->label);
+                snprintf(title, 200, "BTRFS Metadata Allocation for %s", node->label);
+
+                netdata_fix_chart_id(id);
+                netdata_fix_chart_name(name);
+
+                node->st_allocation_metadata = rrdset_create_localhost(
+                        "btrfs"
+                        , id
+                        , name
+                        , node->label
+                        , "btrfs.system_bytes"
+                        , title
+                        , "MB"
+                        , "proc"
+                        , "sys/fs/btrfs"
+                        , 2302
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                );
+
+                node->rd_allocation_metadata_total_bytes = rrddim_add(node->st_allocation_metadata, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_bytes_used = rrddim_add(node->st_allocation_metadata, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_disk_total = rrddim_add(node->st_allocation_metadata, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_disk_used = rrddim_add(node->st_allocation_metadata, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            }
+            else rrdset_next(node->st_allocation_metadata);
+
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_total_bytes, node->allocation_metadata_total_bytes);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_bytes_used, node->allocation_metadata_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_disk_total, node->allocation_metadata_disk_total);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_disk_used, node->allocation_metadata_disk_used);
+            rrdset_done(node->st_allocation_metadata);
+        }
+
+
+        // --------------------------------------------------------------------
+        // allocation/global_rsv
+
+        if(do_allocation_global_rsv == CONFIG_BOOLEAN_YES || (do_allocation_global_rsv == CONFIG_BOOLEAN_AUTO && (node->allocation_global_rsv_size || node->allocation_global_rsv_reserved))) {
+            do_allocation_global_rsv = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!node->st_allocation_global_rsv)) {
+                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
+
+                snprintf(id, RRD_ID_LENGTH_MAX, "global_reserve_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "global_reserve_%s", node->label);
+                snprintf(title, 200, "BTRFS Global Reserve for %s", node->label);
+
+                netdata_fix_chart_id(id);
+                netdata_fix_chart_name(name);
+
+                node->st_allocation_global_rsv = rrdset_create_localhost(
+                        "btrfs"
+                        , id
+                        , name
+                        , node->label
+                        , "btrfs.system_bytes"
+                        , title
+                        , "MB"
+                        , "proc"
+                        , "sys/fs/btrfs"
+                        , 2302
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                );
+                node->rd_allocation_global_rsv_size = rrddim_add(node->st_allocation_global_rsv, "size", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_global_rsv_reserved = rrddim_add(node->st_allocation_global_rsv, "reserved", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            }
+            else rrdset_next(node->st_allocation_global_rsv);
+
+            rrddim_set_by_pointer(node->st_allocation_global_rsv, node->rd_allocation_global_rsv_size, node->allocation_global_rsv_size);
+            rrddim_set_by_pointer(node->st_allocation_global_rsv, node->rd_allocation_global_rsv_reserved, node->allocation_global_rsv_reserved);
+            rrdset_done(node->st_allocation_global_rsv);
+        }
+    }
+
+    return 0;
+}
+

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -300,8 +300,13 @@ static inline int find_all_btrfs_pools(const char *path) {
 
             snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
             read_file(filename, label, FILENAME_MAX);
-            if (label[0])
-                node->label = strdupz(label);
+
+            char *s = label;
+            if (s[0])
+                s = trim(label);
+
+            if(s && s[0])
+                node->label = strdupz(s);
             else
                 node->label = strdupz(node->id);
         }

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -205,6 +205,7 @@ static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
 
         node->all_disks_total += d->size * d->hw_sector_size;
     }
+    closedir(dir);
 
     // ------------------------------------------------------------------------
     // cleanup

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -64,6 +64,9 @@ static inline void btrfs_free_node(BTRFS_NODE *node) {
     if(node->st_allocation_metadata)
         rrdset_is_obsolete(node->st_allocation_metadata);
 
+    if(node->st_allocation_global_rsv)
+        rrdset_is_obsolete(node->st_allocation_global_rsv);
+
     freez(node->allocation_system_bytes_used_filename);
     freez(node->allocation_system_total_bytes_filename);
 

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -644,7 +644,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                         , id
                         , name
                         , node->label
-                        , "btrfs.metdata"
+                        , "btrfs.metadata"
                         , title
                         , "MB"
                         , "proc"

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -505,7 +505,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                         , "MB"
                         , "proc"
                         , "sys/fs/btrfs"
-                        , 2302
+                        , 2303
                         , update_every
                         , RRDSET_TYPE_LINE
                 );

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -35,9 +35,13 @@ typedef struct btrfs_node {
         unsigned long long int allocation_ ## FIELD;
 
     RRDSET *st_allocation_disks;
-    RRDDIM *rd_allocation_disks_used;
     RRDDIM *rd_allocation_disks_unallocated;
-    RRDDIM *rd_allocation_disks_free;
+    RRDDIM *rd_allocation_disks_data_used;
+    RRDDIM *rd_allocation_disks_data_free;
+    RRDDIM *rd_allocation_disks_metadata_used;
+    RRDDIM *rd_allocation_disks_metadata_free;
+    RRDDIM *rd_allocation_disks_system_used;
+    RRDDIM *rd_allocation_disks_system_free;
     unsigned long long all_disks_total;
 
     RRDSET *st_allocation_data;
@@ -549,19 +553,26 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                 );
 
                 node->rd_allocation_disks_unallocated = rrddim_add(node->st_allocation_disks, "unallocated", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_disks_used = rrddim_add(node->st_allocation_disks, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_disks_free = rrddim_add(node->st_allocation_disks, "free", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_data_used = rrddim_add(node->st_allocation_disks, "data_used", "data used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_data_free = rrddim_add(node->st_allocation_disks, "data_free", "data free", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_metadata_used = rrddim_add(node->st_allocation_disks, "meta_used", "meta used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_metadata_free = rrddim_add(node->st_allocation_disks, "meta_free", "meta free", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_system_used = rrddim_add(node->st_allocation_disks, "sys_used", "sys used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_system_free = rrddim_add(node->st_allocation_disks, "sys_free", "sys free", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
             }
             else rrdset_next(node->st_allocation_disks);
 
-
-            unsigned long long disk_used = node->allocation_data_disk_used + node->allocation_metadata_disk_used + node->allocation_system_disk_used;
+            // unsigned long long disk_used = node->allocation_data_disk_used + node->allocation_metadata_disk_used + node->allocation_system_disk_used;
             unsigned long long disk_total = node->allocation_data_disk_total + node->allocation_metadata_disk_total + node->allocation_system_disk_total;
             unsigned long long disk_unallocated = node->all_disks_total - disk_total;
 
             rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_unallocated, disk_unallocated);
-            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_used, disk_used);
-            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_free, disk_total - disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_data_used, node->allocation_data_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_data_free, node->allocation_data_disk_total - node->allocation_data_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_metadata_used, node->allocation_metadata_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_metadata_free, node->allocation_metadata_disk_total - node->allocation_metadata_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_system_used, node->allocation_system_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_system_free, node->allocation_system_disk_total - node->allocation_system_disk_used);
             rrdset_done(node->st_allocation_disks);
         }
 

--- a/src/sys_fs_btrfs.c
+++ b/src/sys_fs_btrfs.c
@@ -1,15 +1,26 @@
 #include "common.h"
 
-#define BTRFS_MAX_ID_LENGTH 50
-#define BTRFS_MAX_LABEL_LENGTH 200
+typedef struct btrfs_disk {
+    char *name;
+    uint32_t hash;
+    int exists;
+
+    char *size_filename;
+    char *hw_sector_size_filename;
+    unsigned long long size;
+    unsigned long long hw_sector_size;
+
+    struct btrfs_disk *next;
+} BTRFS_DISK;
 
 typedef struct btrfs_node {
     int exists;
+    int logged_error;
 
-    char id[BTRFS_MAX_ID_LENGTH + 1];
+    char *id;
     uint32_t hash;
 
-    char label[BTRFS_MAX_LABEL_LENGTH + 1];
+    char *label;
 
     // unsigned long long int sectorsize;
     // unsigned long long int nodesize;
@@ -17,46 +28,64 @@ typedef struct btrfs_node {
 
     #define declare_btrfs_allocation_section_field(SECTION, FIELD) \
         char *allocation_ ## SECTION ## _ ## FIELD ## _filename; \
-        unsigned long long int allocation_ ## SECTION ## _ ## FIELD; \
-        RRDDIM *rd_allocation_ ## SECTION ## _ ## FIELD;
+        unsigned long long int allocation_ ## SECTION ## _ ## FIELD;
 
     #define declare_btrfs_allocation_field(FIELD) \
         char *allocation_ ## FIELD ## _filename; \
-        unsigned long long int allocation_ ## FIELD; \
-        RRDDIM *rd_allocation_ ## FIELD;
+        unsigned long long int allocation_ ## FIELD;
 
-    RRDSET *st_allocation_system;
-    declare_btrfs_allocation_section_field(system, total_bytes)
-    declare_btrfs_allocation_section_field(system, bytes_used)
-    declare_btrfs_allocation_section_field(system, disk_total)
-    declare_btrfs_allocation_section_field(system, disk_used)
+    RRDSET *st_allocation_disks;
+    RRDDIM *rd_allocation_disks_used;
+    RRDDIM *rd_allocation_disks_unallocated;
+    RRDDIM *rd_allocation_disks_free;
+    unsigned long long all_disks_total;
 
     RRDSET *st_allocation_data;
+    RRDDIM *rd_allocation_data_free;
+    RRDDIM *rd_allocation_data_used;
     declare_btrfs_allocation_section_field(data, total_bytes)
     declare_btrfs_allocation_section_field(data, bytes_used)
     declare_btrfs_allocation_section_field(data, disk_total)
     declare_btrfs_allocation_section_field(data, disk_used)
 
     RRDSET *st_allocation_metadata;
+    RRDDIM *rd_allocation_metadata_free;
+    RRDDIM *rd_allocation_metadata_used;
+    RRDDIM *rd_allocation_metadata_reserved;
     declare_btrfs_allocation_section_field(metadata, total_bytes)
     declare_btrfs_allocation_section_field(metadata, bytes_used)
     declare_btrfs_allocation_section_field(metadata, disk_total)
     declare_btrfs_allocation_section_field(metadata, disk_used)
-
-    RRDSET *st_allocation_global_rsv;
-    declare_btrfs_allocation_field(global_rsv_reserved)
+    //declare_btrfs_allocation_field(global_rsv_reserved)
     declare_btrfs_allocation_field(global_rsv_size)
+
+    RRDSET *st_allocation_system;
+    RRDDIM *rd_allocation_system_free;
+    RRDDIM *rd_allocation_system_used;
+    declare_btrfs_allocation_section_field(system, total_bytes)
+    declare_btrfs_allocation_section_field(system, bytes_used)
+    declare_btrfs_allocation_section_field(system, disk_total)
+    declare_btrfs_allocation_section_field(system, disk_used)
+
+    BTRFS_DISK *disks;
 
     struct btrfs_node *next;
 } BTRFS_NODE;
 
 static BTRFS_NODE *nodes = NULL;
 
+static inline void btrfs_free_disk(BTRFS_DISK *d) {
+    freez(d->name);
+    freez(d->size_filename);
+    freez(d->hw_sector_size_filename);
+    freez(d);
+}
+
 static inline void btrfs_free_node(BTRFS_NODE *node) {
     // info("BTRFS: destroying '%s'", node->id);
 
-    if(node->st_allocation_system)
-        rrdset_is_obsolete(node->st_allocation_system);
+    if(node->st_allocation_disks)
+        rrdset_is_obsolete(node->st_allocation_disks);
 
     if(node->st_allocation_data)
         rrdset_is_obsolete(node->st_allocation_data);
@@ -64,11 +93,8 @@ static inline void btrfs_free_node(BTRFS_NODE *node) {
     if(node->st_allocation_metadata)
         rrdset_is_obsolete(node->st_allocation_metadata);
 
-    if(node->st_allocation_global_rsv)
-        rrdset_is_obsolete(node->st_allocation_global_rsv);
-
-    freez(node->allocation_system_bytes_used_filename);
-    freez(node->allocation_system_total_bytes_filename);
+    if(node->st_allocation_system)
+        rrdset_is_obsolete(node->st_allocation_system);
 
     freez(node->allocation_data_bytes_used_filename);
     freez(node->allocation_data_total_bytes_filename);
@@ -76,8 +102,130 @@ static inline void btrfs_free_node(BTRFS_NODE *node) {
     freez(node->allocation_metadata_bytes_used_filename);
     freez(node->allocation_metadata_total_bytes_filename);
 
+    freez(node->allocation_system_bytes_used_filename);
+    freez(node->allocation_system_total_bytes_filename);
+
+    while(node->disks) {
+        BTRFS_DISK *d = node->disks;
+        node->disks = node->disks->next;
+        btrfs_free_disk(d);
+    }
+
+    freez(node->label);
+    freez(node->id);
     freez(node);
 }
+
+static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
+    char filename[FILENAME_MAX + 1];
+
+    node->all_disks_total = 0;
+
+    BTRFS_DISK *d;
+    for(d = node->disks ; d ; d = d->next)
+        d->exists = 0;
+
+    DIR *dir = opendir(path);
+    if (!dir) {
+        if(!node->logged_error) {
+            error("BTRFS: Cannot open directory '%s'.", path);
+            node->logged_error = 1;
+        }
+        return 1;
+    }
+    node->logged_error = 0;
+
+    struct dirent *de = NULL;
+    while ((de = readdir(dir))) {
+        if (de->d_type != DT_LNK
+            || !strcmp(de->d_name, ".")
+            || !strcmp(de->d_name, "..")
+                ) {
+            // info("BTRFS: ignoring '%s'", de->d_name);
+            continue;
+        }
+
+        uint32_t hash = simple_hash(de->d_name);
+
+        // --------------------------------------------------------------------
+        // search for it
+
+        for(d = node->disks ; d ; d = d->next) {
+            if(hash == d->hash && !strcmp(de->d_name, d->name))
+                break;
+        }
+
+        // --------------------------------------------------------------------
+        // did we find it?
+
+        if(!d) {
+            d = callocz(sizeof(BTRFS_DISK), 1);
+
+            d->name = strdupz(de->d_name);
+            d->hash = simple_hash(d->name);
+
+            snprintfz(filename, FILENAME_MAX, "%s/%s/size", path, de->d_name);
+            d->size_filename = strdupz(filename);
+
+            snprintfz(filename, FILENAME_MAX, "%s/%s/queue/hw_sector_size", path, de->d_name);
+            d->hw_sector_size_filename = strdupz(filename);
+
+            // link it
+            d->next = node->disks;
+            node->disks = d;
+        }
+
+        d->exists = 1;
+
+
+        // --------------------------------------------------------------------
+        // update the values
+
+        if(read_single_number_file(d->size_filename, &d->size) != 0) {
+            error("BTRFS: failed to read '%s'", d->size_filename);
+            d->exists = 0;
+            continue;
+        }
+
+        if(read_single_number_file(d->hw_sector_size_filename, &d->hw_sector_size) != 0) {
+            error("BTRFS: failed to read '%s'", d->hw_sector_size_filename);
+            d->exists = 0;
+            continue;
+        }
+
+        node->all_disks_total += d->size * d->hw_sector_size;
+    }
+
+    // ------------------------------------------------------------------------
+    // cleanup
+
+    BTRFS_DISK *last = NULL;
+    d = node->disks;
+
+    while(d) {
+        if(unlikely(!d->exists)) {
+            if(unlikely(node->disks == d)) {
+                node->disks = d->next;
+                btrfs_free_disk(d);
+                d = node->disks;
+                last = NULL;
+            }
+            else {
+                last->next = d->next;
+                btrfs_free_disk(d);
+                d = last->next;
+            }
+
+            continue;
+        }
+
+        last = d;
+        d = d->next;
+    }
+
+    return 0;
+}
+
 
 static inline int find_all_btrfs_pools(const char *path) {
     static int logged_error = 0;
@@ -120,7 +268,12 @@ static inline int find_all_btrfs_pools(const char *path) {
         if(node) {
             // info("BTRFS: already exists '%s'", de->d_name);
             node->exists = 1;
-            break;
+
+            // update the disk sizes
+            snprintfz(filename, FILENAME_MAX, "%s/%s/devices", path, de->d_name);
+            find_btrfs_disks(node, filename);
+
+            continue;
         }
 
         // info("BTRFS: adding '%s'", de->d_name);
@@ -128,18 +281,20 @@ static inline int find_all_btrfs_pools(const char *path) {
         // not found, create it
         node = callocz(sizeof(BTRFS_NODE), 1);
 
-        strncpyz(node->id, de->d_name, BTRFS_MAX_ID_LENGTH);
+        node->id = strdupz(de->d_name);
         node->hash = simple_hash(node->id);
         node->exists = 1;
 
-        snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
-        if(read_file(filename, node->label, sizeof(node->label)) != 0) {
-            error("BTRFS: failed to read '%s'", filename);
-            btrfs_free_node(node);
-            continue;
+        {
+            char label[FILENAME_MAX + 1] = "";
+
+            snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
+            read_file(filename, label, FILENAME_MAX);
+            if (label[0])
+                node->label = strdupz(label);
+            else
+                node->label = strdupz(node->id);
         }
-        if(!node->label[0])
-            strncpyz(node->label, node->id, BTRFS_MAX_LABEL_LENGTH);
 
         //snprintfz(filename, FILENAME_MAX, "%s/%s/sectorsize", path, de->d_name);
         //if(read_single_number_file(filename, &node->sectorsize) != 0) {
@@ -195,6 +350,7 @@ static inline int find_all_btrfs_pools(const char *path) {
         init_btrfs_allocation_section_field(data, disk_total);
         init_btrfs_allocation_section_field(data, disk_used);
 
+
         // --------------------------------------------------------------------
         // allocation/metadata
 
@@ -202,6 +358,9 @@ static inline int find_all_btrfs_pools(const char *path) {
         init_btrfs_allocation_section_field(metadata, bytes_used);
         init_btrfs_allocation_section_field(metadata, disk_total);
         init_btrfs_allocation_section_field(metadata, disk_used);
+
+        init_btrfs_allocation_field(global_rsv_size);
+        // init_btrfs_allocation_field(global_rsv_reserved);
 
 
         // --------------------------------------------------------------------
@@ -214,10 +373,11 @@ static inline int find_all_btrfs_pools(const char *path) {
 
 
         // --------------------------------------------------------------------
-        // allocation/global_rsv
+        // find all disks related to this node
+        // and collect their sizes
 
-        init_btrfs_allocation_field(global_rsv_size);
-        init_btrfs_allocation_field(global_rsv_reserved);
+        snprintfz(filename, FILENAME_MAX, "%s/%s/devices", path, de->d_name);
+        find_btrfs_disks(node, filename);
 
 
         // --------------------------------------------------------------------
@@ -261,7 +421,12 @@ static inline int find_all_btrfs_pools(const char *path) {
 }
 
 int do_sys_fs_btrfs(int update_every, usec_t dt) {
-    static int initialized = 0, do_allocation_system = 1, do_allocation_data = 1, do_allocation_metadata = 1, do_allocation_global_rsv = 1;
+    static int initialized = 0
+        , do_allocation_disks = CONFIG_BOOLEAN_AUTO
+        , do_allocation_system = CONFIG_BOOLEAN_AUTO
+        , do_allocation_data = CONFIG_BOOLEAN_AUTO
+        , do_allocation_metadata = CONFIG_BOOLEAN_AUTO;
+
     static usec_t refresh_delta = 0, refresh_every = 60 * USEC_PER_SEC;
     static char *btrfs_path = NULL;
 
@@ -277,10 +442,10 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         refresh_every = config_get_number("plugin:proc:/sys/fs/btrfs", "check for btrfs changes every", refresh_every / USEC_PER_SEC) * USEC_PER_SEC;
         refresh_delta = refresh_every;
 
-        do_allocation_data = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "data allocation", CONFIG_BOOLEAN_AUTO);
-        do_allocation_metadata = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "metadata allocation", CONFIG_BOOLEAN_AUTO);
-        do_allocation_system = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "system allocation", CONFIG_BOOLEAN_AUTO);
-        do_allocation_global_rsv = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "global reserve", CONFIG_BOOLEAN_AUTO);
+        do_allocation_disks = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "physical disks allocation", do_allocation_disks);
+        do_allocation_data = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "data allocation", do_allocation_data);
+        do_allocation_metadata = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "metadata allocation", do_allocation_metadata);
+        do_allocation_system = config_get_boolean_ondemand("plugin:proc:/sys/fs/btrfs", "system allocation", do_allocation_system);
     }
 
     refresh_delta += dt;
@@ -300,11 +465,23 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         #define collect_btrfs_allocation_section_field(SECTION, FIELD) \
             read_single_number_file(node->allocation_ ## SECTION ## _ ## FIELD ## _filename, &node->allocation_ ## SECTION ## _ ## FIELD)
 
+        if(do_allocation_disks != CONFIG_BOOLEAN_NO) {
+            if(     collect_btrfs_allocation_section_field(data, disk_total) != 0
+                 || collect_btrfs_allocation_section_field(data, disk_used) != 0
+                 || collect_btrfs_allocation_section_field(metadata, disk_total) != 0
+                 || collect_btrfs_allocation_section_field(metadata, disk_used) != 0
+                 || collect_btrfs_allocation_section_field(system, disk_total) != 0
+                 || collect_btrfs_allocation_section_field(system, disk_used) != 0) {
+                error("BTRFS: failed to collect physical disks allocation for '%s'", node->id);
+                // make it refresh btrfs at the next iteration
+                refresh_delta = refresh_every;
+                continue;
+            }
+        }
+
         if(do_allocation_data != CONFIG_BOOLEAN_NO) {
             if (collect_btrfs_allocation_section_field(data, total_bytes) != 0
-                || collect_btrfs_allocation_section_field(data, bytes_used) != 0
-                || collect_btrfs_allocation_section_field(data, disk_total) != 0
-                || collect_btrfs_allocation_section_field(data, disk_used) != 0) {
+                || collect_btrfs_allocation_section_field(data, bytes_used) != 0) {
                 error("BTRFS: failed to collect allocation/data for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
@@ -315,8 +492,8 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         if(do_allocation_metadata != CONFIG_BOOLEAN_NO) {
             if (collect_btrfs_allocation_section_field(metadata, total_bytes) != 0
                 || collect_btrfs_allocation_section_field(metadata, bytes_used) != 0
-                || collect_btrfs_allocation_section_field(metadata, disk_total) != 0
-                || collect_btrfs_allocation_section_field(metadata, disk_used) != 0) {
+                || collect_btrfs_allocation_field(global_rsv_size) != 0
+                    ) {
                 error("BTRFS: failed to collect allocation/metadata for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
@@ -326,9 +503,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
 
         if(do_allocation_system != CONFIG_BOOLEAN_NO) {
             if (collect_btrfs_allocation_section_field(system, total_bytes) != 0
-                || collect_btrfs_allocation_section_field(system, bytes_used) != 0
-                || collect_btrfs_allocation_section_field(system, disk_total) != 0
-                || collect_btrfs_allocation_section_field(system, disk_used) != 0) {
+                || collect_btrfs_allocation_section_field(system, bytes_used) != 0) {
                 error("BTRFS: failed to collect allocation/system for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
@@ -336,27 +511,66 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
             }
         }
 
-        if(do_allocation_global_rsv != CONFIG_BOOLEAN_NO) {
-            if(collect_btrfs_allocation_field(global_rsv_reserved) != 0
-               || collect_btrfs_allocation_field(global_rsv_size) != 0) {
-                error("BTRFS: failed to collect global reserve for '%s'", node->id);
-                // make it refresh btrfs at the next iteration
-                refresh_delta = refresh_every;
-                continue;
+        // --------------------------------------------------------------------
+        // allocation/disks
+
+        if(do_allocation_disks == CONFIG_BOOLEAN_YES || (do_allocation_disks == CONFIG_BOOLEAN_AUTO && node->all_disks_total && node->allocation_data_disk_total)) {
+            do_allocation_disks = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!node->st_allocation_disks)) {
+                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
+
+                snprintf(id, RRD_ID_LENGTH_MAX, "disk_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "disk_%s", node->label);
+                snprintf(title, 200, "BTRFS Disk Allocation for %s", node->label);
+
+                netdata_fix_chart_id(id);
+                netdata_fix_chart_name(name);
+
+                node->st_allocation_disks = rrdset_create_localhost(
+                        "btrfs"
+                        , id
+                        , name
+                        , node->label
+                        , "btrfs.disk"
+                        , title
+                        , "MB"
+                        , "proc"
+                        , "sys/fs/btrfs"
+                        , 2300
+                        , update_every
+                        , RRDSET_TYPE_STACKED
+                );
+
+                node->rd_allocation_disks_unallocated = rrddim_add(node->st_allocation_disks, "unallocated", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_used = rrddim_add(node->st_allocation_disks, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_disks_free = rrddim_add(node->st_allocation_disks, "free", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
             }
+            else rrdset_next(node->st_allocation_disks);
+
+
+            unsigned long long disk_used = node->allocation_data_disk_used + node->allocation_metadata_disk_used + node->allocation_system_disk_used;
+            unsigned long long disk_total = node->allocation_data_disk_total + node->allocation_metadata_disk_total + node->allocation_system_disk_total;
+            unsigned long long disk_unallocated = node->all_disks_total - disk_total;
+
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_unallocated, disk_unallocated);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_used, disk_used);
+            rrddim_set_by_pointer(node->st_allocation_disks, node->rd_allocation_disks_free, disk_total - disk_used);
+            rrdset_done(node->st_allocation_disks);
         }
+
 
         // --------------------------------------------------------------------
         // allocation/data
 
-        if(do_allocation_data == CONFIG_BOOLEAN_YES || (do_allocation_data == CONFIG_BOOLEAN_AUTO && (node->allocation_data_total_bytes || node->allocation_data_bytes_used))) {
+        if(do_allocation_data == CONFIG_BOOLEAN_YES || (do_allocation_data == CONFIG_BOOLEAN_AUTO && node->allocation_data_total_bytes)) {
             do_allocation_data = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_data)) {
                 char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
 
-                snprintf(id, RRD_ID_LENGTH_MAX, "data_bytes_%s", node->id);
-                snprintf(name, RRD_ID_LENGTH_MAX, "data_bytes_%s", node->label);
+                snprintf(id, RRD_ID_LENGTH_MAX, "data_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "data_%s", node->label);
                 snprintf(title, 200, "BTRFS Data Allocation for %s", node->label);
 
                 netdata_fix_chart_id(id);
@@ -367,86 +581,37 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                         , id
                         , name
                         , node->label
-                        , "btrfs.system_bytes"
-                        , title
-                        , "MB"
-                        , "proc"
-                        , "sys/fs/btrfs"
-                        , 2300
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                );
-
-                node->rd_allocation_data_total_bytes = rrddim_add(node->st_allocation_data, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_data_bytes_used = rrddim_add(node->st_allocation_data, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_data_disk_total = rrddim_add(node->st_allocation_data, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_data_disk_used = rrddim_add(node->st_allocation_data, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-            }
-            else rrdset_next(node->st_allocation_data);
-
-            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_total_bytes, node->allocation_data_total_bytes);
-            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_bytes_used, node->allocation_data_bytes_used);
-            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_disk_total, node->allocation_data_disk_total);
-            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_disk_used, node->allocation_data_disk_used);
-            rrdset_done(node->st_allocation_data);
-        }
-
-        // --------------------------------------------------------------------
-        // allocation/system
-
-        if(do_allocation_system == CONFIG_BOOLEAN_YES || (do_allocation_system == CONFIG_BOOLEAN_AUTO && (node->allocation_system_total_bytes || node->allocation_system_bytes_used))) {
-            do_allocation_system = CONFIG_BOOLEAN_YES;
-
-            if(unlikely(!node->st_allocation_system)) {
-                char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
-
-                snprintf(id, RRD_ID_LENGTH_MAX, "system_bytes_%s", node->id);
-                snprintf(name, RRD_ID_LENGTH_MAX, "system_bytes_%s", node->label);
-                snprintf(title, 200, "BTRFS System Allocation for %s", node->label);
-
-                netdata_fix_chart_id(id);
-                netdata_fix_chart_name(name);
-
-                node->st_allocation_system = rrdset_create_localhost(
-                        "btrfs"
-                        , id
-                        , name
-                        , node->label
-                        , "btrfs.system_bytes"
+                        , "btrfs.data"
                         , title
                         , "MB"
                         , "proc"
                         , "sys/fs/btrfs"
                         , 2301
                         , update_every
-                        , RRDSET_TYPE_LINE
+                        , RRDSET_TYPE_STACKED
                 );
 
-                node->rd_allocation_system_total_bytes = rrddim_add(node->st_allocation_system, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_system_bytes_used = rrddim_add(node->st_allocation_system, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_system_disk_total = rrddim_add(node->st_allocation_system, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_system_disk_used = rrddim_add(node->st_allocation_system, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_data_free = rrddim_add(node->st_allocation_data, "free", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_data_used = rrddim_add(node->st_allocation_data, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
             }
-            else rrdset_next(node->st_allocation_system);
+            else rrdset_next(node->st_allocation_data);
 
-            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_total_bytes, node->allocation_system_total_bytes);
-            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_bytes_used, node->allocation_system_bytes_used);
-            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_disk_total, node->allocation_system_disk_total);
-            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_disk_used, node->allocation_system_disk_used);
-            rrdset_done(node->st_allocation_system);
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_free, node->allocation_data_total_bytes - node->allocation_data_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_data, node->rd_allocation_data_used, node->allocation_data_bytes_used);
+            rrdset_done(node->st_allocation_data);
         }
 
         // --------------------------------------------------------------------
         // allocation/metadata
 
-        if(do_allocation_metadata == CONFIG_BOOLEAN_YES || (do_allocation_metadata == CONFIG_BOOLEAN_AUTO && (node->allocation_metadata_total_bytes || node->allocation_metadata_bytes_used))) {
+        if(do_allocation_metadata == CONFIG_BOOLEAN_YES || (do_allocation_metadata == CONFIG_BOOLEAN_AUTO && node->allocation_metadata_total_bytes)) {
             do_allocation_metadata = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_metadata)) {
                 char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
 
-                snprintf(id, RRD_ID_LENGTH_MAX, "metadata_bytes_%s", node->id);
-                snprintf(name, RRD_ID_LENGTH_MAX, "metadata_bytes_%s", node->label);
+                snprintf(id, RRD_ID_LENGTH_MAX, "metadata_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "metadata_%s", node->label);
                 snprintf(title, 200, "BTRFS Metadata Allocation for %s", node->label);
 
                 netdata_fix_chart_id(id);
@@ -457,69 +622,67 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                         , id
                         , name
                         , node->label
-                        , "btrfs.system_bytes"
+                        , "btrfs.metdata"
                         , title
                         , "MB"
                         , "proc"
                         , "sys/fs/btrfs"
                         , 2302
                         , update_every
-                        , RRDSET_TYPE_LINE
+                        , RRDSET_TYPE_STACKED
                 );
 
-                node->rd_allocation_metadata_total_bytes = rrddim_add(node->st_allocation_metadata, "total", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_metadata_bytes_used = rrddim_add(node->st_allocation_metadata, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_metadata_disk_total = rrddim_add(node->st_allocation_metadata, "disk_total", "disk total", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_metadata_disk_used = rrddim_add(node->st_allocation_metadata, "disk_used", "disk used", 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_free = rrddim_add(node->st_allocation_metadata, "free", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_used = rrddim_add(node->st_allocation_metadata, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_metadata_reserved = rrddim_add(node->st_allocation_metadata, "reserved", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
             }
             else rrdset_next(node->st_allocation_metadata);
 
-            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_total_bytes, node->allocation_metadata_total_bytes);
-            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_bytes_used, node->allocation_metadata_bytes_used);
-            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_disk_total, node->allocation_metadata_disk_total);
-            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_disk_used, node->allocation_metadata_disk_used);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_free, node->allocation_metadata_total_bytes - node->allocation_metadata_bytes_used - node->allocation_global_rsv_size);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_used, node->allocation_metadata_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_metadata, node->rd_allocation_metadata_reserved, node->allocation_global_rsv_size);
             rrdset_done(node->st_allocation_metadata);
         }
 
-
         // --------------------------------------------------------------------
-        // allocation/global_rsv
+        // allocation/system
 
-        if(do_allocation_global_rsv == CONFIG_BOOLEAN_YES || (do_allocation_global_rsv == CONFIG_BOOLEAN_AUTO && (node->allocation_global_rsv_size || node->allocation_global_rsv_reserved))) {
-            do_allocation_global_rsv = CONFIG_BOOLEAN_YES;
+        if(do_allocation_system == CONFIG_BOOLEAN_YES || (do_allocation_system == CONFIG_BOOLEAN_AUTO && node->allocation_system_total_bytes)) {
+            do_allocation_system = CONFIG_BOOLEAN_YES;
 
-            if(unlikely(!node->st_allocation_global_rsv)) {
+            if(unlikely(!node->st_allocation_system)) {
                 char id[RRD_ID_LENGTH_MAX + 1], name[RRD_ID_LENGTH_MAX + 1], title[200 + 1];
 
-                snprintf(id, RRD_ID_LENGTH_MAX, "global_reserve_%s", node->id);
-                snprintf(name, RRD_ID_LENGTH_MAX, "global_reserve_%s", node->label);
-                snprintf(title, 200, "BTRFS Global Reserve for %s", node->label);
+                snprintf(id, RRD_ID_LENGTH_MAX, "system_%s", node->id);
+                snprintf(name, RRD_ID_LENGTH_MAX, "system_%s", node->label);
+                snprintf(title, 200, "BTRFS System Allocation for %s", node->label);
 
                 netdata_fix_chart_id(id);
                 netdata_fix_chart_name(name);
 
-                node->st_allocation_global_rsv = rrdset_create_localhost(
+                node->st_allocation_system = rrdset_create_localhost(
                         "btrfs"
                         , id
                         , name
                         , node->label
-                        , "btrfs.system_bytes"
+                        , "btrfs.system"
                         , title
                         , "MB"
                         , "proc"
                         , "sys/fs/btrfs"
                         , 2303
                         , update_every
-                        , RRDSET_TYPE_LINE
+                        , RRDSET_TYPE_STACKED
                 );
-                node->rd_allocation_global_rsv_size = rrddim_add(node->st_allocation_global_rsv, "size", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-                node->rd_allocation_global_rsv_reserved = rrddim_add(node->st_allocation_global_rsv, "reserved", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-            }
-            else rrdset_next(node->st_allocation_global_rsv);
 
-            rrddim_set_by_pointer(node->st_allocation_global_rsv, node->rd_allocation_global_rsv_size, node->allocation_global_rsv_size);
-            rrddim_set_by_pointer(node->st_allocation_global_rsv, node->rd_allocation_global_rsv_reserved, node->allocation_global_rsv_reserved);
-            rrdset_done(node->st_allocation_global_rsv);
+                node->rd_allocation_system_free = rrddim_add(node->st_allocation_system, "free", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                node->rd_allocation_system_used = rrddim_add(node->st_allocation_system, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+            }
+            else rrdset_next(node->st_allocation_system);
+
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_free, node->allocation_system_total_bytes - node->allocation_system_bytes_used);
+            rrddim_set_by_pointer(node->st_allocation_system, node->rd_allocation_system_used, node->allocation_system_bytes_used);
+            rrdset_done(node->st_allocation_system);
         }
     }
 

--- a/src/zfs_common.c
+++ b/src/zfs_common.c
@@ -48,7 +48,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "MB"
                     , plugin
                     , "zfs"
-                    , 2000
+                    , 2500
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -86,7 +86,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "MB"
                     , plugin
                     , "zfs"
-                    , 2000
+                    , 2500
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -123,7 +123,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "reads/s"
                     , plugin
                     , "zfs"
-                    , 2010
+                    , 2510
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -168,7 +168,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "kilobytes/s"
                     , plugin
                     , "zfs"
-                    , 2200
+                    , 2700
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -202,7 +202,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2020
+                    , 2520
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -236,7 +236,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2030
+                    , 2530
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -270,7 +270,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2040
+                    , 2540
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -304,7 +304,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2050
+                    , 2550
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -338,7 +338,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2060
+                    , 2560
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -374,7 +374,7 @@ void generate_charts_arcstats(const char *plugin, int update_every) {
                     , "hits/s"
                     , plugin
                     , "zfs"
-                    , 2100
+                    , 2600
                     , update_every
                     , RRDSET_TYPE_AREA
             );
@@ -433,7 +433,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2020
+                    , 2520
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -472,7 +472,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "operations/s"
                     , plugin
                     , "zfs"
-                    , 2023
+                    , 2523
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -518,7 +518,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "operations/s"
                     , plugin
                     , "zfs"
-                    , 2022
+                    , 2522
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -556,7 +556,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2019
+                    , 2519
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -590,7 +590,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2031
+                    , 2531
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -624,7 +624,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "percentage"
                     , plugin
                     , "zfs"
-                    , 2032
+                    , 2532
                     , update_every
                     , RRDSET_TYPE_STACKED
             );
@@ -658,7 +658,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "elements"
                     , plugin
                     , "zfs"
-                    , 2300
+                    , 2800
                     , update_every
                     , RRDSET_TYPE_LINE
             );
@@ -692,7 +692,7 @@ void generate_charts_arc_summary(const char *plugin, int update_every) {
                     , "chains"
                     , plugin
                     , "zfs"
-                    , 2310
+                    , 2810
                     , update_every
                     , RRDSET_TYPE_LINE
             );

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -121,6 +121,12 @@ netdataDashboard.menu = {
         info: 'Performance metrics of the ZFS filesystem. The following charts visualize all metrics reported by <a href="https://github.com/zfsonlinux/zfs/blob/master/cmd/arcstat/arcstat.py" target="_blank">arcstat.py</a> and <a href="https://github.com/zfsonlinux/zfs/blob/master/cmd/arc_summary/arc_summary.py" target="_blank">arc_summary.py</a>.'
     },
 
+    'btrfs': {
+        title: 'BTRFS filesystem',
+        icon: '<i class="fas fa-folder-open"></i>',
+        info: 'Utilization metrics of the BTRFS filesystem.'
+    },
+
     'apps': {
         title: 'Applications',
         icon: '<i class="fas fa-heartbeat"></i>',

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -124,7 +124,7 @@ netdataDashboard.menu = {
     'btrfs': {
         title: 'BTRFS filesystem',
         icon: '<i class="fas fa-folder-open"></i>',
-        info: 'Utilization metrics of the BTRFS filesystem.'
+        info: 'Disk space metrics for the BTRFS filesystem.'
     },
 
     'apps': {
@@ -1667,5 +1667,21 @@ netdataDashboard.context = {
 
     'couchdb.open_files': {
         info: 'Count of all files held open by CouchDB. If this value seems pegged at 1024 or 4096, your server process is probably hitting the open file handle limit and <a href="http://docs.couchdb.org/en/latest/maintenance/performance.html#pam-and-ulimit">needs to be increased.</a>'
+    },
+
+    'btrfs.disk': {
+        info: 'Physical disk usage of BTRFS. The disk space reported here, is the raw physical disk space assigned to the BTRFS volume (i.e. <b>before any RAID levels</b>). BTRFS uses a two-stage allocator, first allocating large regions of disk space for one type of block (data, metadata, or system), and then using a regular block allocator inside those regions. <code>unallocated</code> is the physical disk space that is not allocated yet and is available to become data, metdata or system on demand. When <code>unallocated</code> is zero, all available disk space has been allocated to a specific function.'
+    },
+
+    'btrfs.data': {
+        info: 'Logical disk usage for BTRFS data. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
+    },
+
+    'btrfs.metadata': {
+        info: 'Logical disk usage for BTRFS metadata. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
+    },
+
+    'btrfs.system': {
+        info: 'Logical disk usage for BTRFS system. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
     }
 };

--- a/web/index.html
+++ b/web/index.html
@@ -4274,7 +4274,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverStatic + 'dashboard_info.js?v20171208-1',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20171217-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });

--- a/web/index.html
+++ b/web/index.html
@@ -4274,7 +4274,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverStatic + 'dashboard_info.js?v20171217-1',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20171218-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });


### PR DESCRIPTION
fixes #3095 (check it for the discussion of this implementation - we went through a few phases)

btrfs monitoring:

1. physical disk space allocation + alarm
2. data allocation + alarm
3. metadata allocation + alarm
4. system allocation + alarm

![screenshot from 2017-12-19 01-15-38](https://user-images.githubusercontent.com/2662304/34132777-28bb0b52-e45a-11e7-806d-f9b0e791c4ec.png)

---

also re-arranged the priorities of NFS and ZFS to appear after `Disk` on the dashboard, and all of them close to each other.