### PR TITLE
Include the current netdata version in the HTTP 'Server' header.

### DIFF
--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1016,13 +1016,14 @@ static inline void web_client_send_http_header(struct web_client *w) {
     buffer_sprintf(w->response.header_output,
             "HTTP/1.1 %d %s\r\n"
                     "Connection: %s\r\n"
-                    "Server: NetData Embedded HTTP Server\r\n"
+                    "Server: NetData Embedded HTTP Server v%s\r\n"
                     "Access-Control-Allow-Origin: %s\r\n"
                     "Access-Control-Allow-Credentials: true\r\n"
                     "Content-Type: %s\r\n"
                     "Date: %s\r\n"
                    , w->response.code, code_msg
                    , web_client_has_keepalive(w)?"keep-alive":"close"
+                   , VERSION
                    , w->origin
                    , content_type_string
                    , date


### PR DESCRIPTION
Super simplistic patch to include the current netdata version within HTTP contexts.