### PR TITLE
enable cleanup of threads on exit

### DIFF
--- a/src/backends.c
+++ b/src/backends.c
@@ -503,7 +503,7 @@ static void backends_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/health.c
+++ b/src/health.c
@@ -343,7 +343,7 @@ static void health_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -7,7 +7,7 @@ static void checks_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -71,7 +71,7 @@ static void freebsd_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -7,7 +7,7 @@ static void cpuidlejitter_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -5,7 +5,7 @@ static void macos_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -756,7 +756,7 @@ static void nfacct_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
 #ifdef DO_NFACCT
         nfacct_cleanup();

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -69,7 +69,7 @@ static void proc_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -333,7 +333,7 @@ static void diskspace_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -835,7 +835,7 @@ static void tc_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
         if(tc_child_pid) {
             info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -879,7 +879,7 @@ void statsd_collector_thread_cleanup(void *data) {
     static __thread int executed = 0;
     if(!executed) {
         executed = 1;
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
         struct statsd_udp *d = data;
 
@@ -1973,7 +1973,7 @@ static void statsd_main_cleanup(void *data) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
         if (statsd.collection_threads) {
             int i;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2679,7 +2679,7 @@ static void cgroup_main_cleanup(void *ptr) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
     }
 }
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -98,7 +98,7 @@ static void thread_cleanup(void *ptr) {
     }
 
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP))
-        info("%s: thread with task id %d finished", netdata_thread_tag(), gettid());
+        info("thread with task id %d finished", gettid());
 
     freez((void *)netdata_thread->tag);
     netdata_thread->tag = NULL;
@@ -111,13 +111,13 @@ static void *thread_start(void *ptr) {
     netdata_thread = (NETDATA_THREAD *)ptr;
 
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_STARTUP))
-        info("%s: thread created with task id %d", netdata_thread_tag(), gettid());
+        info("thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("%s: cannot set pthread cancel type to DEFERRED.", netdata_thread_tag());
+        error("cannot set pthread cancel type to DEFERRED.");
 
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("%s: cannot set pthread cancel state to ENABLE.", netdata_thread_tag());
+        error("cannot set pthread cancel state to ENABLE.");
 
     void *ret = NULL;
     pthread_cleanup_push(thread_cleanup, ptr);
@@ -137,13 +137,13 @@ int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THR
 
     int ret = pthread_create(thread, attr, thread_start, info);
     if(ret != 0)
-        error("%s: failed to create new thread for %s. pthread_create() failed with code %d", netdata_thread_tag(), tag, ret);
+        error("failed to create new thread for %s. pthread_create() failed with code %d", tag, ret);
 
     else {
         if (!(options & NETDATA_THREAD_OPTION_JOINABLE)) {
             int ret2 = pthread_detach(*thread);
             if (ret2 != 0)
-                error("%s: cannot request detach of newly created %s thread. pthread_detach() failed with code %d", netdata_thread_tag(), tag, ret2);
+                error("cannot request detach of newly created %s thread. pthread_detach() failed with code %d", tag, ret2);
         }
     }
 
@@ -156,7 +156,7 @@ int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THR
 int netdata_thread_cancel(netdata_thread_t thread) {
     int ret = pthread_cancel(thread);
     if(ret != 0)
-        error("%s: cannot cancel thread. pthread_cancel() failed with code %d.", netdata_thread_tag(), ret);
+        error("cannot cancel thread. pthread_cancel() failed with code %d.", ret);
 
     return ret;
 }
@@ -167,7 +167,7 @@ int netdata_thread_cancel(netdata_thread_t thread) {
 int netdata_thread_join(netdata_thread_t thread, void **retval) {
     int ret = pthread_join(thread, retval);
     if(ret != 0)
-        error("%s: cannot join thread. pthread_join() failed with code %d.", netdata_thread_tag(), ret);
+        error("cannot join thread. pthread_join() failed with code %d.", ret);
 
     return ret;
 }
@@ -175,7 +175,7 @@ int netdata_thread_join(netdata_thread_t thread, void **retval) {
 int netdata_thread_detach(pthread_t thread) {
     int ret = pthread_detach(thread);
     if(ret != 0)
-        error("%s: cannot detach thread. pthread_detach() failed with code %d.", netdata_thread_tag(), ret);
+        error("cannot detach thread. pthread_detach() failed with code %d.", ret);
 
     return ret;
 }

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -114,22 +114,22 @@ static void socket_listen_main_multi_threaded_cleanup(void *data) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
-        info("LISTENER: releasing allocated memory...");
+        info("releasing allocated memory...");
         freez(socket_listen_main_multi_threaded_fds);
 
-        info("LISTENER: closing all sockets...");
+        info("closing all sockets...");
         listen_sockets_close(&api_sockets);
 
-        info("LISTENER: cleanup completed.");
+        info("cleanup completed.");
     }
 
     struct web_client *w;
     for(w = web_clients; w ; w = w->next) {
         if(!web_client_check_obsolete(w)) {
             WEB_CLIENT_IS_OBSOLETE(w);
-            info("LISTENER: Stopping web client %s, id %llu", w->client_ip, w->id);
+            info("Stopping web client %s, id %llu", w->client_ip, w->id);
             netdata_thread_cancel(w->thread);
         }
     }
@@ -262,12 +262,12 @@ static void socket_listen_main_single_threaded_cleanup(void *data) {
     if(static_thread->enabled) {
         static_thread->enabled = 0;
 
-        info("%s: cleaning up...", netdata_thread_tag());
+        info("cleaning up...");
 
-        info("LISTENER: closing all sockets...");
+        info("closing all sockets...");
         listen_sockets_close(&api_sockets);
 
-        info("LISTENER: cleanup completed.");
+        info("cleanup completed.");
         debug(D_WEB_CLIENT, "LISTENER: exit!");
     }
 }


### PR DESCRIPTION
fixes https://github.com/firehol/binary-packages/issues/4 again  

also cleaned up a few logs (repeating the thread name on the log line).