### PR TITLE
move tcp active and passive opens to a separate chart; 

### DIFF
--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -24,13 +24,13 @@ void *cpuidlejitter_main(void *ptr) {
             "system"
             , "idlejitter"
             , NULL
-            , "processes"
+            , "idlejitter"
             , NULL
             , "CPU Idle Jitter"
             , "microseconds lost/s"
             , "idlejitter"
             , NULL
-            , 9999
+            , 800
             , localhost->rrd_update_every
             , RRDSET_TYPE_AREA
     );

--- a/src/proc_net_sockstat.c
+++ b/src/proc_net_sockstat.c
@@ -304,7 +304,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
                     , "KB"
                     , "proc"
                     , "net/sockstat"
-                    , 2540
+                    , 4000
                     , update_every
                     , RRDSET_TYPE_AREA
             );

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -689,6 +689,28 @@ netdataDashboard.context = {
         info: 'TCP connection aborts. <b>baddata</b> (<code>TCPAbortOnData</code>) happens while the connection is on <code>FIN_WAIT1</code> and the kernel receives a packet with a sequence number beyond the last one for this connection - the kernel responds with <code>RST</code> (closes the connection). <b>userclosed</b> (<code>TCPAbortOnClose</code>) happens when the kernel receives data on an already closed connection and responds with <code>RST</code>. <b>nomemory</b> (<code>TCPAbortOnMemory</code> happens when there are too many orphaned sockets (not attached to an fd) and the kernel has to drop a connection - sometimes it will send an <code>RST</code>, sometimes it won\'t. <b>timeout</b> (<code>TCPAbortOnTimeout</code>) happens when a connection times out. <b>linger</b> (<code>TCPAbortOnLinger</code>) happens when the kernel killed a socket that was already closed by the application and lingered around for long enough. <b>failed</b> (<code>TCPAbortFailed</code>) happens when the kernel attempted to send an <code>RST</code> but failed because there was no memory available.'
     },
 
+    'ipv4.tcpsock': {
+        info: 'The number of TCP connections (known as <code>CurrEstab</code>) with status <code>ESTABLISHED</code> or <code>CLOSE_WAIT</code>.'
+    },
+
+    'ipv4.tcpopens': {
+        info: '<b>active</b> or <code>ActiveOpens</code> is the number of <b>connections made</b> (i.e. connections that made a direct transition from <code>CLOSED</code> to <code>SYN-SENT</code>).'
+            + ' <b>passive</b> or <code>PassiveOpens</code> is the number of <b>connections received</b> (i.e. connections that made a direct transition from <code>LISTEN</code> to <code>SYN-RCVD</code>).'
+    },
+
+    'ipv4.tcperrors': {
+        info: '<code>InErrs</code> is the number of TCP segments received in error.'
+            + ' <code>InCsumErrors</code> is the number of TCP segments received with checksum errors.'
+            + ' <code>RetransSegs</code> is the number of TCP segments retransmitted.'
+    },
+
+    'ipv4.tcphandshake': {
+        info: '<code>EstabResets</code> is the number of established connections resets (i.e. connections that made a direct transition from <code>ESTABLISHED</code> to <code>CLOSED</code>).'
+            + ' <code>OutRsts</code> is the number of TCP segments sent, with the <code>RST</code> flag set.'
+            + ' <code>AttemptFails</code> is the number of times TCP connections made a direct transition from either <code>SYN-SENT</code> or <code>SYN-RCVD</code> to <code>CLOSED</code>, plus the number of times TCP connections made a direct transition from the <code>SYN-RCVD</code> to <code>LISTEN</code>.'
+            + ' <code>TCPSynRetrans</code> shows retries for new outbound TCP connections, which can indicate general connectivity issues or backlog on the remote host.'
+    },
+
     // ------------------------------------------------------------------------
     // APPS
 

--- a/web/index.html
+++ b/web/index.html
@@ -4344,7 +4344,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverStatic + 'dashboard_info.js?v20171220-1',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20180106-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });
@@ -4528,7 +4528,7 @@
             <div class="col-md-10" role="main">
                 <div class="p">
                     <big><a href="https://github.com/firehol/netdata/wiki" target="_blank">netdata</a></big><br/>
-                    <i class="fas fa-copyright"></i> Copyright 2016-2017, <a href="mailto:costa@tsaousis.gr">Costa Tsaousis</a>.<br/>
+                    <i class="fas fa-copyright"></i> Copyright 2016-2018, <a href="mailto:costa@tsaousis.gr">Costa Tsaousis</a>.<br/>
                     Released under <a href="http://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank">GPL v3 or later</a>.<br/>
                 </div>
                 <div class="p">
@@ -5622,6 +5622,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20171226-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20180106-1"></script>
 </body>
 </html>


### PR DESCRIPTION
also: give idle jitter its own sub-menu

When a server is busy, ActiveOpens and PassiveOpens "hide" the TCP handshake issues. This PR moves the connection opens to a separate chart, so that TCP handshake issue can shine...