### PR TITLE
Update BTRFS chart descriptions.

### DIFF
--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1670,18 +1670,18 @@ netdataDashboard.context = {
     },
 
     'btrfs.disk': {
-        info: 'Physical disk usage of BTRFS. The disk space reported here is the raw physical disk space assigned to the BTRFS volume (i.e. <b>before any RAID levels</b>). BTRFS uses a two-stage allocator, first allocating large regions of disk space for one type of block (data, metadata, or system), and then using a regular block allocator inside those regions. <code>unallocated</code> is the physical disk space that is not allocated yet and is available to become data, metdata or system on demand. When <code>unallocated</code> is zero, all available disk space has been allocated to a specific function.  Healthy volumes should ideally have at least five percent of their total space <code>unallocated/<code>.  You can keep your volume healthy by running the <code>btrfs balance</code> command on it regularly (check <code>man btrfs-balance</code> for more info).'
+        info: 'Physical disk usage of BTRFS. The disk space reported here is the raw physical disk space assigned to the BTRFS volume (i.e. <b>before any RAID levels</b>). BTRFS uses a two-stage allocator, first allocating large regions of disk space for one type of block (data, metadata, or system), and then using a regular block allocator inside those regions. <code>unallocated</code> is the physical disk space that is not allocated yet and is available to become data, metdata or system on demand. When <code>unallocated</code> is zero, all available disk space has been allocated to a specific function. Healthy volumes should ideally have at least five percent of their total space <code>unallocated/<code>. You can keep your volume healthy by running the <code>btrfs balance</code> command on it regularly (check <code>man btrfs-balance</code> for more info).'
     },
 
     'btrfs.data': {
-        info: 'Logical disk usage for BTRFS data. The disk space reported here is the usable allocation (i.e. after any striping or replication).  Healthy volumes should ideally have no more than a few GB of free space reported here persistently.  Running <code>btrfs balance</code> can help here.'
+        info: 'Logical disk usage for BTRFS data. Data chunks are used to store the actual file data (file contents). The disk space reported here is the usable allocation (i.e. after any striping or replication). Healthy volumes should ideally have no more than a few GB of free space reported here persistently. Running <code>btrfs balance</code> can help here.'
     },
 
     'btrfs.metadata': {
-        info: 'Logical disk usage for BTRFS metadata. The disk space reported here is the usable allocation (i.e. after any striping or replication).  Healthy volumes should ideally have no more than a few GB of free space reported here persistently.  Running <code>btrfs balance</code> can help here.'
+        info: 'Logical disk usage for BTRFS metadata. Metadata chunks store most of the filesystem interal structures, as well as information like directory structure and file names. The disk space reported here is the usable allocation (i.e. after any striping or replication). Healthy volumes should ideally have no more than a few GB of free space reported here persistently. Running <code>btrfs balance</code> can help here.'
     },
 
     'btrfs.system': {
-        info: 'Logical disk usage for BTRFS system. The disk space reported here is the usable allocation (i.e. after any striping or replication).  The values reported here should be relatively small compared to Data and Metadata, and will scale with the volume size and overall space usage.'
+        info: 'Logical disk usage for BTRFS system. System chunks store information aobut the allocation of other chunks. The disk space reported here is the usable allocation (i.e. after any striping or replication). The values reported here should be relatively small compared to Data and Metadata, and will scale with the volume size and overall space usage.'
     }
 };

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1670,18 +1670,18 @@ netdataDashboard.context = {
     },
 
     'btrfs.disk': {
-        info: 'Physical disk usage of BTRFS. The disk space reported here, is the raw physical disk space assigned to the BTRFS volume (i.e. <b>before any RAID levels</b>). BTRFS uses a two-stage allocator, first allocating large regions of disk space for one type of block (data, metadata, or system), and then using a regular block allocator inside those regions. <code>unallocated</code> is the physical disk space that is not allocated yet and is available to become data, metdata or system on demand. When <code>unallocated</code> is zero, all available disk space has been allocated to a specific function.'
+        info: 'Physical disk usage of BTRFS. The disk space reported here is the raw physical disk space assigned to the BTRFS volume (i.e. <b>before any RAID levels</b>). BTRFS uses a two-stage allocator, first allocating large regions of disk space for one type of block (data, metadata, or system), and then using a regular block allocator inside those regions. <code>unallocated</code> is the physical disk space that is not allocated yet and is available to become data, metdata or system on demand. When <code>unallocated</code> is zero, all available disk space has been allocated to a specific function.  Healthy volumes should ideally have at least five percent of their total space <code>unallocated/<code>.  You can keep your volume healthy by running the <code>btrfs balance</code> command on it regularly (check <code>man btrfs-balance</code> for more info).'
     },
 
     'btrfs.data': {
-        info: 'Logical disk usage for BTRFS data. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
+        info: 'Logical disk usage for BTRFS data. The disk space reported here is the usable allocation (i.e. after any striping or replication).  Healthy volumes should ideally have no more than a few GB of free space reported here persistently.  Running <code>btrfs balance</code> can help here.'
     },
 
     'btrfs.metadata': {
-        info: 'Logical disk usage for BTRFS metadata. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
+        info: 'Logical disk usage for BTRFS metadata. The disk space reported here is the usable allocation (i.e. after any striping or replication).  Healthy volumes should ideally have no more than a few GB of free space reported here persistently.  Running <code>btrfs balance</code> can help here.'
     },
 
     'btrfs.system': {
-        info: 'Logical disk usage for BTRFS system. The disk space reported here is the usable allocation (i.e. after any RAID levels).'
+        info: 'Logical disk usage for BTRFS system. The disk space reported here is the usable allocation (i.e. after any striping or replication).  The values reported here should be relatively small compared to Data and Metadata, and will scale with the volume size and overall space usage.'
     }
 };


### PR DESCRIPTION
This adds some info on what the values in the graphs should ideally look like, and a bit on how to keep them that way, namely:

* Suggest some degree of slack space that should be present in the physical usage chart.  The particular 5% reference is based on my own experience.  Also refers to `btrfs balance` as the way to help keep things that way, with a reference to the man page for the balance command.
* Suggestions for data and metadata are based on the ideal standard of having no more than one chunk partially full (Data chunks are nominally 1-5GB, metadata are nominally 256MB to 1GB, but need more slack space to account for the Global Reserve).
* The info added for system chunks gives descriptions of expected behavior only.  The system chunks only store the tree that tracks the locations of chunk allocations on the FS, so they are generally not an issue (16K of space here holds enough room for approximately 663 chunks to be tracked, which translates to roughly 500 GB of allocated space).
* I've also removed references to RAID in the descriptions.  Strictly speaking, BTRFS replication and striping are _not_ RAID, and there's been a lot of noise recently on the BTRFS mailing list regarding this and the confusion the profile naming has caused, so I would suggest not referring to things as RAID.

If desired, I can update things with more specific advice on fixing things, but that is liable to get very long and involved, and I personally don't see much value in doing so (given that the best way to fix things is somewhat dependent on the design of the system in question and exactly how things have failed).