### PR TITLE
fix deadlock on exit of static netdata build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(NETDATA_LINUX_FILES
         src/sys_kernel_mm_ksm.c
         src/sys_fs_cgroup.c
         src/sys_fs_btrfs.c
-        )
+        src/threads.c src/threads.h)
 
 set(NETDATA_COMMON_FILES
         src/adaptive_resortable_list.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ set(NETDATA_LINUX_FILES
         src/proc_uptime.c
         src/sys_kernel_mm_ksm.c
         src/sys_fs_cgroup.c
-        src/sys_fs_btrfs.c)
+        src/sys_fs_btrfs.c
+        )
 
 set(NETDATA_COMMON_FILES
         src/adaptive_resortable_list.c
@@ -94,6 +95,7 @@ set(NETDATA_COMMON_FILES
         src/health_json.c
         src/health_log.c
         src/inlined.h
+        src/locks.c
         src/locks.h
         src/log.c
         src/log.h
@@ -189,6 +191,8 @@ set(APPS_PLUGIN_SOURCE_FILES
         src/clocks.c
         src/clocks.h
         src/inlined.h
+        src/locks.c
+        src/locks.h
         src/log.c
         src/log.h
         src/procfile.c
@@ -205,6 +209,8 @@ set(FREEIPMI_PLUGIN_SOURCE_FILES
         src/clocks.c
         src/clocks.h
         src/inlined.h
+        src/locks.c
+        src/locks.h
         src/log.c
         src/log.h
         src/procfile.c
@@ -219,6 +225,8 @@ set(CGROUP_NETWORK_SOURCE_FILES
         src/clocks.c
         src/clocks.h
         src/inlined.h
+        src/locks.c
+        src/locks.h
         src/log.c
         src/log.h
         src/procfile.c

--- a/makeself/build-x86_64-static.sh
+++ b/makeself/build-x86_64-static.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-DOCKER_CONTAINER_NAME="netdata-package-x86_64-static"
+DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine37"
 
 if ! sudo docker inspect "${DOCKER_CONTAINER_NAME}" >/dev/null 2>&1
 then
@@ -21,7 +21,7 @@ then
     # inside the container and runs the script install-alpine-packages.sh
     # (also inside the container)
     #
-    run sudo docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.6 \
+    run sudo docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
         /bin/sh /usr/src/netdata.git/makeself/install-alpine-packages.sh
 
     # save the changes made permanently

--- a/makeself/jobs/70-netdata-git.install.sh
+++ b/makeself/jobs/70-netdata-git.install.sh
@@ -6,7 +6,7 @@ cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
 then
-    export CFLAGS="-static -O3 -DNETDATA_WAIT_BEFORE_EXIT=2"
+    export CFLAGS="-static -O3"
 else
     export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
 #    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness"

--- a/makeself/jobs/70-netdata-git.install.sh
+++ b/makeself/jobs/70-netdata-git.install.sh
@@ -6,9 +6,10 @@ cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
 then
-    export CFLAGS="-static -O3"
+    export CFLAGS="-static -O3 -DNETDATA_WAIT_BEFORE_EXIT=2"
 else
     export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
+#    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness"
 fi
 
 if [ ! -z "${NETDATA_INSTALL_PATH}" -a -d "${NETDATA_INSTALL_PATH}/etc" ]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,6 +70,7 @@ netdata_SOURCES = \
 	health_json.c \
 	health_log.c \
 	inlined.h \
+	locks.c \
 	locks.h \
 	log.c \
 	log.h \
@@ -227,6 +228,7 @@ apps_plugin_SOURCES = \
 	clocks.c clocks.h \
 	common.c common.h \
 	inlined.h \
+	locks.c locks.h \
 	log.c log.h \
 	procfile.c procfile.h \
 	web_buffer.c web_buffer.h \
@@ -248,6 +250,7 @@ freeipmi_plugin_SOURCES = \
 	clocks.c clocks.h \
 	common.c common.h \
 	inlined.h \
+	locks.c locks.h \
 	log.c log.h \
 	procfile.c procfile.h \
 	$(NULL)
@@ -261,6 +264,7 @@ cgroup_network_SOURCES = \
 	clocks.c clocks.h \
     common.c common.h \
     inlined.h \
+	locks.c locks.h \
     log.c log.h \
 	procfile.c procfile.h \
 	popen.c popen.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,8 @@ netdata_SOURCES = \
 	statsd.h \
 	storage_number.c \
 	storage_number.h \
+	threads.c \
+	threads.h \
 	unit_test.c \
 	unit_test.h \
 	url.c \
@@ -224,14 +226,22 @@ netdata_LDADD = \
 
 apps_plugin_SOURCES = \
 	apps_plugin.c \
-	avl.c avl.h \
-	clocks.c clocks.h \
-	common.c common.h \
+	avl.c \
+	avl.h \
+	clocks.c \
+	clocks.h \
+	common.c \
+	common.h \
 	inlined.h \
-	locks.c locks.h \
+	locks.c \
+	locks.h \
 	log.c log.h \
-	procfile.c procfile.h \
-	web_buffer.c web_buffer.h \
+	procfile.c \
+	procfile.h \
+	threads.c \
+	threads.h \
+	web_buffer.c \
+	web_buffer.h \
 	$(NULL)
 
 if FREEBSD
@@ -247,12 +257,18 @@ apps_plugin_LDADD = \
 
 freeipmi_plugin_SOURCES = \
 	freeipmi_plugin.c \
-	clocks.c clocks.h \
-	common.c common.h \
+	clocks.c \
+	clocks.h \
+	common.c \
+	common.h \
 	inlined.h \
-	locks.c locks.h \
+	locks.c \
+	locks.h \
 	log.c log.h \
-	procfile.c procfile.h \
+	procfile.c \
+	procfile.h \
+	threads.c \
+	threads.h \
 	$(NULL)
 
 freeipmi_plugin_LDADD = \
@@ -261,14 +277,23 @@ freeipmi_plugin_LDADD = \
 
 cgroup_network_SOURCES = \
     cgroup-network.c \
-	clocks.c clocks.h \
-    common.c common.h \
+	clocks.c \
+	clocks.h \
+    common.c \
+    common.h \
     inlined.h \
-	locks.c locks.h \
-    log.c log.h \
-	procfile.c procfile.h \
-	popen.c popen.h \
-	signals.c signals.h \
+	locks.c \
+	locks.h \
+    log.c \
+    log.h \
+	procfile.c \
+	procfile.h \
+	popen.c \
+	popen.h \
+	signals.c \
+	signals.h \
+	threads.c \
+	threads.h \
     $(NULL)
 
 cgroup_network_LDADD = \

--- a/src/backends.c
+++ b/src/backends.c
@@ -508,15 +508,13 @@ static void backends_main_cleanup(void *ptr) {
 }
 
 void *backends_main(void *ptr) {
-    netdata_thread_welcome("BACKEND");
-
     int default_port = 0;
     int sock = -1;
     BUFFER *b = buffer_create(1), *response = buffer_create(1);
     int (*backend_request_formatter)(BUFFER *, const char *, RRDHOST *, const char *, RRDSET *, RRDDIM *, time_t, time_t, uint32_t) = NULL;
     int (*backend_response_checker)(BUFFER *) = NULL;
 
-    pthread_cleanup_push(backends_main_cleanup, ptr);
+    netdata_thread_cleanup_push(backends_main_cleanup, ptr);
 
     // ------------------------------------------------------------------------
     // collect configuration options
@@ -913,7 +911,6 @@ cleanup:
     buffer_free(b);
     buffer_free(response);
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/backends.c
+++ b/src/backends.c
@@ -677,6 +677,8 @@ void *backends_main(void *ptr) {
         // ------------------------------------------------------------------------
         // add to the buffer the data we need to send to the backend
 
+        netdata_thread_disable_cancelability();
+
         size_t count_hosts = 0;
         size_t count_charts_total = 0;
         size_t count_dims_total = 0;
@@ -723,6 +725,8 @@ void *backends_main(void *ptr) {
             rrdhost_unlock(host);
         }
         rrd_unlock();
+
+        netdata_thread_enable_cancelability();
 
         debug(D_BACKEND, "BACKEND: buffer has %zu bytes, added metrics for %zu dimensions, of %zu charts, from %zu hosts", buffer_strlen(b), count_dims_total, count_charts_total, count_hosts);
 

--- a/src/backends.c
+++ b/src/backends.c
@@ -508,13 +508,13 @@ static void backends_main_cleanup(void *ptr) {
 }
 
 void *backends_main(void *ptr) {
+    netdata_thread_cleanup_push(backends_main_cleanup, ptr);
+
     int default_port = 0;
     int sock = -1;
     BUFFER *b = buffer_create(1), *response = buffer_create(1);
     int (*backend_request_formatter)(BUFFER *, const char *, RRDHOST *, const char *, RRDSET *, RRDDIM *, time_t, time_t, uint32_t) = NULL;
     int (*backend_response_checker)(BUFFER *) = NULL;
-
-    netdata_thread_cleanup_push(backends_main_cleanup, ptr);
 
     // ------------------------------------------------------------------------
     // collect configuration options

--- a/src/common.c
+++ b/src/common.c
@@ -1116,22 +1116,6 @@ int fd_is_valid(int fd) {
     return fcntl(fd, F_GETFD) != -1 || errno != EBADF;
 }
 
-pid_t gettid(void) {
-#ifdef __FreeBSD__
-    return (pid_t)pthread_getthreadid_np();
-#elif defined(__APPLE__)
-#if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
-    uint64_t curthreadid;
-    pthread_threadid_np(NULL, &curthreadid);
-    return (pid_t)curthreadid;
-#else /* __MAC_OS_X_VERSION_MIN_REQUIRED */
-    return (pid_t)pthread_self;
-#endif /* __MAC_OS_X_VERSION_MIN_REQUIRED */
-#else /* __APPLE__*/
-    return (pid_t)syscall(SYS_gettid);
-#endif /* __FreeBSD__, __APPLE__*/
-}
-
 char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len) {
     char *s = fgets(buf, (int)buf_size, fp);
     if (!s) return NULL;

--- a/src/common.h
+++ b/src/common.h
@@ -172,6 +172,7 @@
 
 #include "clocks.h"
 #include "log.h"
+#include "threads.h"
 #include "locks.h"
 #include "simple_pattern.h"
 #include "avl.h"
@@ -293,8 +294,6 @@ extern int memory_file_save(const char *filename, void *mem, size_t size);
 extern int fd_is_valid(int fd);
 
 extern int enable_ksm;
-
-extern pid_t gettid(void);
 
 extern int sleep_usec(usec_t usec);
 

--- a/src/health.c
+++ b/src/health.c
@@ -348,10 +348,8 @@ static void health_main_cleanup(void *ptr) {
 }
 
 void *health_main(void *ptr) {
-    netdata_thread_welcome("HEALTH");
-
     BUFFER *wb = buffer_create(100);
-    pthread_cleanup_push(health_main_cleanup, ptr);
+    netdata_thread_cleanup_push(health_main_cleanup, ptr);
 
     int min_run_every = (int)config_get_number(CONFIG_SECTION_HEALTH, "run at least every seconds", 10);
     if(min_run_every < 1) min_run_every = 1;
@@ -736,7 +734,6 @@ void *health_main(void *ptr) {
 
     buffer_free(wb);
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/locks.c
+++ b/src/locks.c
@@ -1,6 +1,30 @@
 #include "common.h"
 
 // ----------------------------------------------------------------------------
+// threads initialization
+
+static __thread char *netdata_thread_tag_name = NULL;
+
+const char *netdata_thread_tag(void) {
+    return ((netdata_thread_tag_name && *netdata_thread_tag_name)?netdata_thread_tag_name:"unknown");
+}
+
+void netdata_thread_welcome_nolog(char *tag) {
+    netdata_thread_tag_name = tag;
+
+    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+        error("%s: cannot set pthread cancel type to DEFERRED.", netdata_thread_tag());
+
+    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+        error("%s: cannot set pthread cancel state to ENABLE.", netdata_thread_tag());
+}
+
+void netdata_thread_welcome(char *tag) {
+    netdata_thread_welcome_nolog(tag);
+    info("%s: thread created with task id %d", netdata_thread_tag(), gettid());
+}
+
+// ----------------------------------------------------------------------------
 // automatic thread cancelability management, based on locks
 
 static __thread int netdata_thread_first_cancelability = 0;
@@ -10,7 +34,7 @@ static inline void netdata_thread_disable_cancelability(void) {
     int old;
     int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
     if(ret != 0)
-        error("THREAD_CANCELABILITY: pthread_setcancelstate() returned error %d", ret);
+        error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d", netdata_thread_tag(), ret);
     else {
         if(!netdata_thread_lock_cancelability)
             netdata_thread_first_cancelability = old;
@@ -21,16 +45,16 @@ static inline void netdata_thread_disable_cancelability(void) {
 
 static inline void netdata_thread_enable_cancelability(void) {
     if(netdata_thread_lock_cancelability < 1) {
-        error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): oops! invalid thread cancelability count %d - results will be undefined - please report this!", netdata_thread_lock_cancelability);
+        error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): invalid thread cancelability count %d on thread %s - results will be undefined - please report this!", netdata_thread_lock_cancelability, netdata_thread_tag());
     }
     else if(netdata_thread_lock_cancelability == 1) {
         int old = 1;
         int ret = pthread_setcancelstate(netdata_thread_first_cancelability, &old);
         if(ret != 0)
-            error("THREAD_CANCELABILITY: pthread_setcancelstate() returned error %d", ret);
+            error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d", netdata_thread_tag(), ret);
         else {
             if(!old)
-                error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): oops! old thread cancelability was changed, expected ENABLED, found DISABLED - please report this!");
+                error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): old thread cancelability on thread %s was changed, expected ENABLED, found DISABLED - please report this!", netdata_thread_tag());
         }
 
         netdata_thread_lock_cancelability = 0;

--- a/src/locks.c
+++ b/src/locks.c
@@ -1,30 +1,6 @@
 #include "common.h"
 
 // ----------------------------------------------------------------------------
-// threads initialization
-
-static __thread char *netdata_thread_tag_name = NULL;
-
-const char *netdata_thread_tag(void) {
-    return ((netdata_thread_tag_name && *netdata_thread_tag_name)?netdata_thread_tag_name:"unknown");
-}
-
-void netdata_thread_welcome_nolog(char *tag) {
-    netdata_thread_tag_name = tag;
-
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("%s: cannot set pthread cancel type to DEFERRED.", netdata_thread_tag());
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("%s: cannot set pthread cancel state to ENABLE.", netdata_thread_tag());
-}
-
-void netdata_thread_welcome(char *tag) {
-    netdata_thread_welcome_nolog(tag);
-    info("%s: thread created with task id %d", netdata_thread_tag(), gettid());
-}
-
-// ----------------------------------------------------------------------------
 // automatic thread cancelability management, based on locks
 
 static __thread int netdata_thread_first_cancelability = 0;

--- a/src/locks.c
+++ b/src/locks.c
@@ -1,0 +1,319 @@
+#include "common.h"
+
+// ----------------------------------------------------------------------------
+// automatic thread cancelability management, based on locks
+
+static __thread int netdata_thread_first_cancelability = 0;
+static __thread int netdata_thread_lock_cancelability = 0;
+
+static inline void netdata_thread_disable_cancelability(void) {
+    int old;
+    int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
+    if(ret != 0)
+        error("THREAD_CANCELABILITY: pthread_setcancelstate() returned error %d", ret);
+    else {
+        if(!netdata_thread_lock_cancelability)
+            netdata_thread_first_cancelability = old;
+
+        netdata_thread_lock_cancelability++;
+    }
+}
+
+static inline void netdata_thread_enable_cancelability(void) {
+    if(netdata_thread_lock_cancelability < 1) {
+        error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): oops! invalid thread cancelability count %d - results will be undefined - please report this!", netdata_thread_lock_cancelability);
+    }
+    else if(netdata_thread_lock_cancelability == 1) {
+        int old = 1;
+        int ret = pthread_setcancelstate(netdata_thread_first_cancelability, &old);
+        if(ret != 0)
+            error("THREAD_CANCELABILITY: pthread_setcancelstate() returned error %d", ret);
+        else {
+            if(!old)
+                error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): oops! old thread cancelability was changed, expected ENABLED, found DISABLED - please report this!");
+        }
+
+        netdata_thread_lock_cancelability = 0;
+    }
+    else
+        netdata_thread_lock_cancelability--;
+}
+
+// ----------------------------------------------------------------------------
+// mutex
+
+int __netdata_mutex_init(netdata_mutex_t *mutex) {
+    int ret = pthread_mutex_init(mutex, NULL);
+    if(unlikely(ret != 0))
+        error("MUTEX_LOCK: failed to initialize (code %d).", ret);
+    return ret;
+}
+
+int __netdata_mutex_lock(netdata_mutex_t *mutex) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_mutex_lock(mutex);
+    if(unlikely(ret != 0)) {
+        netdata_thread_enable_cancelability();
+        error("MUTEX_LOCK: failed to get lock (code %d)", ret);
+    }
+    return ret;
+}
+
+int __netdata_mutex_trylock(netdata_mutex_t *mutex) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_mutex_trylock(mutex);
+    if(ret != 0)
+        netdata_thread_enable_cancelability();
+
+    return ret;
+}
+
+int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
+    int ret = pthread_mutex_unlock(mutex);
+    if(unlikely(ret != 0))
+        error("MUTEX_LOCK: failed to unlock (code %d).", ret);
+    else
+        netdata_thread_enable_cancelability();
+
+    return ret;
+}
+
+int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    }
+
+    int ret = __netdata_mutex_init(mutex);
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    }
+
+    int ret = __netdata_mutex_lock(mutex);
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    }
+
+    int ret = __netdata_mutex_trylock(mutex);
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    }
+
+    int ret = __netdata_mutex_unlock(mutex);
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+
+// ----------------------------------------------------------------------------
+// r/w lock
+
+int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock) {
+    int ret = pthread_rwlock_destroy(rwlock);
+    if(unlikely(ret != 0))
+        error("RW_LOCK: failed to destroy lock (code %d)", ret);
+    return ret;
+}
+
+int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
+    int ret = pthread_rwlock_init(rwlock, NULL);
+    if(unlikely(ret != 0))
+        error("RW_LOCK: failed to initialize lock (code %d)", ret);
+    return ret;
+}
+
+int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_rwlock_rdlock(rwlock);
+    if(unlikely(ret != 0)) {
+        netdata_thread_enable_cancelability();
+        error("RW_LOCK: failed to obtain read lock (code %d)", ret);
+    }
+
+    return ret;
+}
+
+int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_rwlock_wrlock(rwlock);
+    if(unlikely(ret != 0)) {
+        error("RW_LOCK: failed to obtain write lock (code %d)", ret);
+        netdata_thread_enable_cancelability();
+    }
+
+    return ret;
+}
+
+int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
+    int ret = pthread_rwlock_unlock(rwlock);
+    if(unlikely(ret != 0))
+        error("RW_LOCK: failed to release lock (code %d)", ret);
+    else
+        netdata_thread_enable_cancelability();
+
+    return ret;
+}
+
+int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_rwlock_tryrdlock(rwlock);
+    if(ret != 0)
+        netdata_thread_enable_cancelability();
+
+    return ret;
+}
+
+int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
+    netdata_thread_disable_cancelability();
+
+    int ret = pthread_rwlock_trywrlock(rwlock);
+    if(ret != 0)
+        netdata_thread_enable_cancelability();
+
+    return ret;
+}
+
+
+int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_destroy(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_init(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_rdlock(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_wrlock(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_unlock(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_tryrdlock(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    usec_t start = 0;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    }
+
+    int ret = __netdata_rwlock_trywrlock(rwlock);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}

--- a/src/locks.c
+++ b/src/locks.c
@@ -6,7 +6,7 @@
 static __thread int netdata_thread_first_cancelability = 0;
 static __thread int netdata_thread_lock_cancelability = 0;
 
-static inline void netdata_thread_disable_cancelability(void) {
+inline void netdata_thread_disable_cancelability(void) {
     int old;
     int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
     if(ret != 0)
@@ -19,7 +19,7 @@ static inline void netdata_thread_disable_cancelability(void) {
     }
 }
 
-static inline void netdata_thread_enable_cancelability(void) {
+inline void netdata_thread_enable_cancelability(void) {
     if(netdata_thread_lock_cancelability < 1) {
         error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): invalid thread cancelability count %d on thread %s - results will be undefined - please report this!", netdata_thread_lock_cancelability, netdata_thread_tag());
     }

--- a/src/locks.h
+++ b/src/locks.h
@@ -7,6 +7,10 @@ typedef pthread_mutex_t netdata_mutex_t;
 typedef pthread_rwlock_t netdata_rwlock_t;
 #define NETDATA_RWLOCK_INITIALIZER PTHREAD_RWLOCK_INITIALIZER
 
+extern void netdata_thread_welcome(char *tag);
+extern void netdata_thread_welcome_nolog(char *tag);
+extern const char *netdata_thread_tag(void);
+
 extern int __netdata_mutex_init(netdata_mutex_t *mutex);
 extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
 extern int __netdata_mutex_trylock(netdata_mutex_t *mutex);

--- a/src/locks.h
+++ b/src/locks.h
@@ -33,6 +33,8 @@ extern int netdata_rwlock_unlock_debug( const char *file, const char *function, 
 extern int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 extern int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 
+extern void netdata_thread_disable_cancelability(void);
+extern void netdata_thread_enable_cancelability(void);
 
 #ifdef NETDATA_INTERNAL_CHECKS
 

--- a/src/locks.h
+++ b/src/locks.h
@@ -7,10 +7,6 @@ typedef pthread_mutex_t netdata_mutex_t;
 typedef pthread_rwlock_t netdata_rwlock_t;
 #define NETDATA_RWLOCK_INITIALIZER PTHREAD_RWLOCK_INITIALIZER
 
-extern void netdata_thread_welcome(char *tag);
-extern void netdata_thread_welcome_nolog(char *tag);
-extern const char *netdata_thread_tag(void);
-
 extern int __netdata_mutex_init(netdata_mutex_t *mutex);
 extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
 extern int __netdata_mutex_trylock(netdata_mutex_t *mutex);

--- a/src/locks.h
+++ b/src/locks.h
@@ -1,275 +1,45 @@
 #ifndef NETDATA_LOCKS_H
 #define NETDATA_LOCKS_H
 
-// ----------------------------------------------------------------------------
-// mutex
-
 typedef pthread_mutex_t netdata_mutex_t;
-
 #define NETDATA_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 
-static inline int __netdata_mutex_init(netdata_mutex_t *mutex) {
-    int ret = pthread_mutex_init(mutex, NULL);
-    if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to initialize (code %d).", ret);
-    return ret;
-}
+typedef pthread_rwlock_t netdata_rwlock_t;
+#define NETDATA_RWLOCK_INITIALIZER PTHREAD_RWLOCK_INITIALIZER
 
-static inline int __netdata_mutex_lock(netdata_mutex_t *mutex) {
-    int ret = pthread_mutex_lock(mutex);
-    if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to get lock (code %d)", ret);
-    return ret;
-}
+extern int __netdata_mutex_init(netdata_mutex_t *mutex);
+extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
+extern int __netdata_mutex_trylock(netdata_mutex_t *mutex);
+extern int __netdata_mutex_unlock(netdata_mutex_t *mutex);
 
-static inline int __netdata_mutex_trylock(netdata_mutex_t *mutex) {
-    int ret = pthread_mutex_trylock(mutex);
-    return ret;
-}
+extern int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_init(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock);
+extern int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock);
 
-static inline int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
-    int ret = pthread_mutex_unlock(mutex);
-    if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to unlock (code %d).", ret);
-    return ret;
-}
+extern int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+extern int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+extern int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+extern int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+
+extern int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+extern int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+
 
 #ifdef NETDATA_INTERNAL_CHECKS
-
-static inline int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
-    int ret = __netdata_mutex_init(mutex);
-
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
-    int ret = __netdata_mutex_lock(mutex);
-
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
-    int ret = __netdata_mutex_trylock(mutex);
-
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
-    int ret = __netdata_mutex_unlock(mutex);
-
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
 
 #define netdata_mutex_init(mutex)    netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_lock(mutex)    netdata_mutex_lock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_trylock(mutex) netdata_mutex_trylock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_unlock(mutex)  netdata_mutex_unlock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
-
-#else // !NETDATA_INTERNAL_CHECKS
-
-#define netdata_mutex_init(mutex)    __netdata_mutex_init(mutex)
-#define netdata_mutex_lock(mutex)    __netdata_mutex_lock(mutex)
-#define netdata_mutex_trylock(mutex) __netdata_mutex_trylock(mutex)
-#define netdata_mutex_unlock(mutex)  __netdata_mutex_unlock(mutex)
-
-#endif // NETDATA_INTERNAL_CHECKS
-
-
-// ----------------------------------------------------------------------------
-// r/w lock
-
-typedef pthread_rwlock_t netdata_rwlock_t;
-
-#define NETDATA_RWLOCK_INITIALIZER PTHREAD_RWLOCK_INITIALIZER
-
-static inline int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_destroy(rwlock);
-    if(unlikely(ret != 0))
-        error("RW_LOCK: failed to destroy lock (code %d)", ret);
-    return ret;
-}
-
-static inline int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_init(rwlock, NULL);
-    if(unlikely(ret != 0))
-        error("RW_LOCK: failed to initialize lock (code %d)", ret);
-    return ret;
-}
-
-static inline int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_rdlock(rwlock);
-    if(unlikely(ret != 0))
-        error("RW_LOCK: failed to obtain read lock (code %d)", ret);
-    return ret;
-}
-
-static inline int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_wrlock(rwlock);
-    if(unlikely(ret != 0))
-        error("RW_LOCK: failed to obtain write lock (code %d)", ret);
-    return ret;
-}
-
-static inline int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_unlock(rwlock);
-    if(unlikely(ret != 0))
-        error("RW_LOCK: failed to release lock (code %d)", ret);
-    return ret;
-}
-
-static inline int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_tryrdlock(rwlock);
-    return ret;
-}
-
-static inline int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_trywrlock(rwlock);
-    return ret;
-}
-
-
-#ifdef NETDATA_INTERNAL_CHECKS
-
-static inline int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_destroy(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_init(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_rdlock(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_wrlock(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_unlock(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_tryrdlock(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
-
-static inline int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
-
-    int ret = __netdata_rwlock_trywrlock(rwlock);
-
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
-
-    return ret;
-}
 
 #define netdata_rwlock_destroy(rwlock)   netdata_rwlock_destroy_debug(__FILE__, __FUNCTION__, __LINE__, rwlock)
 #define netdata_rwlock_init(rwlock)      netdata_rwlock_init_debug(__FILE__, __FUNCTION__, __LINE__, rwlock)
@@ -280,6 +50,11 @@ static inline int netdata_rwlock_trywrlock_debug( const char *file, const char *
 #define netdata_rwlock_trywrlock(rwlock) netdata_rwlock_trywrlock_debug(__FILE__, __FUNCTION__, __LINE__, rwlock)
 
 #else // !NETDATA_INTERNAL_CHECKS
+
+#define netdata_mutex_init(mutex)    __netdata_mutex_init(mutex)
+#define netdata_mutex_lock(mutex)    __netdata_mutex_lock(mutex)
+#define netdata_mutex_trylock(mutex) __netdata_mutex_trylock(mutex)
+#define netdata_mutex_unlock(mutex)  __netdata_mutex_unlock(mutex)
 
 #define netdata_rwlock_destroy(rwlock)    __netdata_rwlock_destroy(rwlock)
 #define netdata_rwlock_init(rwlock)       __netdata_rwlock_init(rwlock)

--- a/src/log.c
+++ b/src/log.c
@@ -246,7 +246,7 @@ void debug_int( const char *file, const char *function, const unsigned long line
     log_date(date, LOG_DATE_LENGTH);
 
     va_start( args, fmt );
-    printf("%s: %s DEBUG (%04lu@%-10.10s:%-15.15s): ", date, program_name, line, file, function);
+    printf("%s: %s DEBUG : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
     vprintf(fmt, args);
     va_end( args );
     putchar('\n');
@@ -282,8 +282,8 @@ void info_int( const char *file, const char *function, const unsigned long line,
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s INFO : (%04lu@%-10.10s:%-15.15s): ", date, program_name, line, file, function);
-    else            fprintf(stderr, "%s: %s INFO : ", date, program_name);
+    if(debug_flags) fprintf(stderr, "%s: %s INFO  : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    else            fprintf(stderr, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
     vfprintf( stderr, fmt, args );
     va_end( args );
 
@@ -338,8 +338,8 @@ void error_int( const char *prefix, const char *file, const char *function, cons
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s %s: (%04lu@%-10.10s:%-15.15s): ", date, program_name, prefix, line, file, function);
-    else            fprintf(stderr, "%s: %s %s: ", date, program_name, prefix);
+    if(debug_flags) fprintf(stderr, "%s: %s %-5.5s : %s: (%04lu@%-10.10s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    else            fprintf(stderr, "%s: %s %-5.5s : %s: ", date, program_name, prefix, netdata_thread_tag());
     vfprintf( stderr, fmt, args );
     va_end( args );
 
@@ -369,8 +369,8 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s FATAL: (%04lu@%-10.10s:%-15.15s): ", date, program_name, line, file, function);
-    else            fprintf(stderr, "%s: %s FATAL: ", date, program_name);
+    if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    else            fprintf(stderr, "%s: %s FATAL : %s :", date, program_name, netdata_thread_tag());
     vfprintf( stderr, fmt, args );
     va_end( args );
 

--- a/src/main.c
+++ b/src/main.c
@@ -594,6 +594,7 @@ int main(int argc, char **argv) {
     int i;
     int config_loaded = 0;
     int dont_fork = 0;
+    size_t default_stacksize;
 
     // set the name for logging
     program_name = "netdata";
@@ -919,7 +920,7 @@ int main(int argc, char **argv) {
         signals_init();
 
         // setup threads configs
-        netdata_threads_init();
+        default_stacksize = netdata_threads_init();
 
 
         // --------------------------------------------------------------------
@@ -984,7 +985,7 @@ int main(int argc, char **argv) {
     web_files_uid();
     web_files_gid();
 
-    netdata_threads_init_after_fork();
+    netdata_threads_init_after_fork((size_t)config_get_number(CONFIG_SECTION_GLOBAL, "pthread stack size", (long)default_stacksize));
 
     // ------------------------------------------------------------------------
     // initialize rrd, registry, health, rrdpush, etc.

--- a/src/main.c
+++ b/src/main.c
@@ -6,28 +6,28 @@ void netdata_cleanup_and_exit(int ret) {
     netdata_exit = 1;
 
     error_log_limit_unlimited();
-    info("MAIN: netdata prepares to exit...");
+    info("EXIT: netdata prepares to exit...");
 
     // stop everything
-    info("MAIN: stopping all threads and child processes...");
+    info("EXIT: stopping master threads...");
     cancel_main_threads();
 
     // cleanup the database (delete files not needed)
-    info("MAIN: cleaning up the database...");
+    info("EXIT: cleaning up the database...");
     rrdhost_cleanup_all();
 
     // free the database
-    info("MAIN: freeing database memory...");
+    info("EXIT: freeing database memory...");
     rrdhost_free_all();
 
     // unlink the pid
     if(pidfile[0]) {
-        info("MAIN: removing netdata PID file '%s'...", pidfile);
+        info("EXIT: removing netdata PID file '%s'...", pidfile);
         if(unlink(pidfile) != 0)
-            error("MAIN: cannot unlink pidfile '%s'.", pidfile);
+            error("EXIT: cannot unlink pidfile '%s'.", pidfile);
     }
 
-    info("MAIN: all done - netdata is now exiting - bye bye...");
+    info("EXIT: all done - netdata is now exiting - bye bye...");
     exit(ret);
 }
 
@@ -183,12 +183,12 @@ void cancel_main_threads() {
     int i;
     for (i = 0; static_threads[i].name != NULL ; i++) {
         if(static_threads[i].enabled) {
-            info("MAIN: Calling pthread_cancel() on %s thread", static_threads[i].name);
+            info("EXIT: Stopping master thread: %s", static_threads[i].name);
             int ret;
             if((ret = pthread_cancel(*static_threads[i].thread)) != 0)
-                error("MAIN: pthread_cancel() failed with code %d.", ret);
-            else
-                info("MAIN: thread %s cancelled", static_threads[i].name);
+                error("EXIT: pthread_cancel() failed with code %d.", ret);
+            //else
+            //    info("MAIN: thread %s cancelled", static_threads[i].name);
 
             static_threads[i].enabled = 0;
         }
@@ -196,10 +196,10 @@ void cancel_main_threads() {
 
     // if, for any reason there is any child exited
     // catch it here
-    info("MAIN: waiting for any unfinished child processes");
+    info("EXIT: waiting for any unfinished child processes");
     siginfo_t info;
     waitid(P_PID, 0, &info, WEXITED|WNOHANG);
-    info("MAIN: all threads/childs stopped.");
+    info("EXIT: all threads/childs stopped.");
 }
 
 struct option_def option_definitions[] = {

--- a/src/main.h
+++ b/src/main.h
@@ -24,7 +24,7 @@ struct netdata_static_thread {
 
     volatile sig_atomic_t enabled;
 
-    pthread_t *thread;
+    netdata_thread_t *thread;
 
     void (*init_routine) (void);
     void *(*start_routine) (void *);

--- a/src/main.h
+++ b/src/main.h
@@ -22,7 +22,7 @@ struct netdata_static_thread {
     char *config_section;
     char *config_name;
 
-    volatile int enabled;
+    volatile sig_atomic_t enabled;
 
     pthread_t *thread;
 
@@ -30,7 +30,7 @@ struct netdata_static_thread {
     void *(*start_routine) (void *);
 };
 
-extern void kill_childs(void);
+extern void cancel_main_threads(void);
 extern int killpid(pid_t pid, int signal);
 extern void netdata_cleanup_and_exit(int ret) NORETURN;
 

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -12,8 +12,7 @@ static void checks_main_cleanup(void *ptr) {
 }
 
 void *checks_main(void *ptr) {
-    netdata_thread_welcome("CHECKS");
-    pthread_cleanup_push(checks_main_cleanup, ptr);
+    netdata_thread_cleanup_push(checks_main_cleanup, ptr);
 
     usec_t usec = 0, susec = localhost->rrd_update_every * USEC_PER_SEC, loop_usec = 0, total_susec = 0;
     struct timeval now, last, loop;
@@ -121,8 +120,7 @@ void *checks_main(void *ptr) {
         rrdset_done(check3);
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }
 

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -76,8 +76,7 @@ static void freebsd_main_cleanup(void *ptr) {
 }
 
 void *freebsd_main(void *ptr) {
-    netdata_thread_welcome("FREEBSD");
-    pthread_cleanup_push(freebsd_main_cleanup, ptr);
+    netdata_thread_cleanup_push(freebsd_main_cleanup, ptr);
 
     int vdo_cpu_netdata = config_get_boolean("plugin:freebsd", "netdata server resources", 1);
 
@@ -169,7 +168,6 @@ void *freebsd_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -12,8 +12,7 @@ static void cpuidlejitter_main_cleanup(void *ptr) {
 }
 
 void *cpuidlejitter_main(void *ptr) {
-    netdata_thread_welcome("IDLEJITTER");
-    pthread_cleanup_push(cpuidlejitter_main_cleanup, ptr);
+    netdata_thread_cleanup_push(cpuidlejitter_main_cleanup, ptr);
 
     usec_t sleep_ut = config_get_number("plugin:idlejitter", "loop time in ms", CPU_IDLEJITTER_SLEEP_TIME_MS) * USEC_PER_MS;
     if(sleep_ut <= 0) {
@@ -85,8 +84,7 @@ void *cpuidlejitter_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }
 

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -2,16 +2,18 @@
 
 #define CPU_IDLEJITTER_SLEEP_TIME_MS 20
 
-void *cpuidlejitter_main(void *ptr) {
+static void cpuidlejitter_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    if(static_thread->enabled) {
+        static_thread->enabled = 0;
 
-    info("IDLEJITTER thread created with task id %d", gettid());
+        info("%s: cleaning up...", netdata_thread_tag());
+    }
+}
 
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("Cannot set pthread cancel type to DEFERRED.");
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("Cannot set pthread cancel state to ENABLE.");
+void *cpuidlejitter_main(void *ptr) {
+    netdata_thread_welcome("IDLEJITTER");
+    pthread_cleanup_push(cpuidlejitter_main_cleanup, ptr);
 
     usec_t sleep_ut = config_get_number("plugin:idlejitter", "loop time in ms", CPU_IDLEJITTER_SLEEP_TIME_MS) * USEC_PER_MS;
     if(sleep_ut <= 0) {
@@ -40,6 +42,7 @@ void *cpuidlejitter_main(void *ptr) {
     usec_t update_every_ut = localhost->rrd_update_every * USEC_PER_SEC;
     struct timeval before, after;
     unsigned long long counter;
+
     for(counter = 0; 1 ;counter++) {
         int iterations = 0;
         usec_t error_total = 0,
@@ -82,9 +85,7 @@ void *cpuidlejitter_main(void *ptr) {
         }
     }
 
-    info("IDLEJITTER thread exiting");
-
-    static_thread->enabled = 0;
+    pthread_cleanup_pop(1);
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -1,15 +1,17 @@
 #include "common.h"
 
-void *macos_main(void *ptr) {
+static void macos_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    if(static_thread->enabled) {
+        static_thread->enabled = 0;
 
-    info("MACOS Plugin thread created with task id %d", gettid());
+        info("%s: cleaning up...", netdata_thread_tag());
+    }
+}
 
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("Cannot set pthread cancel type to DEFERRED.");
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("Cannot set pthread cancel state to ENABLE.");
+void *macos_main(void *ptr) {
+    netdata_thread_welcome("MACOS");
+    pthread_cleanup_push(macos_main_cleanup, ptr);
 
     // when ZERO, attempt to do it
     int vdo_cpu_netdata             = !config_get_boolean("plugin:macos", "netdata server resources", 1);
@@ -25,7 +27,8 @@ void *macos_main(void *ptr) {
     usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    for(;;) {
+
+    while(!netdata_exit) {
         usec_t hb_dt = heartbeat_next(&hb, step);
 
         if(unlikely(netdata_exit)) break;
@@ -60,9 +63,7 @@ void *macos_main(void *ptr) {
         }
     }
 
-    info("MACOS thread exiting");
-
-    static_thread->enabled = 0;
+    pthread_cleanup_pop(1);
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -10,8 +10,7 @@ static void macos_main_cleanup(void *ptr) {
 }
 
 void *macos_main(void *ptr) {
-    netdata_thread_welcome("MACOS");
-    pthread_cleanup_push(macos_main_cleanup, ptr);
+    netdata_thread_cleanup_push(macos_main_cleanup, ptr);
 
     // when ZERO, attempt to do it
     int vdo_cpu_netdata             = !config_get_boolean("plugin:macos", "netdata server resources", 1);
@@ -63,7 +62,6 @@ void *macos_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -74,8 +74,7 @@ static void proc_main_cleanup(void *ptr) {
 }
 
 void *proc_main(void *ptr) {
-    netdata_thread_welcome("PROC");
-    pthread_cleanup_push(proc_main_cleanup, ptr);
+    netdata_thread_cleanup_push(proc_main_cleanup, ptr);
 
     int vdo_cpu_netdata = config_get_boolean("plugin:proc", "netdata server resources", 1);
 
@@ -163,8 +162,7 @@ void *proc_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }
 

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -64,16 +64,18 @@ static struct proc_module {
         { .name = NULL, .dim = NULL, .func = NULL }
 };
 
-void *proc_main(void *ptr) {
+static void proc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    if(static_thread->enabled) {
+        static_thread->enabled = 0;
 
-    info("PROC Plugin thread created with task id %d", gettid());
+        info("%s: cleaning up...", netdata_thread_tag());
+    }
+}
 
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("Cannot set pthread cancel type to DEFERRED.");
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("Cannot set pthread cancel state to ENABLE.");
+void *proc_main(void *ptr) {
+    netdata_thread_welcome("PROC");
+    pthread_cleanup_push(proc_main_cleanup, ptr);
 
     int vdo_cpu_netdata = config_get_boolean("plugin:proc", "netdata server resources", 1);
 
@@ -91,7 +93,7 @@ void *proc_main(void *ptr) {
     heartbeat_t hb;
     heartbeat_init(&hb);
 
-    for(;;) {
+    while(!netdata_exit) {
         usec_t hb_dt = heartbeat_next(&hb, step);
         usec_t duration = 0ULL;
 
@@ -161,9 +163,7 @@ void *proc_main(void *ptr) {
         }
     }
 
-    info("PROC thread exiting");
-
-    static_thread->enabled = 0;
+    pthread_cleanup_pop(1);
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -338,8 +338,7 @@ static void diskspace_main_cleanup(void *ptr) {
 }
 
 void *proc_diskspace_main(void *ptr) {
-    netdata_thread_welcome("DISKSPACE");
-    pthread_cleanup_push(diskspace_main_cleanup, ptr);
+    netdata_thread_cleanup_push(diskspace_main_cleanup, ptr);
 
     int vdo_cpu_netdata = config_get_boolean("plugin:proc", "netdata server resources", 1);
 
@@ -456,7 +455,6 @@ void *proc_diskspace_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -328,16 +328,18 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         m->collected++;
 }
 
-void *proc_diskspace_main(void *ptr) {
+static void diskspace_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    if(static_thread->enabled) {
+        static_thread->enabled = 0;
 
-    info("DISKSPACE thread created with task id %d", gettid());
+        info("%s: cleaning up...", netdata_thread_tag());
+    }
+}
 
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("DISKSPACE: Cannot set pthread cancel type to DEFERRED.");
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("DISKSPACE: Cannot set pthread cancel state to ENABLE.");
+void *proc_diskspace_main(void *ptr) {
+    netdata_thread_welcome("DISKSPACE");
+    pthread_cleanup_push(diskspace_main_cleanup, ptr);
 
     int vdo_cpu_netdata = config_get_boolean("plugin:proc", "netdata server resources", 1);
 
@@ -357,7 +359,7 @@ void *proc_diskspace_main(void *ptr) {
     usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    for(;;) {
+    while(!netdata_exit) {
         duration = heartbeat_dt_usec(&hb);
         /* usec_t hb_dt = */ heartbeat_next(&hb, step);
 
@@ -454,9 +456,7 @@ void *proc_diskspace_main(void *ptr) {
         }
     }
 
-    info("DISKSPACE thread exiting");
-
-    static_thread->enabled = 0;
+    pthread_cleanup_pop(1);
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -978,8 +978,10 @@ void *tc_main(void *ptr) {
                 // debug(D_TC_LOOP, "END line");
 
                 if(likely(device)) {
+                    netdata_thread_disable_cancelability();
                     tc_device_commit(device);
                     // tc_device_free(device);
+                    netdata_thread_enable_cancelability();
                 }
 
                 device = NULL;

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -853,8 +853,7 @@ static void tc_main_cleanup(void *ptr) {
 }
 
 void *tc_main(void *ptr) {
-    netdata_thread_welcome("TC");
-    pthread_cleanup_push(tc_main_cleanup, ptr);
+    netdata_thread_cleanup_push(tc_main_cleanup, ptr);
 
     struct rusage thread;
 
@@ -1158,7 +1157,6 @@ void *tc_main(void *ptr) {
     }
 
 cleanup:
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/plugin_tc.h
+++ b/src/plugin_tc.h
@@ -1,7 +1,6 @@
 #ifndef NETDATA_PLUGIN_TC_H
 #define NETDATA_PLUGIN_TC_H 1
 
-extern volatile pid_t tc_child_pid;
 extern void *tc_main(void *ptr);
 
 #endif /* NETDATA_PLUGIN_TC_H */

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -131,7 +131,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
     clearerr(fp);
 
     if(unlikely(fileno(fp) == -1)) {
-        error("PLUGINSD: %s: file is not a valid stream.", cd->fullfilename);
+        error("file descriptor given is not a valid stream");
         goto cleanup;
     }
 
@@ -140,7 +140,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 
         char *r = fgets(line, PLUGINSD_LINE_MAX, fp);
         if(unlikely(!r)) {
-            error("PLUGINSD: %s : read failed.", cd->fullfilename);
+            error("read failed");
             break;
         }
 
@@ -148,12 +148,9 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 
         line[PLUGINSD_LINE_MAX] = '\0';
 
-        // debug(D_PLUGINSD, "PLUGINSD: %s: %s", cd->filename, line);
-
         int w = pluginsd_split_words(line, words, PLUGINSD_MAX_WORDS);
         char *s = words[0];
         if(unlikely(!s || !*s || !w)) {
-            // debug(D_PLUGINSD, "PLUGINSD: empty line");
             continue;
         }
 
@@ -164,7 +161,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             char *value = words[2];
 
             if(unlikely(!dimension || !*dimension)) {
-                error("PLUGINSD: '%s' is requesting a SET on chart '%s' of host '%s', without a dimension. Disabling it.", cd->fullfilename, st->id, host->hostname);
+                error("requested a SET on chart '%s' of host '%s', without a dimension. Disabling it.", st->id, host->hostname);
                 enabled = 0;
                 break;
             }
@@ -172,17 +169,18 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             if(unlikely(!value || !*value)) value = NULL;
 
             if(unlikely(!st)) {
-                error("PLUGINSD: '%s' is requesting a SET on dimension %s with value %s on host '%s', without a BEGIN. Disabling it.", cd->fullfilename, dimension, value?value:"<nothing>", host->hostname);
+                error("requested a SET on dimension %s with value %s on host '%s', without a BEGIN. Disabling it.", dimension, value?value:"<nothing>", host->hostname);
                 enabled = 0;
                 break;
             }
 
-            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG))) debug(D_PLUGINSD, "PLUGINSD: '%s' is setting dimension %s/%s to %s", cd->fullfilename, st->id, dimension, value?value:"<nothing>");
+            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
+                debug(D_PLUGINSD, "is setting dimension %s/%s to %s", st->id, dimension, value?value:"<nothing>");
 
             if(value) {
                 RRDDIM *rd = rrddim_find(st, dimension);
                 if(unlikely(!rd)) {
-                    error("PLUGINSD: '%s' is requesting a SET to dimension with id '%s' on stats '%s' (%s) on host '%s', which does not exist. Disabling it.", cd->fullfilename, dimension, st->name, st->id, st->rrdhost->hostname);
+                    error("requested a SET to dimension with id '%s' on stats '%s' (%s) on host '%s', which does not exist. Disabling it.", dimension, st->name, st->id, st->rrdhost->hostname);
                     enabled = 0;
                     break;
                 }
@@ -195,14 +193,14 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             char *microseconds_txt = words[2];
 
             if(unlikely(!id)) {
-                error("PLUGINSD: '%s' is requesting a BEGIN without a chart id for host '%s'. Disabling it.", cd->fullfilename, host->hostname);
+                error("requested a BEGIN without a chart id for host '%s'. Disabling it.", host->hostname);
                 enabled = 0;
                 break;
             }
 
             st = rrdset_find(host, id);
             if(unlikely(!st)) {
-                error("PLUGINSD: '%s' is requesting a BEGIN on chart '%s', which does not exist on host '%s'. Disabling it.", cd->fullfilename, id, host->hostname);
+                error("requested a BEGIN on chart '%s', which does not exist on host '%s'. Disabling it.", id, host->hostname);
                 enabled = 0;
                 break;
             }
@@ -222,12 +220,13 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
         }
         else if(likely(hash == END_HASH && !strcmp(s, PLUGINSD_KEYWORD_END))) {
             if(unlikely(!st)) {
-                error("PLUGINSD: '%s' is requesting an END, without a BEGIN on host '%s'. Disabling it.", cd->fullfilename, host->hostname);
+                error("requested an END, without a BEGIN on host '%s'. Disabling it.", host->hostname);
                 enabled = 0;
                 break;
             }
 
-            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG))) debug(D_PLUGINSD, "PLUGINSD: '%s' is requesting an END on chart %s", cd->fullfilename, st->id);
+            if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
+                debug(D_PLUGINSD, "requested an END on chart %s", st->id);
 
             rrdset_done(st);
             st = NULL;
@@ -259,7 +258,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 
             // make sure we have the required variables
             if(unlikely(!type || !*type || !id || !*id)) {
-                error("PLUGINSD: '%s' is requesting a CHART, without a type.id, on host '%s'. Disabling it.", cd->fullfilename, host->hostname);
+                error("requested a CHART, without a type.id, on host '%s'. Disabling it.", host->hostname);
                 enabled = 0;
                 break;
             }
@@ -295,7 +294,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             if(unlikely(!title)) title = "";
             if(unlikely(!units)) units = "unknown";
 
-            debug(D_PLUGINSD, "PLUGINSD: Creating chart type='%s', id='%s', name='%s', family='%s', context='%s', chart='%s', priority=%d, update_every=%d"
+            debug(D_PLUGINSD, "creating chart type='%s', id='%s', name='%s', family='%s', context='%s', chart='%s', priority=%d, update_every=%d"
                   , type, id
                   , name?name:""
                   , family?family:""
@@ -352,13 +351,13 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             char *options = words[6];
 
             if(unlikely(!id || !*id)) {
-                error("PLUGINSD: '%s' is requesting a DIMENSION, without an id, host '%s' and chart '%s'. Disabling it.", cd->fullfilename, host->hostname, st?st->id:"UNSET");
+                error("requested a DIMENSION, without an id, host '%s' and chart '%s'. Disabling it.", host->hostname, st?st->id:"UNSET");
                 enabled = 0;
                 break;
             }
 
             if(unlikely(!st)) {
-                error("PLUGINSD: '%s' is requesting a DIMENSION, without a CHART, on host '%s'. Disabling it.", cd->fullfilename, host->hostname);
+                error("requested a DIMENSION, without a CHART, on host '%s'. Disabling it.", host->hostname);
                 enabled = 0;
                 break;
             }
@@ -374,7 +373,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             if(unlikely(!algorithm || !*algorithm)) algorithm = "absolute";
 
             if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_DEBUG)))
-                debug(D_PLUGINSD, "PLUGINSD: Creating dimension in chart %s, id='%s', name='%s', algorithm='%s', multiplier=%ld, divisor=%ld, hidden='%s'"
+                debug(D_PLUGINSD, "creating dimension in chart %s, id='%s', name='%s', algorithm='%s', multiplier=%ld, divisor=%ld, hidden='%s'"
                       , st->id
                       , id
                       , name?name:""
@@ -412,7 +411,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             }
 
             if(unlikely(!name || !*name)) {
-                error("PLUGINSD: '%s' is requesting a VARIABLE on host '%s', without a variable name. Disabling it.", cd->fullfilename, host->hostname);
+                error("requested a VARIABLE on host '%s', without a variable name. Disabling it.", host->hostname);
                 enabled = 0;
                 break;
             }
@@ -426,38 +425,38 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 
                 if(unlikely(endptr && *endptr)) {
                     if(endptr == value)
-                        error("PLUGINSD: '%s': the value '%s' of VARIABLE '%s' on host '%s' cannot be parsed as a number", cd->fullfilename, value, name, host->hostname);
+                        error("the value '%s' of VARIABLE '%s' on host '%s' cannot be parsed as a number", value, name, host->hostname);
                     else
-                        error("PLUGINSD: '%s': the value '%s' of VARIABLE '%s' on host '%s' has leftovers: '%s'", cd->fullfilename, value, name, host->hostname, endptr);
+                        error("the value '%s' of VARIABLE '%s' on host '%s' has leftovers: '%s'", value, name, host->hostname, endptr);
                 }
 
                 if(global) {
                     RRDVAR *rv = rrdvar_custom_host_variable_create(host, name);
                     if (rv) rrdvar_custom_host_variable_set(host, rv, v);
-                    else error("PLUGINSD: '%s': cannot find/create HOST VARIABLE '%s' on host '%s'", cd->fullfilename, name, host->hostname);
+                    else error("cannot find/create HOST VARIABLE '%s' on host '%s'", name, host->hostname);
                 }
                 else if(st) {
                     RRDSETVAR *rs = rrdsetvar_custom_chart_variable_create(st, name);
                     if (rs) rrdsetvar_custom_chart_variable_set(rs, v);
-                    else error("PLUGINSD: '%s': cannot find/create CHART VARIABLE '%s' on host '%s', chart '%s'", cd->fullfilename, name, host->hostname, st->id);
+                    else error("cannot find/create CHART VARIABLE '%s' on host '%s', chart '%s'", name, host->hostname, st->id);
                 }
                 else
-                    error("PLUGINSD: '%s': cannot find/create CHART VARIABLE '%s' on host '%s' without a chart", cd->fullfilename, name, host->hostname);
+                    error("cannot find/create CHART VARIABLE '%s' on host '%s' without a chart", name, host->hostname);
             }
             else
-                error("PLUGINSD: '%s': cannot set %s VARIABLE '%s' on host '%s' to an empty value", cd->fullfilename, (global)?"HOST":"CHART", name, host->hostname);
+                error("cannot set %s VARIABLE '%s' on host '%s' to an empty value", (global)?"HOST":"CHART", name, host->hostname);
         }
         else if(likely(hash == FLUSH_HASH && !strcmp(s, PLUGINSD_KEYWORD_FLUSH))) {
-            debug(D_PLUGINSD, "PLUGINSD: '%s' is requesting a FLUSH", cd->fullfilename);
+            debug(D_PLUGINSD, "requested a FLUSH");
             st = NULL;
         }
         else if(unlikely(hash == DISABLE_HASH && !strcmp(s, PLUGINSD_KEYWORD_DISABLE))) {
-            info("PLUGINSD: '%s' called DISABLE. Disabling it.", cd->fullfilename);
+            info("called DISABLE. Disabling it.");
             enabled = 0;
             break;
         }
         else {
-            error("PLUGINSD: '%s' is sending command '%s' which is not known by netdata, for host '%s'. Disabling it.", cd->fullfilename, s, host->hostname);
+            error("sent command '%s' which is not known by netdata, for host '%s'. Disabling it.", s, host->hostname);
             enabled = 0;
             break;
         }
@@ -482,15 +481,14 @@ static void pluginsd_worker_thread_cleanup(void *arg) {
     if(cd->enabled && !cd->obsolete) {
         cd->obsolete = 1;
 
-        info("PLUGINSD: '%s' thread exiting", cd->fullfilename);
+        info("data collection thread exiting");
 
         if (cd->pid) {
             siginfo_t info;
-            info("PLUGINSD: killing %s plugin child process pid %d", cd->id, cd->pid);
+            info("killing child process pid %d", cd->pid);
             if (killpid(cd->pid, SIGTERM) != -1) {
-                info("PLUGINSD: waiting for %s plugin child process pid %d to exit...", cd->id, cd->pid);
+                info("waiting for child process pid %d to exit...", cd->pid);
                 waitid(P_PID, (id_t) cd->pid, &info, WEXITED);
-                info("PLUGINSD: finished %s plugin child process pid %d.", cd->id, cd->pid);
             }
             cd->pid = 0;
         }
@@ -512,9 +510,9 @@ void *pluginsd_worker_thread(void *arg) {
             break;
         }
 
-        info("%s on tid %d: connected to '%s' running on pid %d", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid);
+        info("connected to '%s' running on pid %d", cd->fullfilename, cd->pid);
         count = pluginsd_process(localhost, cd, fp, 0);
-        error("%s on tid %d: '%s' (pid %d) disconnected after %zu successful data collections (ENDs).", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, count);
+        error("'%s' (pid %d) disconnected after %zu successful data collections (ENDs).", cd->fullfilename, cd->pid, count);
         killpid(cd->pid, SIGTERM);
 
         // get the return code
@@ -525,18 +523,18 @@ void *pluginsd_worker_thread(void *arg) {
 
             if(likely(!cd->successful_collections)) {
                 // nothing collected - disable it
-                error("%s on tid %d: '%s' (pid %d) exited with error code %d. Disabling it.", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, code);
+                error("'%s' (pid %d) exited with error code %d. Disabling it.", cd->fullfilename, cd->pid, code);
                 cd->enabled = 0;
             }
             else {
                 // we have collected something
 
                 if(likely(cd->serial_failures <= 10)) {
-                    error("%s on tid %d: '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, code, cd->successful_collections, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is disabled.");
+                    error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s", cd->fullfilename, cd->pid, code, cd->successful_collections, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is disabled.");
                     sleep((unsigned int) (cd->update_every * 10));
                 }
                 else {
-                    error("%s on tid %d: '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). We tried %zu times to restart it, but it failed to generate data. Disabling it.", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, code, cd->successful_collections, cd->serial_failures);
+                    error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). We tried %zu times to restart it, but it failed to generate data. Disabling it.", cd->fullfilename, cd->pid, code, cd->successful_collections, cd->serial_failures);
                     cd->enabled = 0;
                 }
             }
@@ -548,11 +546,11 @@ void *pluginsd_worker_thread(void *arg) {
                 // we have collected nothing so far
 
                 if(likely(cd->serial_failures <= 10)) {
-                    error("%s on tid %d: '%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is now disabled.");
+                    error("'%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.", cd->fullfilename, cd->pid, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is now disabled.");
                     sleep((unsigned int) (cd->update_every * 10));
                 }
                 else {
-                    error("%s on tid %d: '%s' (pid %d) does not generate useful output, although it reports success (exits with 0), but we have tried %zu times to collect something. Disabling it.", netdata_thread_tag(), gettid(), cd->fullfilename, cd->pid, cd->serial_failures);
+                    error("'%s' (pid %d) does not generate useful output, although it reports success (exits with 0), but we have tried %zu times to collect something. Disabling it.", cd->fullfilename, cd->pid, cd->serial_failures);
                     cd->enabled = 0;
                 }
             }
@@ -573,17 +571,17 @@ static void pluginsd_main_cleanup(void *data) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
         struct plugind *cd;
         for (cd = pluginsd_root; cd; cd = cd->next) {
             if (cd->enabled && !cd->obsolete) {
-                info("PLUGINSD: Stopping plugin thread: %s", cd->id);
+                info("stopping plugin thread: %s", cd->id);
                 netdata_thread_cancel(cd->thread);
             }
         }
 
-        info("%s: cleanup completed.", netdata_thread_tag());
+        info("cleanup completed.");
     }
 }
 
@@ -610,7 +608,7 @@ void *pluginsd_main(void *ptr) {
             if(unlikely(!dir)) {
                 if(directory_errors[idx] != errno) {
                     directory_errors[idx] = errno;
-                    error("PLUGINSD: Cannot open plugins directory '%s'.", directory_name);
+                    error("cannot open plugins directory '%s'", directory_name);
                 }
                 continue;
             }
@@ -619,14 +617,14 @@ void *pluginsd_main(void *ptr) {
             while(likely((file = readdir(dir)))) {
                 if(unlikely(netdata_exit)) break;
 
-                debug(D_PLUGINSD, "PLUGINSD: Examining file '%s'", file->d_name);
+                debug(D_PLUGINSD, "examining file '%s'", file->d_name);
 
                 if(unlikely(strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)) continue;
 
                 int len = (int) strlen(file->d_name);
                 if(unlikely(len <= (int)PLUGINSD_FILE_SUFFIX_LEN)) continue;
                 if(unlikely(strcmp(PLUGINSD_FILE_SUFFIX, &file->d_name[len - (int)PLUGINSD_FILE_SUFFIX_LEN]) != 0)) {
-                    debug(D_PLUGINSD, "PLUGINSD: File '%s' does not end in '%s'.", file->d_name, PLUGINSD_FILE_SUFFIX);
+                    debug(D_PLUGINSD, "file '%s' does not end in '%s'", file->d_name, PLUGINSD_FILE_SUFFIX);
                     continue;
                 }
 
@@ -635,7 +633,7 @@ void *pluginsd_main(void *ptr) {
                 int enabled = config_get_boolean(CONFIG_SECTION_PLUGINS, pluginname, automatic_run);
 
                 if(unlikely(!enabled)) {
-                    debug(D_PLUGINSD, "PLUGINSD: plugin '%s' is not enabled", file->d_name);
+                    debug(D_PLUGINSD, "plugin '%s' is not enabled", file->d_name);
                     continue;
                 }
 
@@ -645,7 +643,7 @@ void *pluginsd_main(void *ptr) {
                     if(unlikely(strcmp(cd->filename, file->d_name) == 0)) break;
 
                 if(likely(cd && !cd->obsolete)) {
-                    debug(D_PLUGINSD, "PLUGINSD: plugin '%s' is already running", cd->filename);
+                    debug(D_PLUGINSD, "plugin '%s' is already running", cd->filename);
                     continue;
                 }
 
@@ -674,8 +672,10 @@ void *pluginsd_main(void *ptr) {
                     cd->obsolete = 1;
 
                     if(cd->enabled) {
+                        char tag[NETDATA_THREAD_TAG_MAX + 1];
+                        snprintfz(tag, NETDATA_THREAD_TAG_MAX, "PLUGINSD[%s]", pluginname);
                         // spawn a new thread for it
-                        netdata_thread_create(&cd->thread, "PLUGINSD_COLLECTOR", NETDATA_THREAD_OPTION_DEFAULT, pluginsd_worker_thread, cd);
+                        netdata_thread_create(&cd->thread, tag, NETDATA_THREAD_OPTION_DEFAULT, pluginsd_worker_thread, cd);
                     }
                 }
             }

--- a/src/plugins_d.h
+++ b/src/plugins_d.h
@@ -27,7 +27,7 @@ struct plugind {
     char cmd[PLUGINSD_CMD_MAX+1];       // the command that it executes
 
     volatile pid_t pid;
-    pthread_t thread;
+    netdata_thread_t thread;
 
     size_t successful_collections;      // the number of times we have seen
                                         // values collected from this plugin

--- a/src/plugins_d.h
+++ b/src/plugins_d.h
@@ -26,7 +26,7 @@ struct plugind {
     char fullfilename[FILENAME_MAX+1];  // with path
     char cmd[PLUGINSD_CMD_MAX+1];       // the command that it executes
 
-    pid_t pid;
+    volatile pid_t pid;
     pthread_t thread;
 
     size_t successful_collections;      // the number of times we have seen
@@ -36,8 +36,8 @@ struct plugind {
                                         // without collecting values
 
     int update_every;                   // the plugin default data collection frequency
-    volatile int obsolete;              // do not touch this structure after setting this to 1
-    volatile int enabled;               // if this is enabled or not
+    volatile sig_atomic_t obsolete;     // do not touch this structure after setting this to 1
+    volatile sig_atomic_t enabled;      // if this is enabled or not
 
     time_t started_t;
 
@@ -47,7 +47,6 @@ struct plugind {
 extern struct plugind *pluginsd_root;
 
 extern void *pluginsd_main(void *ptr);
-extern void pluginsd_stop_all_external_plugins(void);
 
 extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int trust_durations);
 extern int pluginsd_split_words(char *str, char **words, int max_words);

--- a/src/popen.c
+++ b/src/popen.c
@@ -126,6 +126,8 @@ int mypclose(FILE *fp, pid_t pid) {
     // close the pipe file pointer
     fclose(fp);
 
+    errno = 0;
+
     siginfo_t info;
     if(waitid(P_PID, (id_t) pid, &info, WEXITED) != -1) {
         switch(info.si_code) {

--- a/src/popen.c
+++ b/src/popen.c
@@ -43,7 +43,7 @@ static void mypopen_del(FILE *fp) {
 #define PIPE_READ 0
 #define PIPE_WRITE 1
 
-FILE *mypopen(const char *command, pid_t *pidptr)
+FILE *mypopen(const char *command, volatile pid_t *pidptr)
 {
     int pipefd[2];
 

--- a/src/popen.h
+++ b/src/popen.h
@@ -4,7 +4,7 @@
 #define PIPE_READ 0
 #define PIPE_WRITE 1
 
-extern FILE *mypopen(const char *command, pid_t *pidptr);
+extern FILE *mypopen(const char *command, volatile pid_t *pidptr);
 extern int mypclose(FILE *fp, pid_t pid);
 
 #endif /* NETDATA_POPEN_H */

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -437,7 +437,7 @@ struct rrdhost {
     // the following are state information for the threading
     // streaming metrics from this netdata to an upstream netdata
     volatile int rrdpush_sender_spawn:1;            // 1 when the sender thread has been spawn
-    pthread_t rrdpush_sender_thread;                // the sender thread
+    netdata_thread_t rrdpush_sender_thread;         // the sender thread
 
     volatile int rrdpush_sender_connected:1;        // 1 when the sender is ready to push metrics
     int rrdpush_sender_socket;                      // the fd of the socket to the remote host, or -1

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -912,7 +912,10 @@ static void rrdpush_sender_thread_spawn(RRDHOST *host) {
     rrdhost_wrlock(host);
 
     if(!host->rrdpush_sender_spawn) {
-        if(netdata_thread_create(&host->rrdpush_sender_thread, "STREAM_SENDER", NETDATA_THREAD_OPTION_JOINABLE, rrdpush_sender_thread, (void *) host))
+        char tag[NETDATA_THREAD_TAG_MAX + 1];
+        snprintfz(tag, NETDATA_THREAD_TAG_MAX, "STREAM_SENDER[%s]", host->hostname);
+
+        if(netdata_thread_create(&host->rrdpush_sender_thread, tag, NETDATA_THREAD_OPTION_JOINABLE, rrdpush_sender_thread, (void *) host))
             error("STREAM %s [send]: failed to create new thread for client.", host->hostname);
         else
             host->rrdpush_sender_spawn = 1;
@@ -1050,7 +1053,10 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
 
     debug(D_SYSTEM, "STREAM [receive from [%s]:%s]: starting receiving thread.", w->client_ip, w->client_port);
 
-    if(netdata_thread_create(&thread, "STREAM_RECEIVER", NETDATA_THREAD_OPTION_DEFAULT, rrdpush_receiver_thread, (void *)rpt))
+    char tag[FILENAME_MAX + 1];
+    snprintfz(tag, FILENAME_MAX, "STREAM_RECEIVER[[%s]:%s]", w->client_ip, w->client_port);
+
+    if(netdata_thread_create(&thread, tag, NETDATA_THREAD_OPTION_DEFAULT, rrdpush_receiver_thread, (void *)rpt))
         error("STREAM [receive from [%s]:%s]: failed to create new thread for client.", w->client_ip, w->client_port);
 
     // prevent the caller from closing the streaming socket

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -582,6 +582,8 @@ void *rrdpush_sender_thread(void *ptr) {
                         // but the socket is in non-blocking mode
                         // so, we will not block at send()
 
+                        netdata_thread_disable_cancelability();
+
                         debug(D_STREAM, "STREAM: Getting exclusive lock on host...");
                         rrdpush_buffer_lock(host);
 
@@ -630,6 +632,8 @@ void *rrdpush_sender_thread(void *ptr) {
 
                         debug(D_STREAM, "STREAM: Releasing exclusive lock on host...");
                         rrdpush_buffer_unlock(host);
+
+                        netdata_thread_enable_cancelability();
 
                         // END RRDPUSH LOCKED SESSION
                     }

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -935,7 +935,7 @@ int rrdpush_receiver_permission_denied(struct web_client *w) {
 int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url) {
     (void)host;
 
-    info("STREAM [receive from [%s]:%s]: new client connection.", w->client_ip, w->client_port);
+    info("clients wants to STREAM metrics.");
 
     char *key = NULL, *hostname = NULL, *registry_hostname = NULL, *machine_guid = NULL, *os = "unknown", *timezone = "unknown", *tags = NULL;
     int update_every = default_rrd_update_every;
@@ -1051,13 +1051,13 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
     rpt->update_every      = update_every;
     netdata_thread_t thread;
 
-    debug(D_SYSTEM, "STREAM [receive from [%s]:%s]: starting receiving thread.", w->client_ip, w->client_port);
+    debug(D_SYSTEM, "starting STREAM receive thread.");
 
     char tag[FILENAME_MAX + 1];
-    snprintfz(tag, FILENAME_MAX, "STREAM_RECEIVER[[%s]:%s]", w->client_ip, w->client_port);
+    snprintfz(tag, FILENAME_MAX, "STREAM_RECEIVER[%s,[%s]:%s]", rpt->hostname, w->client_ip, w->client_port);
 
     if(netdata_thread_create(&thread, tag, NETDATA_THREAD_OPTION_DEFAULT, rrdpush_receiver_thread, (void *)rpt))
-        error("STREAM [receive from [%s]:%s]: failed to create new thread for client.", w->client_ip, w->client_port);
+        error("Failed to create new STREAM receive thread for client.");
 
     // prevent the caller from closing the streaming socket
     if(w->ifd == w->ofd)

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -1098,6 +1098,8 @@ void rrdset_done(RRDSET *st) {
             next_store_ut,          // the timestamp in microseconds, of the next entry to store in the db
             update_every_ut = st->update_every * USEC_PER_SEC; // st->update_every in microseconds
 
+    netdata_thread_disable_cancelability();
+
     // a read lock is OK here
     rrdset_rdlock(st);
 
@@ -1540,4 +1542,6 @@ void rrdset_done(RRDSET *st) {
 */
 
     rrdset_unlock(st);
+
+    netdata_thread_enable_cancelability();
 }

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -1087,9 +1087,6 @@ void rrdset_done(RRDSET *st) {
 
     RRDDIM *rd;
 
-    int
-            pthreadoldcancelstate;  // store the old cancelable pthread state, to restore it at the end
-
     char
             store_this_entry = 1,   // boolean: 1 = store this entry, 0 = don't store this entry
             first_entry = 0;        // boolean: 1 = this is the first entry seen for this chart, 0 = all other entries
@@ -1100,9 +1097,6 @@ void rrdset_done(RRDSET *st) {
             last_stored_ut,         // the timestamp in microseconds, of the last stored entry in the db
             next_store_ut,          // the timestamp in microseconds, of the next entry to store in the db
             update_every_ut = st->update_every * USEC_PER_SEC; // st->update_every in microseconds
-
-    if(unlikely(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &pthreadoldcancelstate) != 0))
-        error("Cannot set pthread cancel state to DISABLE.");
 
     // a read lock is OK here
     rrdset_rdlock(st);
@@ -1546,7 +1540,4 @@ void rrdset_done(RRDSET *st) {
 */
 
     rrdset_unlock(st);
-
-    if(unlikely(pthread_setcancelstate(pthreadoldcancelstate, NULL) != 0))
-        error("Cannot set pthread cancel state to RESTORE (%d).", pthreadoldcancelstate);
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -1158,7 +1158,7 @@ void poll_events(LISTEN_SOCKETS *sockets
 
     int timeout = -1; // wait forever
 
-    pthread_cleanup_push(poll_events_cleanup, &p);
+    netdata_thread_cleanup_push(poll_events_cleanup, &p);
 
     for(;;) {
         if(unlikely(netdata_exit)) break;
@@ -1293,6 +1293,6 @@ void poll_events(LISTEN_SOCKETS *sockets
         }
     }
 
-    pthread_cleanup_pop(1);
+    netdata_thread_cleanup_pop(1);
     debug(D_POLLFD, "POLLFD: LISTENER: cleanup completed");
 }

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -2085,8 +2085,11 @@ void *statsd_main(void *ptr) {
 
     statsd.collection_threads = callocz((size_t)statsd.threads, sizeof(netdata_thread_t));
     int i;
-    for(i = 0; i < statsd.threads ;i++)
-        netdata_thread_create(&statsd.collection_threads[i], "STATSD_COLLECTOR", NETDATA_THREAD_OPTION_DEFAULT, statsd_collector_thread, &i);
+    for(i = 0; i < statsd.threads ;i++) {
+        char tag[NETDATA_THREAD_TAG_MAX + 1];
+        snprintfz(tag, NETDATA_THREAD_TAG_MAX, "STATSD_COLLECTOR[%d]", i + 1);
+        netdata_thread_create(&statsd.collection_threads[i], tag, NETDATA_THREAD_OPTION_DEFAULT, statsd_collector_thread, &i);
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // statsd monitoring charts

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2684,8 +2684,7 @@ static void cgroup_main_cleanup(void *ptr) {
 }
 
 void *cgroups_main(void *ptr) {
-    netdata_thread_welcome("CGROUP");
-    pthread_cleanup_push(cgroup_main_cleanup, ptr);
+    netdata_thread_cleanup_push(cgroup_main_cleanup, ptr);
 
     struct rusage thread;
 
@@ -2753,7 +2752,6 @@ void *cgroups_main(void *ptr) {
         }
     }
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2674,16 +2674,18 @@ void update_cgroup_charts(int update_every) {
 // ----------------------------------------------------------------------------
 // cgroups main
 
-void *cgroups_main(void *ptr) {
+static void cgroup_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    if(static_thread->enabled) {
+        static_thread->enabled = 0;
 
-    info("CGROUP plugin thread created with task id %d", gettid());
+        info("%s: cleaning up...", netdata_thread_tag());
+    }
+}
 
-    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("CGROUP: cannot set pthread cancel type to DEFERRED.");
-
-    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("CGROUP: cannot set pthread cancel state to ENABLE.");
+void *cgroups_main(void *ptr) {
+    netdata_thread_welcome("CGROUP");
+    pthread_cleanup_push(cgroup_main_cleanup, ptr);
 
     struct rusage thread;
 
@@ -2698,7 +2700,8 @@ void *cgroups_main(void *ptr) {
     heartbeat_init(&hb);
     usec_t step = cgroup_update_every * USEC_PER_SEC;
     usec_t find_every = cgroup_check_for_new_every * USEC_PER_SEC, find_dt = 0;
-    for(;;) {
+
+    while(!netdata_exit) {
         usec_t hb_dt = heartbeat_next(&hb, step);
         if(unlikely(netdata_exit)) break;
 
@@ -2750,9 +2753,7 @@ void *cgroups_main(void *ptr) {
         }
     }
 
-    info("CGROUP thread exiting");
-
-    static_thread->enabled = 0;
+    pthread_cleanup_pop(1);
     pthread_exit(NULL);
     return NULL;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -1,0 +1,178 @@
+#include "common.h"
+
+static size_t stacksize = 0, wanted_stacksize = 0;
+static pthread_attr_t attr;
+
+// ----------------------------------------------------------------------------
+// per thread data
+
+typedef struct {
+    void *arg;
+    pthread_t *thread;
+    const char *tag;
+    void *(*start_routine) (void *);
+    NETDATA_THREAD_OPTIONS options;
+} NETDATA_THREAD;
+
+static __thread NETDATA_THREAD *netdata_thread = NULL;
+
+const char *netdata_thread_tag(void) {
+    return ((netdata_thread && netdata_thread->tag && *netdata_thread->tag)?netdata_thread->tag:"unknown");
+}
+
+// ----------------------------------------------------------------------------
+// compatibility library functions
+
+pid_t gettid(void) {
+#ifdef __FreeBSD__
+
+    return (pid_t)pthread_getthreadid_np();
+
+#elif defined(__APPLE__)
+
+    #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
+        uint64_t curthreadid;
+        pthread_threadid_np(NULL, &curthreadid);
+        return (pid_t)curthreadid;
+    #else /* __MAC_OS_X_VERSION_MIN_REQUIRED */
+        return (pid_t)pthread_self;
+    #endif /* __MAC_OS_X_VERSION_MIN_REQUIRED */
+
+#else /* __APPLE__*/
+
+    return (pid_t)syscall(SYS_gettid);
+
+#endif /* __FreeBSD__, __APPLE__*/
+}
+
+// ----------------------------------------------------------------------------
+// early initialization
+
+void netdata_threads_init(void) {
+    int i;
+
+    // --------------------------------------------------------------------
+    // get the required stack size of the threads of netdata
+
+    i = pthread_attr_init(&attr);
+    if(i != 0)
+        fatal("pthread_attr_init() failed with code %d.", i);
+
+    i = pthread_attr_getstacksize(&attr, &stacksize);
+    if(i != 0)
+        fatal("pthread_attr_getstacksize() failed with code %d.", i);
+    else
+        debug(D_OPTIONS, "initial pthread stack size is %zu bytes", stacksize);
+
+    wanted_stacksize = (size_t)config_get_number(CONFIG_SECTION_GLOBAL, "pthread stack size", (long)stacksize);
+}
+
+// ----------------------------------------------------------------------------
+// late initialization
+
+void netdata_threads_init_after_fork(void) {
+    int i;
+
+    // ------------------------------------------------------------------------
+    // set default pthread stack size
+
+    if(stacksize < wanted_stacksize && wanted_stacksize > 0) {
+        i = pthread_attr_setstacksize(&attr, wanted_stacksize);
+        if(i != 0)
+            fatal("pthread_attr_setstacksize() to %zu bytes, failed with code %d.", wanted_stacksize, i);
+        else
+            debug(D_SYSTEM, "Successfully set pthread stacksize to %zu bytes", wanted_stacksize);
+    }
+}
+
+
+// ----------------------------------------------------------------------------
+// netdata_thread_create
+
+static void thread_cleanup(void *ptr) {
+    if(netdata_thread != ptr) {
+        NETDATA_THREAD *info = (NETDATA_THREAD *)ptr;
+        error("THREADS: internal error - thread local variable does not match the one passed to this function. Expected thread '%s', passed thread '%s'", netdata_thread->tag, info->tag);
+    }
+
+    if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP))
+        info("%s: thread with task id %d finished", netdata_thread_tag(), gettid());
+
+    freez((void *)netdata_thread->tag);
+    freez(netdata_thread);
+    netdata_thread->tag = NULL;
+    netdata_thread = NULL;
+}
+
+static void *thread_start(void *ptr) {
+    netdata_thread = (NETDATA_THREAD *)ptr;
+
+    if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_STARTUP))
+        info("%s: thread created with task id %d", netdata_thread_tag(), gettid());
+
+    if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+        error("%s: cannot set pthread cancel type to DEFERRED.", netdata_thread_tag());
+
+    if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
+        error("%s: cannot set pthread cancel state to ENABLE.", netdata_thread_tag());
+
+    void *ret = NULL;
+    pthread_cleanup_push(thread_cleanup, ptr);
+            ret = netdata_thread->start_routine(netdata_thread->arg);
+    pthread_cleanup_pop(1);
+
+    return ret;
+}
+
+int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg) {
+    NETDATA_THREAD *info = mallocz(sizeof(NETDATA_THREAD));
+    info->arg = arg;
+    info->thread = thread;
+    info->tag = strdupz(tag);
+    info->start_routine = start_routine;
+    info->options = options;
+
+    int ret = pthread_create(thread, &attr, thread_start, info);
+    if(ret != 0)
+        error("%s: failed to create new thread for %s. pthread_create() failed with code %d", netdata_thread_tag(), tag, ret);
+
+    else {
+        if (!(options & NETDATA_THREAD_OPTION_JOINABLE)) {
+            int ret2 = pthread_detach(*thread);
+            if (ret2 != 0)
+                error("%s: cannot request detach of newly created %s thread. pthread_detach() failed with code %d", netdata_thread_tag(), tag, ret2);
+        }
+    }
+
+    return ret;
+}
+
+// ----------------------------------------------------------------------------
+// netdata_thread_cancel
+
+int netdata_thread_cancel(netdata_thread_t thread) {
+    int ret = pthread_cancel(thread);
+    if(ret != 0)
+        error("%s: cannot cancel thread. pthread_cancel() failed with code %d.", netdata_thread_tag(), ret);
+
+    return ret;
+}
+
+// ----------------------------------------------------------------------------
+// netdata_thread_join
+
+int netdata_thread_join(netdata_thread_t thread, void **retval) {
+    int ret = pthread_join(thread, retval);
+    if(ret != 0)
+        error("%s: cannot join thread. pthread_join() failed with code %d.", netdata_thread_tag(), ret);
+
+    return ret;
+}
+
+int netdata_thread_detach(pthread_t thread) {
+    int ret = pthread_detach(thread);
+    if(ret != 0)
+        error("%s: cannot detach thread. pthread_detach() failed with code %d.", netdata_thread_tag(), ret);
+
+    return ret;
+}

--- a/src/threads.c
+++ b/src/threads.c
@@ -17,7 +17,7 @@ typedef struct {
 static __thread NETDATA_THREAD *netdata_thread = NULL;
 
 const char *netdata_thread_tag(void) {
-    return ((netdata_thread && netdata_thread->tag && *netdata_thread->tag)?netdata_thread->tag:"unknown");
+    return ((netdata_thread && netdata_thread->tag && *netdata_thread->tag)?netdata_thread->tag:"MAIN");
 }
 
 // ----------------------------------------------------------------------------

--- a/src/threads.h
+++ b/src/threads.h
@@ -16,6 +16,7 @@ typedef enum {
 
 typedef pthread_t netdata_thread_t;
 
+#define NETDATA_THREAD_TAG_MAX 50
 extern const char *netdata_thread_tag(void);
 
 extern size_t netdata_threads_init(void);

--- a/src/threads.h
+++ b/src/threads.h
@@ -1,0 +1,32 @@
+#ifndef NETDATA_THREADS_H
+#define NETDATA_THREADS_H
+
+extern pid_t gettid(void);
+
+typedef enum {
+    NETDATA_THREAD_OPTION_DEFAULT          = 0 << 0,
+    NETDATA_THREAD_OPTION_JOINABLE         = 1 << 0,
+    NETDATA_THREAD_OPTION_DONT_LOG_STARTUP = 1 << 1,
+    NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP = 1 << 2,
+    NETDATA_THREAD_OPTION_DONT_LOG         = NETDATA_THREAD_OPTION_DONT_LOG_STARTUP|NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP,
+} NETDATA_THREAD_OPTIONS;
+
+#define netdata_thread_cleanup_push(func, arg) pthread_cleanup_push(func, arg)
+#define netdata_thread_cleanup_pop(execute) pthread_cleanup_pop(execute)
+
+typedef pthread_t netdata_thread_t;
+
+extern const char *netdata_thread_tag(void);
+
+extern void netdata_threads_init(void);
+extern void netdata_threads_init_after_fork(void);
+
+extern int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg);
+extern int netdata_thread_cancel(netdata_thread_t thread);
+extern int netdata_thread_join(netdata_thread_t thread, void **retval);
+extern int netdata_thread_detach(pthread_t thread);
+
+#define netdata_thread_self pthread_self
+#define netdata_thread_testcancel pthread_testcancel
+
+#endif //NETDATA_THREADS_H

--- a/src/threads.h
+++ b/src/threads.h
@@ -16,7 +16,7 @@ typedef enum {
 
 typedef pthread_t netdata_thread_t;
 
-#define NETDATA_THREAD_TAG_MAX 50
+#define NETDATA_THREAD_TAG_MAX 100
 extern const char *netdata_thread_tag(void);
 
 extern size_t netdata_threads_init(void);

--- a/src/threads.h
+++ b/src/threads.h
@@ -18,8 +18,8 @@ typedef pthread_t netdata_thread_t;
 
 extern const char *netdata_thread_tag(void);
 
-extern void netdata_threads_init(void);
-extern void netdata_threads_init_after_fork(void);
+extern size_t netdata_threads_init(void);
+extern void netdata_threads_init_after_fork(size_t stacksize);
 
 extern int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg);
 extern int netdata_thread_cancel(netdata_thread_t thread);

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1766,8 +1766,7 @@ static void web_client_main_cleanup(void *ptr) {
 }
 
 void *web_client_main(void *ptr) {
-    netdata_thread_welcome_nolog("WEB_CLIENT");
-    pthread_cleanup_push(web_client_main_cleanup, ptr);
+    netdata_thread_cleanup_push(web_client_main_cleanup, ptr);
 
     struct web_client *w = ptr;
     struct pollfd fds[2], *ifd, *ofd;
@@ -1898,7 +1897,6 @@ void *web_client_main(void *ptr) {
     w->ifd = -1;
     w->ofd = -1;
 
-    pthread_cleanup_pop(1);
-    pthread_exit(NULL);
+    netdata_thread_cleanup_pop(1);
     return NULL;
 }

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -155,7 +155,7 @@ struct web_client {
     size_t stats_received_bytes;
     size_t stats_sent_bytes;
 
-    pthread_t thread;               // the thread servicing this client
+    netdata_thread_t thread;               // the thread servicing this client
 
     struct web_client *prev;
     struct web_client *next;

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -193,7 +193,10 @@ void *socket_listen_main_multi_threaded(void *ptr) {
                 else
                     web_client_set_tcp(w);
 
-                if(netdata_thread_create(&w->thread, "WEB_CLIENT", NETDATA_THREAD_OPTION_DONT_LOG, web_client_main, w) != 0)
+                char tag[NETDATA_THREAD_TAG_MAX + 1];
+                snprintfz(tag, NETDATA_THREAD_TAG_MAX, "WEB_CLIENT[%llu,[%s]:%s]", w->id, w->client_ip, w->client_port);
+
+                if(netdata_thread_create(&w->thread, tag, NETDATA_THREAD_OPTION_DONT_LOG, web_client_main, w) != 0)
                     WEB_CLIENT_IS_OBSOLETE(w);
             }
         }

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -193,7 +193,7 @@ void *socket_listen_main_multi_threaded(void *ptr) {
                 else
                     web_client_set_tcp(w);
 
-                if(netdata_thread_create(&w->thread, "WEB_CLIENT", NETDATA_THREAD_OPTION_DEFAULT, web_client_main, w) != 0)
+                if(netdata_thread_create(&w->thread, "WEB_CLIENT", NETDATA_THREAD_OPTION_DONT_LOG, web_client_main, w) != 0)
                     WEB_CLIENT_IS_OBSOLETE(w);
             }
         }


### PR DESCRIPTION
For some reason, musl-libc deadlocks when netdata exits. netdata calls `exit()` but musl-libc waits forever.

```
#0  __wait () at src/thread/__wait.c:14
#1  0x00007f871ce90873 in __lockfile () at src/stdio/__lockfile.c:10
#2  0x00007f871ce92620 in close_file () at src/stdio/__stdio_exit.c:11
#3  0x00007f871ce9266b in __stdio_exit_needed () at src/stdio/__stdio_exit.c:19
#4  0x00007f871cdec8bb in exit () at src/exit/exit.c:32
#5  0x00007f871ce0a27b in netdata_cleanup_and_exit ()
#6  0x00007f871ce0dfd4 in main ()
```

I traced the problem and found that musl-libc does not like the fact that netdata detaches all threads and the main process exits while all the threads are still running.

I tried to call `pthread_cancel` on all the threads running. The problem however is that if this is called on an exited thread, it crashes with SIGSEGV. So, the exit of threads has to be synchronized somehow.

This PR, attempts to synchronize all threads, by implementing:

1. All threads become non-cancelable while they hold a lock.
2. All cleanup is now local to each thread - even for threads that spawn other threads all the cleanup logic is closer to the thread that needs it.
3. To exit netdata, the main thread cancels the threads it spawned.

So the exit procedure is now: a) the main thread cancels the threads it spawned. These threads cancel the threads they spawned, etc, until all are cancelled. All threads that hold a lock (any lock) defer their cancellation until all the locks they hold are released. Once everything is stopped, netdata exits.

Fixes: https://github.com/firehol/binary-packages/issues/4
