### PR TITLE
added MemAvailable from /proc/meminfo; 

### DIFF
--- a/conf.d/health.d/ram.conf
+++ b/conf.d/health.d/ram.conf
@@ -27,11 +27,11 @@
       on: mem.available
       os: linux
    hosts: *
-    calc: ($avail + $used_ram_to_ignore) * 100 / ($system.ram.used - $used_ram_to_ignore + $system.ram.cached + $system.ram.free)
+    calc: ($avail + $used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
    units: %
    every: 10s
     warn: $this < (($status >= $WARNING)  ? ( 5) : (10))
     crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
    delay: down 15m multiplier 1.5 max 1h
-    info: estimated amount of RAM available for processes
+    info: estimated amount of RAM available for userspace processes, without causing swapping
       to: sysadmin

--- a/conf.d/health.d/ram.conf
+++ b/conf.d/health.d/ram.conf
@@ -20,5 +20,18 @@
     warn: $this > (($status >= $WARNING)  ? (80) : (90))
     crit: $this > (($status == $CRITICAL) ? (90) : (98))
    delay: down 15m multiplier 1.5 max 1h
-    info: system RAM usage
+    info: system RAM used
+      to: sysadmin
+
+   alarm: ram_available
+      on: mem.available
+      os: linux
+   hosts: *
+    calc: ($avail + $used_ram_to_ignore) * 100 / ($system.ram.used - $used_ram_to_ignore + $system.ram.cached + $system.ram.free)
+   units: %
+   every: 10s
+    warn: $this < (($status >= $WARNING)  ? ( 5) : (10))
+    crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
+   delay: down 15m multiplier 1.5 max 1h
+    info: estimated amount of RAM available for processes
       to: sysadmin

--- a/configs.signatures
+++ b/configs.signatures
@@ -199,6 +199,7 @@ declare -A configs_signatures=(
   ['54c3934a03453453b8d7d0e8b84a7cd8']='health_alarm_notify.conf'
   ['55608bdd908a3806df1468f6ee318b2b']='health.d/qos.conf'
   ['5598b83e915e31f68027afe324a427cd']='apps_groups.conf'
+  ['55cc7e3fe365a77f8e92d01d7a428276']='health.d/ram.conf'
   ['565f11c38ae6bd5cc9d3c2adb542bc1b']='health.d/softnet.conf'
   ['5664a814f9351b55da76edd472169a73']='health_alarm_notify.conf'
   ['56b689031cdcf138064825f31474b37d']='apps_groups.conf'

--- a/configs.signatures
+++ b/configs.signatures
@@ -326,6 +326,7 @@ declare -A configs_signatures=(
   ['8d0552371a7c9725a04196fa560813d1']='health.d/cpu.conf'
   ['8d24873bb25c195026918f15626310ea']='health.d/softnet.conf'
   ['8dc0bd0a70b5117454bd5f5b98f91c2c']='health.d/disks.conf'
+  ['8dc6a32b8e2995cbdd527c621a72c4fb']='health.d/ram.conf'
   ['8ec636a4f96158044d2cec0fd1ff8452']='python.d/rabbitmq.conf'
   ['8f4f925c1e97dd164007495ec5135ffc']='health.d/fping.conf'
   ['8f7b734ea0f89abf8acbb47c50234477']='health.d/web_log.conf'

--- a/src/proc_vmstat.c
+++ b/src/proc_vmstat.c
@@ -168,7 +168,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
                     , "page faults/s"
                     , "proc"
                     , "vmstat"
-                    , 500
+                    , 4010
                     , update_every
                     , RRDSET_TYPE_LINE
             );

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -659,6 +659,10 @@ netdataDashboard.context = {
         info: 'Committed Memory, is the sum of all memory which has been allocated by processes.'
     },
 
+    'mem.available': {
+        info: 'Available Memory is estimated by the kernel, as the amount of RAM that can be used by userspace processes, without causing swapping.'
+    },
+
     'mem.writeback': {
         info: '<b>Dirty</b> is the amount of memory waiting to be written to disk. <b>Writeback</b> is how much memory is actively being written to disk.'
     },

--- a/web/index.html
+++ b/web/index.html
@@ -4344,7 +4344,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverStatic + 'dashboard_info.js?v20180106-3',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20180106-4',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });


### PR DESCRIPTION
fixes #3241 

Added a new chart called `mem.available`, that shows the kernel estimated available RAM for userspace allocations, without causing swapping.

![screenshot from 2018-01-07 03-38-30](https://user-images.githubusercontent.com/2662304/34645669-79df0e3c-f35c-11e7-8c85-641e84362b71.png)

And an alarm:

![screenshot from 2018-01-07 03-39-05](https://user-images.githubusercontent.com/2662304/34645671-81e64c80-f35c-11e7-92ef-1b9af8c42d60.png)
