### PR TITLE
macos installer fixes

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -142,6 +142,24 @@ service() {
 }
 
 # -----------------------------------------------------------------------------
+# portable pidof
+
+pidof_cmd="$(which_cmd pidof)"
+pidof() {
+    if [ ! -z "${pidof_cmd}" ]
+    then
+        ${pidof_cmd} "${@}"
+        return $?
+    else
+        ps -acxo pid,comm |\
+            sed "s/^ *//g" |\
+            grep netdata |\
+            cut -d ' ' -f 1
+        return $?
+    fi
+}
+
+# -----------------------------------------------------------------------------
 
 run_ok() {
     printf >&2 "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET} ${*} \n\n"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -557,7 +557,7 @@ config_signature_matches() {
 
 # backup user configurations
 installer_backup_suffix="${PID}.${RANDOM}"
-for x in $(find -L "${NETDATA_PREFIX}/etc/netdata/" -name '*.conf' -type f)
+for x in $(find -L "${NETDATA_PREFIX}/etc/netdata" -name '*.conf' -type f)
 do
     if [ -f "${x}" ]
         then


### PR DESCRIPTION
1. added portable `pidof` to allow the installer restart netdata
2. fixed an issue that was preventing the installer from detecting stock config files
