### PR TITLE
Fix icons not being consistent size

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -232,7 +232,7 @@
         font-weight: 500;
         color: #767676;
     }
-    .dashboard-sidebar .nav > li > a > .fa {
+    .dashboard-sidebar .nav > li > a > .svg-inline--fa {
         width: 20px;
         text-align: center;
     }


### PR DESCRIPTION
This was initially done in 9941e2f5829426f2fa9bbb9db61f9f59511673b5 but broke when icons changed to SVG version.