### PR TITLE
New multi-threaded web server

### DIFF
--- a/src/backends.c
+++ b/src/backends.c
@@ -501,9 +501,9 @@ inline uint32_t backend_parse_data_source(const char *source, uint32_t mode) {
 static void backends_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/global_statistics.c
+++ b/src/global_statistics.c
@@ -100,6 +100,7 @@ inline void global_statistics_copy(struct global_statistics *gs, uint8_t options
     gs->bytes_sent              = __atomic_fetch_add(&global_statistics.bytes_sent, 0, __ATOMIC_SEQ_CST);
     gs->content_size            = __atomic_fetch_add(&global_statistics.content_size, 0, __ATOMIC_SEQ_CST);
     gs->compressed_content_size = __atomic_fetch_add(&global_statistics.compressed_content_size, 0, __ATOMIC_SEQ_CST);
+    gs->web_client_count        = __atomic_fetch_add(&global_statistics.web_client_count, 0, __ATOMIC_SEQ_CST);
 
     if(options & GLOBAL_STATS_RESET_WEB_USEC_MAX) {
         uint64_t n = 0;

--- a/src/global_statistics.c
+++ b/src/global_statistics.c
@@ -7,7 +7,8 @@ volatile struct global_statistics global_statistics = {
         .bytes_received = 0,
         .bytes_sent = 0,
         .content_size = 0,
-        .compressed_content_size = 0
+        .compressed_content_size = 0,
+        .web_client_count = 1
 };
 
 netdata_mutex_t global_statistics_mutex = NETDATA_MUTEX_INITIALIZER;
@@ -38,7 +39,7 @@ void finished_web_request_statistics(uint64_t dt,
     __atomic_fetch_add(&global_statistics.compressed_content_size, compressed_content_size, __ATOMIC_SEQ_CST);
 #else
 #warning NOT using atomic operations - using locks for global statistics
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_lock();
 
     if (dt > global_statistics.web_usec_max)
@@ -51,35 +52,39 @@ void finished_web_request_statistics(uint64_t dt,
     global_statistics.content_size += content_size;
     global_statistics.compressed_content_size += compressed_content_size;
 
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_unlock();
 #endif
 }
 
-void web_client_connected(void) {
+uint64_t web_client_connected(void) {
 #if defined(HAVE_C___ATOMIC) && !defined(NETDATA_NO_ATOMIC_INSTRUCTIONS)
     __atomic_fetch_add(&global_statistics.connected_clients, 1, __ATOMIC_SEQ_CST);
+    uint64_t id = __atomic_fetch_add(&global_statistics.web_client_count, 1, __ATOMIC_SEQ_CST);
 #else
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_lock();
 
     global_statistics.connected_clients++;
+    uint64_t id = global_statistics.web_client_count++;
 
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_unlock();
 #endif
+
+    return id;
 }
 
 void web_client_disconnected(void) {
 #if defined(HAVE_C___ATOMIC) && !defined(NETDATA_NO_ATOMIC_INSTRUCTIONS)
     __atomic_fetch_sub(&global_statistics.connected_clients, 1, __ATOMIC_SEQ_CST);
 #else
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_lock();
 
     global_statistics.connected_clients--;
 
-    if (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED)
+    if (web_server_is_multithreaded)
         global_statistics_unlock();
 #endif
 }

--- a/src/global_statistics.h
+++ b/src/global_statistics.h
@@ -14,6 +14,8 @@ struct global_statistics {
     volatile uint64_t bytes_sent;
     volatile uint64_t content_size;
     volatile uint64_t compressed_content_size;
+
+    volatile uint64_t web_client_count;
 };
 
 extern volatile struct global_statistics global_statistics;
@@ -26,7 +28,7 @@ extern void finished_web_request_statistics(uint64_t dt,
                                      uint64_t content_size,
                                      uint64_t compressed_content_size);
 
-extern void web_client_connected(void);
+extern uint64_t web_client_connected(void);
 extern void web_client_disconnected(void);
 
 #define GLOBAL_STATS_RESET_WEB_USEC_MAX 0x01

--- a/src/health.c
+++ b/src/health.c
@@ -341,9 +341,9 @@ static inline int check_if_resumed_from_suspention(void) {
 static void health_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,7 @@
 #include "common.h"
 
+int web_server_is_multithreaded = 1;
+
 const char *program_name = "";
 uint64_t debug_flags = DEBUG;
 

--- a/src/log.c
+++ b/src/log.c
@@ -61,7 +61,7 @@ int open_log_file(int fd, FILE **fp, const char *filename, int *enabled_syslog) 
 
     if(!filename || !*filename || !strcmp(filename, "none") ||  !strcmp(filename, "/dev/null")) {
         filename = "/dev/null";
-        devnull =1;
+        devnull = 1;
     }
 
     if(!strcmp(filename, "syslog")) {

--- a/src/log.c
+++ b/src/log.c
@@ -338,8 +338,8 @@ void error_int( const char *prefix, const char *file, const char *function, cons
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s %-5.5s : %s: (%04lu@%-10.10s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
-    else            fprintf(stderr, "%s: %s %-5.5s : %s: ", date, program_name, prefix, netdata_thread_tag());
+    if(debug_flags) fprintf(stderr, "%s: %s %-5.5s : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    else            fprintf(stderr, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
     vfprintf( stderr, fmt, args );
     va_end( args );
 

--- a/src/log.h
+++ b/src/log.h
@@ -38,6 +38,8 @@
 //#define DEBUG 0xffffffff
 #define DEBUG (0)
 
+extern int web_server_is_multithreaded;
+
 extern uint64_t debug_flags;
 
 extern const char *program_name;

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,7 @@ struct netdata_static_thread static_threads[] = {
     {"PLUGINSD",            NULL,                    NULL,         1, NULL, NULL, pluginsd_main},
     {"WEB_SERVER[multi]",   NULL,                    NULL,         1, NULL, NULL, socket_listen_main_multi_threaded},
     {"WEB_SERVER[single]",  NULL,                    NULL,         0, NULL, NULL, socket_listen_main_single_threaded},
+    {"WEB_SERVER[static]",  NULL,                    NULL,         0, NULL, NULL, socket_listen_main_static_threaded},
     {"STREAM",              NULL,                    NULL,         0, NULL, NULL, rrdpush_sender_thread},
     {"STATSD",              NULL,                    NULL,         1, NULL, NULL, statsd_main},
 
@@ -87,6 +88,7 @@ void web_server_threading_selection(void) {
 
     int multi_threaded = (web_server_mode == WEB_SERVER_MODE_MULTI_THREADED);
     int single_threaded = (web_server_mode == WEB_SERVER_MODE_SINGLE_THREADED);
+    int static_threaded = (web_server_mode == WEB_SERVER_MODE_STATIC_THREADED);
 
     int i;
     for (i = 0; static_threads[i].name; i++) {
@@ -95,6 +97,9 @@ void web_server_threading_selection(void) {
 
         if (static_threads[i].start_routine == socket_listen_main_single_threaded)
             static_threads[i].enabled = single_threaded;
+
+        if (static_threads[i].start_routine == socket_listen_main_static_threaded)
+            static_threads[i].enabled = static_threaded;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -196,7 +196,7 @@ int killpid(pid_t pid, int sig)
 void cancel_main_threads() {
     error_log_limit_unlimited();
 
-    int i, found = 0, max = 1 * USEC_PER_SEC, step = 100000;
+    int i, found = 0, max = 5 * USEC_PER_SEC, step = 100000;
     for (i = 0; static_threads[i].name != NULL ; i++) {
         if(static_threads[i].enabled) {
             info("EXIT: Stopping master thread: %s", static_threads[i].name);

--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,7 @@ struct netdata_static_thread static_threads[] = {
     {"PLUGINSD",            NULL,                    NULL,         1, NULL, NULL, pluginsd_main},
     {"WEB_SERVER[multi]",   NULL,                    NULL,         1, NULL, NULL, socket_listen_main_multi_threaded},
     {"WEB_SERVER[single]",  NULL,                    NULL,         0, NULL, NULL, socket_listen_main_single_threaded},
-    {"WEB_SERVER[static]",  NULL,                    NULL,         0, NULL, NULL, socket_listen_main_static_threaded},
+    {"WEB_SERVER[static1]", NULL,                    NULL,         0, NULL, NULL, socket_listen_main_static_threaded},
     {"STREAM",              NULL,                    NULL,         0, NULL, NULL, rrdpush_sender_thread},
     {"STATSD",              NULL,                    NULL,         1, NULL, NULL, statsd_main},
 

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -5,9 +5,9 @@
 static void checks_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -69,9 +69,9 @@ static struct freebsd_module {
 static void freebsd_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -5,9 +5,9 @@
 static void cpuidlejitter_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -3,9 +3,9 @@
 static void macos_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -754,8 +754,6 @@ static void nfacct_send_metrics() {
 static void nfacct_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
 
 #ifdef DO_NFACCT
@@ -765,6 +763,8 @@ static void nfacct_main_cleanup(void *ptr) {
 #ifdef DO_NFSTAT
         nfstat_cleanup();
 #endif
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -67,9 +67,9 @@ static struct proc_module {
 static void proc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -331,9 +331,9 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 static void diskspace_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -833,8 +833,6 @@ static pid_t tc_child_pid = 0;
 static void tc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
 
         if(tc_child_pid) {
@@ -849,6 +847,8 @@ static void tc_main_cleanup(void *ptr) {
 
             tc_child_pid = 0;
         }
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -569,8 +569,6 @@ void *pluginsd_worker_thread(void *arg) {
 static void pluginsd_main_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
 
         struct plugind *cd;
@@ -582,6 +580,7 @@ static void pluginsd_main_cleanup(void *data) {
         }
 
         info("cleanup completed.");
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/registry.c
+++ b/src/registry.c
@@ -27,10 +27,10 @@ static void registry_set_cookie(struct web_client *w, const char *guid) {
     struct tm etmbuf, *etm = gmtime_r(&et, &etmbuf);
     strftime(edate, sizeof(edate), "%a, %d %b %Y %H:%M:%S %Z", etm);
 
-    snprintfz(w->cookie1, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", guid, edate);
+    snprintfz(w->cookie1, NETDATA_WEB_REQUEST_COOKIE_SIZE, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", guid, edate);
 
     if(registry.registry_domain && registry.registry_domain[0])
-        snprintfz(w->cookie2, COOKIE_MAX, NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s", guid, registry.registry_domain, edate);
+        snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE, NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s", guid, registry.registry_domain, edate);
 }
 
 static inline void registry_set_person_cookie(struct web_client *w, REGISTRY_PERSON *p) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -965,6 +965,8 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
 #define POLLINFO_FLAG_CLIENT_SOCKET 0x00000002
 
 struct pollinfo {
+    struct poll *p; // the parent
+
     size_t slot;
     char *client_ip;
     char *client_port;
@@ -1014,6 +1016,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
             p->fds[i].events = 0;
             p->fds[i].revents = 0;
 
+            p->inf[i].p = p;
             p->inf[i].slot = (size_t)i;
             p->inf[i].flags = 0;
             p->inf[i].socktype = -1;
@@ -1043,6 +1046,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
     pf->events = events;
     pf->revents = 0;
 
+    pi->p = p;
     pi->socktype = socktype;
     pi->flags = flags;
     pi->next = NULL;

--- a/src/socket.c
+++ b/src/socket.c
@@ -869,7 +869,8 @@ int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
 #endif
 
     if (flags) {
-        errno = -EINVAL;
+        close(fd);
+        errno = EINVAL;
         return -1;
     }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -1051,7 +1051,7 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
     return pi;
 }
 
-static inline void poll_close_fd(POLLINFO *pi) {
+inline void poll_close_fd(POLLINFO *pi) {
     POLLJOB *p = pi->p;
 
     struct pollfd *pf = &p->fds[pi->slot];

--- a/src/socket.c
+++ b/src/socket.c
@@ -847,7 +847,7 @@ ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) 
 // --------------------------------------------------------------------------------------------------------------------
 // accept4() replacement for systems that do not have one
 
-//#ifndef HAVE_ACCEPT4
+#ifndef HAVE_ACCEPT4
 int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
     int fd = accept(sock, addr, addrlen);
     int newflags = 0;
@@ -882,7 +882,7 @@ int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
 
     return fd;
 }
-//#endif
+#endif
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/socket.c
+++ b/src/socket.c
@@ -961,42 +961,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
 
 #define POLL_FDS_INCREASE_STEP 10
 
-#define POLLINFO_FLAG_SERVER_SOCKET 0x00000001
-#define POLLINFO_FLAG_CLIENT_SOCKET 0x00000002
-
-struct pollinfo {
-    struct poll *p; // the parent
-
-    size_t slot;
-    char *client_ip;
-    char *client_port;
-    struct pollinfo *next;
-    uint32_t flags;
-    int socktype;
-
-    void  (*del_callback)(int fd, int socktype, void *data);
-    int   (*rcv_callback)(int fd, int socktype, void *data, short int *events);
-    int   (*snd_callback)(int fd, int socktype, void *data, short int *events);
-
-    void *data;
-};
-
-struct poll {
-    size_t slots;
-    size_t used;
-    size_t min;
-    size_t max;
-    struct pollfd *fds;
-    struct pollinfo *inf;
-    struct pollinfo *first_free;
-
-    void *(*add_callback)(int fd, int socktype, short int *events, const char *client_ip, const char *client_port);
-    void  (*del_callback)(int fd, int socktype, void *data);
-    int   (*rcv_callback)(int fd, int socktype, void *data, short int *events);
-    int   (*snd_callback)(int fd, int socktype, void *data, short int *events);
-};
-
-static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype, short int events, uint32_t flags, const char *client_ip, const char *client_port) {
+static inline POLLINFO *poll_add_fd(POLLJOB *p, int fd, int socktype, short int events, uint32_t flags, const char *client_ip, const char *client_port) {
     debug(D_POLLFD, "POLLFD: ADD: request to add fd %d, slots = %zu, used = %zu, min = %zu, max = %zu, next free = %zd", fd, p->slots, p->used, p->min, p->max, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
 
     if(unlikely(fd < 0)) return NULL;
@@ -1006,7 +971,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
         debug(D_POLLFD, "POLLFD: ADD: increasing size (current = %zu, new = %zu, used = %zu, min = %zu, max = %zu)", p->slots, new_slots, p->used, p->min, p->max);
 
         p->fds = reallocz(p->fds, sizeof(struct pollfd) * new_slots);
-        p->inf = reallocz(p->inf, sizeof(struct pollinfo) * new_slots);
+        p->inf = reallocz(p->inf, sizeof(POLLINFO) * new_slots);
 
         // reset all the newly added slots
         ssize_t i;
@@ -1036,7 +1001,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
         p->slots = new_slots;
     }
 
-    struct pollinfo *pi = p->first_free;
+    POLLINFO *pi = p->first_free;
     p->first_free = p->first_free->next;
 
     debug(D_POLLFD, "POLLFD: ADD: selected slot %zu, next free is %zd", pi->slot, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
@@ -1046,6 +1011,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
     pf->events = events;
     pf->revents = 0;
 
+    pi->fd = fd;
     pi->p = p;
     pi->socktype = socktype;
     pi->flags = flags;
@@ -1062,7 +1028,7 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
         p->max = pi->slot;
 
     if(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET) {
-        pi->data = p->add_callback(fd, pi->socktype, &pf->events, client_ip, client_port);
+        pi->data = p->add_callback(pi, &pf->events);
     }
 
     if(pi->flags & POLLINFO_FLAG_SERVER_SOCKET) {
@@ -1074,14 +1040,16 @@ static inline struct pollinfo *poll_add_fd(struct poll *p, int fd, int socktype,
     return pi;
 }
 
-static inline void poll_close_fd(struct poll *p, struct pollinfo *pi) {
+static inline void poll_close_fd(POLLINFO *pi) {
+    POLLJOB *p = pi->p;
+
     struct pollfd *pf = &p->fds[pi->slot];
     debug(D_POLLFD, "POLLFD: DEL: request to clear slot %zu (fd %d), old next free was %zd", pi->slot, pf->fd, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
 
     if(unlikely(pf->fd == -1)) return;
 
     if(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET) {
-        pi->del_callback(pf->fd, pi->socktype, pi->data);
+        pi->del_callback(pi);
     }
 
     // info("POLLFD: closing fd %d", pf->fd);
@@ -1090,6 +1058,7 @@ static inline void poll_close_fd(struct poll *p, struct pollinfo *pi) {
     pf->events = 0;
     pf->revents = 0;
 
+    pi->fd = -1;
     pi->socktype = -1;
     pi->flags = 0;
     pi->data = NULL;
@@ -1122,34 +1091,26 @@ static inline void poll_close_fd(struct poll *p, struct pollinfo *pi) {
     debug(D_POLLFD, "POLLFD: DEL: completed, slots = %zu, used = %zu, min = %zu, max = %zu, next free = %zd", p->slots, p->used, p->min, p->max, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
 }
 
-static void *add_callback_default(int fd, int socktype, short int *events, const char *client_ip, const char *client_port) {
-    (void)fd;
-    (void)socktype;
+void *poll_default_add_callback(POLLINFO *pi, short int *events) {
+    (void)pi;
     (void)events;
-    (void)client_ip;
-    (void)client_port;
 
     return NULL;
 }
-static void del_callback_default(int fd, int socktype, void *data) {
-    (void)fd;
-    (void)socktype;
-    (void)data;
 
-    if(data)
+void poll_default_del_callback(POLLINFO *pi) {
+    if(pi->data)
         error("POLLFD: internal error: del_callback_default() called with data pointer - possible memory leak");
 }
 
-static int rcv_callback_default(int fd, int socktype, void *data, short int *events) {
-    (void)socktype;
-    (void)data;
+int poll_default_rcv_callback(POLLINFO *pi, short int *events) {
     (void)events;
 
     char buffer[1024 + 1];
 
     ssize_t rc;
     do {
-        rc = recv(fd, buffer, 1024, MSG_DONTWAIT);
+        rc = recv(pi->fd, buffer, 1024, MSG_DONTWAIT);
         if (rc < 0) {
             // read failed
             if (errno != EWOULDBLOCK && errno != EAGAIN) {
@@ -1158,48 +1119,164 @@ static int rcv_callback_default(int fd, int socktype, void *data, short int *eve
             }
         } else if (rc) {
             // data received
-            info("POLLFD: internal error: discarding %zd bytes received on socket %d", rc, fd);
+            info("POLLFD: internal error: discarding %zd bytes received on socket %d", rc, pi->fd);
         }
     } while (rc != -1);
 
     return 0;
 }
 
-static int snd_callback_default(int fd, int socktype, void *data, short int *events) {
-    (void)socktype;
-    (void)data;
-    (void)events;
-
+int poll_default_snd_callback(POLLINFO *pi, short int *events) {
     *events &= ~POLLOUT;
 
-    info("POLLFD: internal error: nothing to send on socket %d", fd);
+    info("POLLFD: internal error: nothing to send on socket %d", pi->fd);
     return 0;
 }
 
 static void poll_events_cleanup(void *data) {
-    struct poll *p = (struct poll *)data;
+    POLLJOB *p = (POLLJOB *)data;
 
     size_t i;
     for(i = 0 ; i <= p->max ; i++) {
-        struct pollinfo *pi = &p->inf[i];
-        poll_close_fd(p, pi);
+        POLLINFO *pi = &p->inf[i];
+        poll_close_fd(pi);
     }
 
     freez(p->fds);
     freez(p->inf);
 }
 
+static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, short int revents) {
+    short int events = pf->events;
+    int fd = pf->fd;
+    pf->revents = 0;
+    size_t i = pi->slot;
+
+    if(unlikely(fd == -1)) {
+        debug(D_POLLFD, "POLLFD: LISTENER: ignoring slot %zu, it does not have an fd", i);
+        return;
+    }
+
+    debug(D_POLLFD, "POLLFD: LISTENER: processing events for slot %zu (events = %d, revents = %d)", i, events, revents);
+
+    if(revents & POLLIN || revents & POLLPRI) {
+        // receiving data
+
+        if(likely(pi->flags & POLLINFO_FLAG_SERVER_SOCKET)) {
+            // new connection
+            // debug(D_POLLFD, "POLLFD: LISTENER: accepting connections from slot %zu (fd %d)", i, fd);
+
+            switch(pi->socktype) {
+                case SOCK_STREAM: {
+                    // a TCP socket
+                    // we accept the connection
+
+                    int nfd;
+                    do {
+                        char client_ip[NI_MAXHOST + 1];
+                        char client_port[NI_MAXSERV + 1];
+
+                        debug(D_POLLFD, "POLLFD: LISTENER: calling accept4() slot %zu (fd %d)", i, fd);
+                        nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, NI_MAXHOST + 1, client_port, NI_MAXSERV + 1, p->access_list);
+                        if (unlikely(nfd < 0)) {
+                            // accept failed
+
+                            debug(D_POLLFD, "POLLFD: LISTENER: accept4() slot %zu (fd %d) failed.", i, fd);
+
+                            if(errno != EWOULDBLOCK && errno != EAGAIN)
+                                error("POLLFD: LISTENER: accept() failed.");
+
+                            break;
+                        }
+                        else {
+                            // accept ok
+                            // info("POLLFD: LISTENER: client '[%s]:%s' connected to '%s' on fd %d", client_ip, client_port, sockets->fds_names[i], nfd);
+                            poll_add_fd(p, nfd, SOCK_STREAM, POLLIN, POLLINFO_FLAG_CLIENT_SOCKET, client_ip, client_port);
+
+                            // it may have reallocated them, so refresh our pointers
+                            pf = &p->fds[i];
+                            pi = &p->inf[i];
+                        }
+                    } while (nfd >= 0);
+                    break;
+                }
+
+                case SOCK_DGRAM: {
+                    // a UDP socket
+                    // we read data from the server socket
+
+                    debug(D_POLLFD, "POLLFD: LISTENER: reading data from UDP slot %zu (fd %d)", i, fd);
+
+                    // FIXME: access_list is not applied to UDP
+
+                    pf->events = 0;
+                    pi->rcv_callback(pi, &pf->events);
+                    break;
+                }
+
+                default: {
+                    error("POLLFD: LISTENER: Unknown socktype %d on slot %zu", pi->socktype, pi->slot);
+                    break;
+                }
+            }
+        }
+
+        if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
+            // read data from client TCP socket
+            debug(D_POLLFD, "POLLFD: LISTENER: reading data from TCP client slot %zu (fd %d)", i, fd);
+
+            pf->events = 0;
+            if (pi->rcv_callback(pi, &pf->events) == -1) {
+                poll_close_fd(pi);
+                return;
+            }
+        }
+    }
+
+    if(unlikely(revents & POLLOUT)) {
+        // sending data
+        debug(D_POLLFD, "POLLFD: LISTENER: sending data to socket on slot %zu (fd %d)", i, fd);
+
+        pf->events = 0;
+        if (pi->snd_callback(pi, &pf->events) == -1) {
+            poll_close_fd(pi);
+            return;
+        }
+    }
+
+    if(unlikely(revents & POLLERR)) {
+        error("POLLFD: LISTENER: processing POLLERR events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
+        pf->events = 0;
+        poll_close_fd(pi);
+        return;
+    }
+
+    if(unlikely(revents & POLLHUP)) {
+        error("POLLFD: LISTENER: processing POLLHUP events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
+        pf->events = 0;
+        poll_close_fd(pi);
+        return;
+    }
+
+    if(unlikely(revents & POLLNVAL)) {
+        error("POLLFD: LISTENER: processing POLLNVAL events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
+        pf->events = 0;
+        poll_close_fd(pi);
+        return;
+    }
+}
+
 void poll_events(LISTEN_SOCKETS *sockets
-        , void *(*add_callback)(int fd, int socktype, short int *events, const char *client_ip, const char *client_port)
-        , void  (*del_callback)(int fd, int socktype, void *data)
-        , int   (*rcv_callback)(int fd, int socktype, void *data, short int *events)
-        , int   (*snd_callback)(int fd, int socktype, void *data, short int *events)
+        , void *(*add_callback)(POLLINFO *pi, short int *events)
+        , void  (*del_callback)(POLLINFO *pi)
+        , int   (*rcv_callback)(POLLINFO *pi, short int *events)
+        , int   (*snd_callback)(POLLINFO *pi, short int *events)
         , SIMPLE_PATTERN *access_list
         , void *data
 ) {
     int retval;
 
-    struct poll p = {
+    POLLJOB p = {
             .slots = 0,
             .used = 0,
             .max = 0,
@@ -1207,15 +1284,17 @@ void poll_events(LISTEN_SOCKETS *sockets
             .inf = NULL,
             .first_free = NULL,
 
-            .add_callback = add_callback?add_callback:add_callback_default,
-            .del_callback = del_callback?del_callback:del_callback_default,
-            .rcv_callback = rcv_callback?rcv_callback:rcv_callback_default,
-            .snd_callback = snd_callback?snd_callback:snd_callback_default
+            .access_list = access_list,
+
+            .add_callback = add_callback?add_callback:poll_default_add_callback,
+            .del_callback = del_callback?del_callback:poll_default_del_callback,
+            .rcv_callback = rcv_callback?rcv_callback:poll_default_rcv_callback,
+            .snd_callback = snd_callback?snd_callback:poll_default_snd_callback
     };
 
     size_t i;
     for(i = 0; i < sockets->opened ;i++) {
-        struct pollinfo *pi = poll_add_fd(&p, sockets->fds[i], sockets->fds_types[i], POLLIN, POLLINFO_FLAG_SERVER_SOCKET, (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN", "");
+        POLLINFO *pi = poll_add_fd(&p, sockets->fds[i], sockets->fds_types[i], POLLIN, POLLINFO_FLAG_SERVER_SOCKET, (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN", "");
         pi->data = data;
         info("POLLFD: LISTENER: listening on '%s'", (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN");
     }
@@ -1224,9 +1303,7 @@ void poll_events(LISTEN_SOCKETS *sockets
 
     netdata_thread_cleanup_push(poll_events_cleanup, &p);
 
-    for(;;) {
-        if(unlikely(netdata_exit)) break;
-
+    while(!netdata_exit) {
         debug(D_POLLFD, "POLLFD: LISTENER: Waiting on %zu sockets...", p.max + 1);
         retval = poll(p.fds, p.max + 1, timeout);
 
@@ -1243,123 +1320,9 @@ void poll_events(LISTEN_SOCKETS *sockets
 
         for(i = 0 ; i <= p.max ; i++) {
             struct pollfd *pf = &p.fds[i];
-            struct pollinfo *pi = &p.inf[i];
-            int fd = pf->fd;
-            short int events = pf->events, revents = pf->revents;
-            pf->revents = 0;
-
-            if(unlikely(fd == -1)) {
-                debug(D_POLLFD, "POLLFD: LISTENER: ignoring slot %zu, it does not have an fd", i);
-                continue;
-            }
-
-            debug(D_POLLFD, "POLLFD: LISTENER: processing events for slot %zu (events = %d, revents = %d)", i, events, revents);
-
-            if(revents & POLLIN || revents & POLLPRI) {
-                // receiving data
-
-                if(likely(pi->flags & POLLINFO_FLAG_SERVER_SOCKET)) {
-                    // new connection
-                    // debug(D_POLLFD, "POLLFD: LISTENER: accepting connections from slot %zu (fd %d)", i, fd);
-
-                    switch(pi->socktype) {
-                        case SOCK_STREAM: {
-                            // a TCP socket
-                            // we accept the connection
-
-                            int nfd;
-                            do {
-                                char client_ip[NI_MAXHOST + 1];
-                                char client_port[NI_MAXSERV + 1];
-
-                                debug(D_POLLFD, "POLLFD: LISTENER: calling accept4() slot %zu (fd %d)", i, fd);
-                                nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, NI_MAXHOST + 1, client_port, NI_MAXSERV + 1, access_list);
-                                if (unlikely(nfd < 0)) {
-                                    // accept failed
-
-                                    debug(D_POLLFD, "POLLFD: LISTENER: accept4() slot %zu (fd %d) failed.", i, fd);
-
-                                    if(errno != EWOULDBLOCK && errno != EAGAIN)
-                                        error("POLLFD: LISTENER: accept() failed.");
-
-                                    break;
-                                }
-                                else {
-                                    // accept ok
-                                    // info("POLLFD: LISTENER: client '[%s]:%s' connected to '%s' on fd %d", client_ip, client_port, sockets->fds_names[i], nfd);
-                                    poll_add_fd(&p, nfd, SOCK_STREAM, POLLIN, POLLINFO_FLAG_CLIENT_SOCKET, client_ip, client_port);
-
-                                    // it may have reallocated them, so refresh our pointers
-                                    pf = &p.fds[i];
-                                    pi = &p.inf[i];
-                                }
-                            } while (nfd >= 0);
-                            break;
-                        }
-
-                        case SOCK_DGRAM: {
-                            // a UDP socket
-                            // we read data from the server socket
-
-                            debug(D_POLLFD, "POLLFD: LISTENER: reading data from UDP slot %zu (fd %d)", i, fd);
-
-                            // FIXME: access_list is not applied to UDP
-
-                            pf->events = 0;
-                            pi->rcv_callback(fd, pi->socktype, pi->data, &pf->events);
-                            break;
-                        }
-
-                        default: {
-                            error("POLLFD: LISTENER: Unknown socktype %d on slot %zu", pi->socktype, pi->slot);
-                            break;
-                        }
-                    }
-                }
-
-                if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
-                    // read data from client TCP socket
-                    debug(D_POLLFD, "POLLFD: LISTENER: reading data from TCP client slot %zu (fd %d)", i, fd);
-
-                    pf->events = 0;
-                    if (pi->rcv_callback(fd, pi->socktype, pi->data, &pf->events) == -1) {
-                        poll_close_fd(&p, pi);
-                        continue;
-                    }
-                }
-            }
-
-            if(unlikely(revents & POLLOUT)) {
-                // sending data
-                debug(D_POLLFD, "POLLFD: LISTENER: sending data to socket on slot %zu (fd %d)", i, fd);
-
-                pf->events = 0;
-                if (pi->snd_callback(fd, pi->socktype, pi->data, &pf->events) == -1) {
-                    poll_close_fd(&p, pi);
-                    continue;
-                }
-            }
-
-            if(unlikely(revents & POLLERR)) {
-                error("POLLFD: LISTENER: processing POLLERR events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
-                pf->events = 0;
-                poll_close_fd(&p, pi);
-                continue;
-            }
-
-            if(unlikely(revents & POLLHUP)) {
-                error("POLLFD: LISTENER: processing POLLHUP events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
-                pf->events = 0;
-                poll_close_fd(&p, pi);
-                continue;
-            }
-
-            if(unlikely(revents & POLLNVAL)) {
-                error("POLLFD: LISTENER: processing POLLNVAL events for slot %zu fd %d (events = %d, revents = %d)", i, events, revents, fd);
-                pf->events = 0;
-                poll_close_fd(&p, pi);
-                continue;
-            }
+            short int revents = pf->revents;
+            if(unlikely(revents))
+                poll_events_process(&p, &p.inf[i], pf, revents);
         }
     }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -1080,7 +1080,7 @@ static inline void poll_close_fd(struct poll *p, struct pollinfo *pi) {
         pi->del_callback(pf->fd, pi->socktype, pi->data);
     }
 
-    info("POLLFD: closing fd %d", pf->fd);
+    // info("POLLFD: closing fd %d", pf->fd);
     close(pf->fd);
     pf->fd = -1;
     pf->events = 0;
@@ -1282,7 +1282,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                                 }
                                 else {
                                     // accept ok
-                                    info("POLLFD: LISTENER: client '[%s]:%s' connected to '%s' on fd %d", client_ip, client_port, sockets->fds_names[i], nfd);
+                                    // info("POLLFD: LISTENER: client '[%s]:%s' connected to '%s' on fd %d", client_ip, client_port, sockets->fds_names[i], nfd);
                                     poll_add_fd(&p, nfd, SOCK_STREAM, POLLIN, POLLINFO_FLAG_CLIENT_SOCKET, client_ip, client_port);
 
                                     // it may have reallocated them, so refresh our pointers

--- a/src/socket.h
+++ b/src/socket.h
@@ -19,6 +19,8 @@ typedef struct listen_sockets {
     int fds_families[MAX_LISTEN_FDS];   // the family of the open sockets (AF_UNIX, AF_INET, AF_INET6)
 } LISTEN_SOCKETS;
 
+extern char *strdup_client_description(int family, const char *protocol, const char *ip, int port);
+
 extern int listen_sockets_setup(LISTEN_SOCKETS *sockets);
 extern void listen_sockets_close(LISTEN_SOCKETS *sockets);
 
@@ -52,7 +54,7 @@ extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flag
 
 
 extern void poll_events(LISTEN_SOCKETS *sockets
-        , void *(*add_callback)(int fd, int socktype, short int *events)
+        , void *(*add_callback)(int fd, int socktype, short int *events, const char *client_ip, const char *client_port)
         , void  (*del_callback)(int fd, int socktype, void *data)
         , int   (*rcv_callback)(int fd, int socktype, void *data, short int *events)
         , int   (*snd_callback)(int fd, int socktype, void *data, short int *events)

--- a/src/socket.h
+++ b/src/socket.h
@@ -96,7 +96,7 @@ typedef struct poll {
 
     SIMPLE_PATTERN *access_list;
 
-    void *(*add_callback)(POLLINFO *pi, short int *events);
+    void *(*add_callback)(POLLINFO *pi, short int *events, void *data);
     void  (*del_callback)(POLLINFO *pi);
     int   (*rcv_callback)(POLLINFO *pi, short int *events);
     int   (*snd_callback)(POLLINFO *pi, short int *events);
@@ -105,10 +105,23 @@ typedef struct poll {
 extern int poll_default_snd_callback(POLLINFO *pi, short int *events);
 extern int poll_default_rcv_callback(POLLINFO *pi, short int *events);
 extern void poll_default_del_callback(POLLINFO *pi);
-extern void *poll_default_add_callback(POLLINFO *pi, short int *events);
+extern void *poll_default_add_callback(POLLINFO *pi, short int *events, void *data);
+
+extern POLLINFO *poll_add_fd(POLLJOB *p
+                             , int fd
+                             , int socktype
+                             , uint32_t flags
+                             , const char *client_ip
+                             , const char *client_port
+                             , void *(*add_callback)(POLLINFO *pi, short int *events, void *data)
+                             , void  (*del_callback)(POLLINFO *pi)
+                             , int   (*rcv_callback)(POLLINFO *pi, short int *events)
+                             , int   (*snd_callback)(POLLINFO *pi, short int *events)
+                             , void *data
+);
 
 extern void poll_events(LISTEN_SOCKETS *sockets
-        , void *(*add_callback)(POLLINFO *pi, short int *events)
+        , void *(*add_callback)(POLLINFO *pi, short int *events, void *data)
         , void  (*del_callback)(POLLINFO *pi)
         , int   (*rcv_callback)(POLLINFO *pi, short int *events)
         , int   (*snd_callback)(POLLINFO *pi, short int *events)

--- a/src/socket.h
+++ b/src/socket.h
@@ -119,6 +119,7 @@ extern POLLINFO *poll_add_fd(POLLJOB *p
                              , int   (*snd_callback)(POLLINFO *pi, short int *events)
                              , void *data
 );
+extern void poll_close_fd(POLLINFO *pi);
 
 extern void poll_events(LISTEN_SOCKETS *sockets
         , void *(*add_callback)(POLLINFO *pi, short int *events, void *data)

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1970,8 +1970,6 @@ static int statsd_listen_sockets_setup(void) {
 static void statsd_main_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
 
         if (statsd.collection_threads) {
@@ -1986,6 +1984,7 @@ static void statsd_main_cleanup(void *data) {
         listen_sockets_close(&statsd.sockets);
 
         info("STATSD: cleanup completed.");
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -697,28 +697,23 @@ struct statsd_udp {
 #endif
 
 // new TCP client connected
-static void *statsd_add_callback(int fd, int socktype, short int *events, const char *client_ip, const char *client_port) {
-    (void)fd;
-    (void)socktype;
-    (void)client_ip;
-    (void)client_port;
+static void *statsd_add_callback(POLLINFO *pi, short int *events) {
+    (void)pi;
 
     *events = POLLIN;
 
-    struct statsd_tcp *data = (struct statsd_tcp *)callocz(sizeof(struct statsd_tcp) + STATSD_TCP_BUFFER_SIZE, 1);
-    data->type = STATSD_SOCKET_DATA_TYPE_TCP;
-    data->size = STATSD_TCP_BUFFER_SIZE - 1;
+    struct statsd_tcp *t = (struct statsd_tcp *)callocz(sizeof(struct statsd_tcp) + STATSD_TCP_BUFFER_SIZE, 1);
+    t->type = STATSD_SOCKET_DATA_TYPE_TCP;
+    t->size = STATSD_TCP_BUFFER_SIZE - 1;
 
-    return data;
+    return t;
 }
 
 // TCP client disconnected
-static void statsd_del_callback(int fd, int socktype, void *data) {
-    (void)fd;
-    (void)socktype;
+static void statsd_del_callback(POLLINFO *pi) {
+    struct statsd_tcp *t = pi->data;
 
-    if(data) {
-        struct statsd_tcp *t = data;
+    if(likely(t)) {
         if(t->type == STATSD_SOCKET_DATA_TYPE_TCP) {
             if(t->len != 0) {
                 statsd.socket_errors++;
@@ -729,17 +724,19 @@ static void statsd_del_callback(int fd, int socktype, void *data) {
         else
             error("STATSD: internal error: received socket data type is %d, but expected %d", (int)t->type, (int)STATSD_SOCKET_DATA_TYPE_TCP);
 
-        freez(data);
+        freez(t);
     }
 }
 
 // Receive data
-static int statsd_rcv_callback(int fd, int socktype, void *data, short int *events) {
+static int statsd_rcv_callback(POLLINFO *pi, short int *events) {
     *events = POLLIN;
 
-    switch(socktype) {
+    int fd = pi->fd;
+
+    switch(pi->socktype) {
         case SOCK_STREAM: {
-            struct statsd_tcp *d = (struct statsd_tcp *)data;
+            struct statsd_tcp *d = (struct statsd_tcp *)pi->data;
             if(unlikely(!d)) {
                 error("STATSD: internal error: expected TCP data pointer is NULL");
                 statsd.socket_errors++;
@@ -791,7 +788,7 @@ static int statsd_rcv_callback(int fd, int socktype, void *data, short int *even
         }
 
         case SOCK_DGRAM: {
-            struct statsd_udp *d = (struct statsd_udp *)data;
+            struct statsd_udp *d = (struct statsd_udp *)pi->data;
             if(unlikely(!d)) {
                 error("STATSD: internal error: expected UDP data pointer is NULL");
                 statsd.socket_errors++;
@@ -856,7 +853,7 @@ static int statsd_rcv_callback(int fd, int socktype, void *data, short int *even
         }
 
         default: {
-            error("STATSD: internal error: unknown socktype %d on socket %d", socktype, fd);
+            error("STATSD: internal error: unknown socktype %d on socket %d", pi->socktype, fd);
             statsd.socket_errors++;
             return -1;
         }
@@ -865,10 +862,8 @@ static int statsd_rcv_callback(int fd, int socktype, void *data, short int *even
     return 0;
 }
 
-static int statsd_snd_callback(int fd, int socktype, void *data, short int *events) {
-    (void)fd;
-    (void)socktype;
-    (void)data;
+static int statsd_snd_callback(POLLINFO *pi, short int *events) {
+    (void)pi;
     (void)events;
 
     error("STATSD: snd_callback() called, but we never requested to send data to statsd clients.");

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -697,8 +697,9 @@ struct statsd_udp {
 #endif
 
 // new TCP client connected
-static void *statsd_add_callback(POLLINFO *pi, short int *events) {
+static void *statsd_add_callback(POLLINFO *pi, short int *events, void *data) {
     (void)pi;
+    (void)data;
 
     *events = POLLIN;
 

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -697,9 +697,12 @@ struct statsd_udp {
 #endif
 
 // new TCP client connected
-static void *statsd_add_callback(int fd, int socktype, short int *events) {
+static void *statsd_add_callback(int fd, int socktype, short int *events, const char *client_ip, const char *client_port) {
     (void)fd;
     (void)socktype;
+    (void)client_ip;
+    (void)client_port;
+
     *events = POLLIN;
 
     struct statsd_tcp *data = (struct statsd_tcp *)callocz(sizeof(struct statsd_tcp) + STATSD_TCP_BUFFER_SIZE, 1);

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2677,9 +2677,9 @@ void update_cgroup_charts(int update_every) {
 static void cgroup_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     if(static_thread->enabled) {
-        static_thread->enabled = 0;
-
         info("cleaning up...");
+
+        static_thread->enabled = 0;
     }
 }
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -532,14 +532,14 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 }
 
 static inline void cgroup_read_blkio(struct blkio *io) {
-    static procfile *ff = NULL;
-
     if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0)) {
         io->delay_counter--;
         return;
     }
 
     if(likely(io->filename)) {
+        static procfile *ff = NULL;
+
         ff = procfile_reopen(ff, io->filename, NULL, PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) {
             io->updated = 0;

--- a/src/web_buffer.h
+++ b/src/web_buffer.h
@@ -47,8 +47,6 @@ typedef struct web_buffer {
 #define buffer_strlen(wb) ((wb)->len)
 extern const char *buffer_tostring(BUFFER *wb);
 
-#define buffer_need_bytes(buffer, needed_free_size) do { if(unlikely((buffer)->size - (buffer)->len < (size_t)(needed_free_size))) buffer_increase((buffer), (size_t)(needed_free_size)); } while(0)
-
 #define buffer_flush(wb) wb->buffer[(wb)->len = 0] = '\0'
 extern void buffer_reset(BUFFER *wb);
 
@@ -74,5 +72,10 @@ extern char *print_number_llu_r(char *str, unsigned long long uvalue);
 extern char *print_number_llu_r_smart(char *str, unsigned long long uvalue);
 
 extern void buffer_print_llu(BUFFER *wb, unsigned long long uvalue);
+
+static inline void buffer_need_bytes(BUFFER *buffer, size_t needed_free_size) {
+    if(unlikely(buffer->size - buffer->len < needed_free_size))
+        buffer_increase(buffer, needed_free_size);
+}
 
 #endif /* NETDATA_WEB_BUFFER_H */

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -98,7 +98,6 @@ static void web_client_fix_socket(struct web_client *w) {
     w->origin[0] = '*';
     web_client_enable_wait_receive(w);
 
-    web_client_connected();
     log_connection(w, "CONNECTED");
 }
 

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -81,14 +81,14 @@ static void web_client_update_acl_matches(struct web_client *w) {
         w->acl |= WEB_CLIENT_ACL_BADGE;
 }
 
-static void web_client_fix_socket(struct web_client *w) {
+static void web_client_initialize_connection(struct web_client *w) {
     int flag = 1;
     if(setsockopt(w->ifd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: failed to enable TCP_NODELAY on socket fd %d.", w->id, w->ofd);
+        error("%llu: failed to enable TCP_NODELAY on socket fd %d.", w->id, w->ifd);
 
     flag = 1;
     if(setsockopt(w->ifd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: Cannot set SO_KEEPALIVE on socket fd %d.", w->id, w->ifd);
+        error("%llu: failed to enable SO_KEEPALIVE on socket fd %d.", w->id, w->ifd);
 
     web_client_update_acl_matches(w);
 
@@ -115,7 +115,7 @@ struct web_client *web_client_create_on_fd(int fd, const char *client_ip, const 
     if(unlikely(!*w->client_ip))   strcpy(w->client_ip,   "-");
     if(unlikely(!*w->client_port)) strcpy(w->client_port, "-");
 
-    web_client_fix_socket(w);
+    web_client_initialize_connection(w);
     return(w);
 }
 
@@ -144,7 +144,7 @@ struct web_client *web_client_create_on_listenfd(int listener) {
         return NULL;
     }
 
-    web_client_fix_socket(w);
+    web_client_initialize_connection(w);
     return(w);
 }
 

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1778,7 +1778,10 @@ ssize_t web_client_receive(struct web_client *w)
             web_client_disable_wait_receive(w);
 
             debug(D_WEB_CLIENT, "%llu: Read the whole file.", w->id);
-            if(w->ifd != w->ofd) close(w->ifd);
+
+            if(w->ifd != w->ofd && web_server_mode != WEB_SERVER_MODE_STATIC_THREADED)
+                close(w->ifd);
+
             w->ifd = w->ofd;
         }
         else {

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1,25 +1,22 @@
 #include "common.h"
 
-#define INITIAL_WEB_DATA_LENGTH 16384
-#define WEB_REQUEST_LENGTH 16384
-#define TOO_BIG_REQUEST 16384
+// this is an async I/O implementation of the web server request parser
+// it is used by all netdata web servers
 
-int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
 int respect_web_browser_do_not_track_policy = 0;
 char *web_x_frame_options = NULL;
-
-SIMPLE_PATTERN *web_allow_connections_from = NULL;
-SIMPLE_PATTERN *web_allow_streaming_from = NULL;
-SIMPLE_PATTERN *web_allow_netdataconf_from = NULL;
-
-// WEB_CLIENT_ACL
-SIMPLE_PATTERN *web_allow_dashboard_from = NULL;
-SIMPLE_PATTERN *web_allow_registry_from = NULL;
-SIMPLE_PATTERN *web_allow_badges_from = NULL;
 
 #ifdef NETDATA_WITH_ZLIB
 int web_enable_gzip = 1, web_gzip_level = 3, web_gzip_strategy = Z_DEFAULT_STRATEGY;
 #endif /* NETDATA_WITH_ZLIB */
+
+inline int web_client_permission_denied(struct web_client *w) {
+    w->response.data->contenttype = CT_TEXT_PLAIN;
+    buffer_flush(w->response.data);
+    buffer_strcat(w->response.data, "You are not allowed to access this resource.");
+    w->response.code = 403;
+    return 403;
+}
 
 static inline int web_client_crock_socket(struct web_client *w) {
 #ifdef TCP_CORK
@@ -54,240 +51,6 @@ static inline int web_client_uncrock_socket(struct web_client *w) {
 #endif /* TCP_CORK */
 
     return 0;
-}
-
-inline int web_client_permission_denied(struct web_client *w) {
-    w->response.data->contenttype = CT_TEXT_PLAIN;
-    buffer_flush(w->response.data);
-    buffer_strcat(w->response.data, "You are not allowed to access this resource.");
-    w->response.code = 403;
-    return 403;
-}
-
-static void log_connection(struct web_client *w, const char *msg) {
-    log_access("%llu: %d '[%s]:%s' '%s'", w->id, gettid(), w->client_ip, w->client_port, msg);
-}
-
-static void web_client_update_acl_matches(struct web_client *w) {
-    w->acl = WEB_CLIENT_ACL_NONE;
-
-    if(!web_allow_dashboard_from || simple_pattern_matches(web_allow_dashboard_from, w->client_ip))
-        w->acl |= WEB_CLIENT_ACL_DASHBOARD;
-
-    if(!web_allow_registry_from || simple_pattern_matches(web_allow_registry_from, w->client_ip))
-        w->acl |= WEB_CLIENT_ACL_REGISTRY;
-
-    if(!web_allow_badges_from || simple_pattern_matches(web_allow_badges_from, w->client_ip))
-        w->acl |= WEB_CLIENT_ACL_BADGE;
-}
-
-static void web_client_initialize_connection(struct web_client *w) {
-    int flag = 1;
-    if(setsockopt(w->ifd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: failed to enable TCP_NODELAY on socket fd %d.", w->id, w->ifd);
-
-    flag = 1;
-    if(setsockopt(w->ifd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: failed to enable SO_KEEPALIVE on socket fd %d.", w->id, w->ifd);
-
-    web_client_update_acl_matches(w);
-
-    w->origin[0] = '*'; w->origin[1] = '\0';
-    web_client_enable_wait_receive(w);
-
-    log_connection(w, "CONNECTED");
-}
-
-struct clients_cache {
-    struct web_client *used;
-    size_t used_count;
-
-    struct web_client *avail;
-    size_t avail_count;
-};
-
-__thread struct clients_cache web_clients_cache = {
-        .used = 0,
-        .used_count = 0,
-
-        .avail = 0,
-        .avail_count = 0
-};
-
-static void web_client_free(struct web_client *w) {
-    buffer_free(w->response.header_output);
-    buffer_free(w->response.header);
-    buffer_free(w->response.data);
-    freez(w);
-}
-
-void web_client_cache_destroy(void) {
-    struct web_client *w, *t;
-
-    w = web_clients_cache.used;
-    while(w) {
-        t = w;
-        w = w->next;
-        web_client_free(t);
-    }
-    web_clients_cache.used = NULL;
-    web_clients_cache.used_count = 0;
-
-    w = web_clients_cache.avail;
-    while(w) {
-        t = w;
-        w = w->next;
-        web_client_free(t);
-    }
-    web_clients_cache.avail = NULL;
-    web_clients_cache.avail_count = 0;
-}
-
-void web_client_multi_threaded_web_server_stop_all_threads(void) {
-    struct web_client *w;
-
-    int found = 1, max = 2 * USEC_PER_SEC, step = 50000;
-    for(w = web_clients_cache.used; w ; w = w->next) {
-        if(w->running) {
-            found++;
-            info("stopping web client %s, id %llu", w->client_ip, w->id);
-            netdata_thread_cancel(w->thread);
-        }
-    }
-
-    while(found && max > 0) {
-        max -= step;
-        info("Waiting %d web threads to finish...", found);
-        sleep_usec(step);
-        found = 0;
-        for(w = web_clients_cache.used; w ; w = w->next)
-            if(w->running) found++;
-    }
-
-    if(found)
-        error("%d web threads are taking too long to finish. Giving up.", found);
-}
-
-static void web_client_return_to_cache_or_free(struct web_client *w) {
-    // unlink it from the used;
-    if (w == web_clients_cache.used) web_clients_cache.used = w->next;
-    if(w->prev) w->prev->next = w->next;
-    if(w->next) w->next->prev = w->prev;
-    web_clients_cache.used_count--;
-
-    if(web_clients_cache.avail_count > 100) {
-        // we have too many of them - free it
-        web_client_free(w);
-    }
-    else {
-        // link it to the avail
-        if (web_clients_cache.avail) web_clients_cache.avail->prev = w;
-        w->next                 = web_clients_cache.avail;
-        w->prev                 = NULL;
-        web_clients_cache.avail = w;
-        web_clients_cache.avail_count++;
-    }
-}
-
-static struct web_client *web_client_get_from_cache_or_allocate() {
-    struct web_client *w = web_clients_cache.avail;
-
-    if(w) {
-        // unlink it from avail
-        if (w == web_clients_cache.avail) web_clients_cache.avail = w->next;
-        if(w->prev) w->prev->next = w->next;
-        if(w->next) w->next->prev = w->prev;
-        web_clients_cache.avail_count--;
-
-        // zero everything about it - but keep the buffers
-
-        BUFFER *b1 = w->response.data;
-        BUFFER *b2 = w->response.header;
-        BUFFER *b3 = w->response.header_output;
-
-        buffer_flush(b1);
-        buffer_flush(b2);
-        buffer_flush(b3);
-
-        memset(w, 0, sizeof(struct web_client));
-
-        w->response.data = b1;
-        w->response.header = b2;
-        w->response.header_output = b3;
-    }
-    else {
-        w = callocz(1, sizeof(struct web_client));
-        w->response.data = buffer_create(INITIAL_WEB_DATA_LENGTH);
-        w->response.header = buffer_create(HTTP_RESPONSE_HEADER_SIZE);
-        w->response.header_output = buffer_create(HTTP_RESPONSE_HEADER_SIZE);
-    }
-
-    // link it to used web clients
-    if (web_clients_cache.used) web_clients_cache.used->prev = w;
-    w->next = web_clients_cache.used;
-    w->prev = NULL;
-    web_clients_cache.used = w;
-    web_clients_cache.used_count++;
-
-    // initialize it
-    w->id = web_client_connected();
-    w->mode = WEB_CLIENT_MODE_NORMAL;
-    return w;
-}
-
-void web_client_release(struct web_client *w) {
-    debug(D_WEB_CLIENT_ACCESS, "%llu: Closing web client from %s port %s.", w->id, w->client_ip, w->client_port);
-
-    web_client_request_done(w);
-    web_client_disconnected();
-
-    if(web_server_mode != WEB_SERVER_MODE_STATIC_THREADED) {
-        if (w->ifd != -1) close(w->ifd);
-        if (w->ofd != -1 && w->ofd != w->ifd) close(w->ofd);
-    }
-
-    web_client_return_to_cache_or_free(w);
-}
-
-struct web_client *web_client_create_on_fd(int fd, const char *client_ip, const char *client_port) {
-    struct web_client *w;
-
-    w = web_client_get_from_cache_or_allocate();
-    w->ifd = w->ofd = fd;
-
-    strncpyz(w->client_ip, client_ip, sizeof(w->client_ip) - 1);
-    strncpyz(w->client_port, client_port, sizeof(w->client_port) - 1);
-
-    if(unlikely(!*w->client_ip))   strcpy(w->client_ip,   "-");
-    if(unlikely(!*w->client_port)) strcpy(w->client_port, "-");
-
-    web_client_initialize_connection(w);
-    return(w);
-}
-
-struct web_client *web_client_create_on_listenfd(int listener) {
-    struct web_client *w;
-
-    w = web_client_get_from_cache_or_allocate();
-    w->ifd = w->ofd = accept_socket(listener, SOCK_NONBLOCK, w->client_ip, sizeof(w->client_ip), w->client_port, sizeof(w->client_port), web_allow_connections_from);
-
-    if(unlikely(!*w->client_ip))   strcpy(w->client_ip,   "-");
-    if(unlikely(!*w->client_port)) strcpy(w->client_port, "-");
-
-    if (w->ifd == -1) {
-        if(errno == EPERM)
-            log_connection(w, "ACCESS DENIED");
-        else {
-            log_connection(w, "CONNECTION FAILED");
-            error("%llu: Failed to accept new incoming connection.", w->id);
-        }
-
-        web_client_release(w);
-        return NULL;
-    }
-
-    web_client_initialize_connection(w);
-    return(w);
 }
 
 void web_client_request_done(struct web_client *w) {
@@ -999,7 +762,7 @@ static inline char *http_header_parse(struct web_client *w, char *s) {
     uint32_t hash = simple_uhash(s);
 
     if(hash == hash_origin && !strcasecmp(s, "Origin"))
-        strncpyz(w->origin, v, ORIGIN_MAX);
+        strncpyz(w->origin, v, NETDATA_WEB_REQUEST_ORIGIN_HEADER_SIZE);
 
     else if(hash == hash_connection && !strcasecmp(s, "Connection")) {
         if(strcasestr(v, "keep-alive"))
@@ -1096,12 +859,12 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // a valid complete HTTP request found
 
                 *ue = '\0';
-                url_decode_r(w->decoded_url, encoded_url, URL_MAX + 1);
+                url_decode_r(w->decoded_url, encoded_url, NETDATA_WEB_REQUEST_URL_SIZE + 1);
                 *ue = ' ';
                 
                 // copy the URL - we are going to overwrite parts of it
                 // FIXME -- we should avoid it
-                strncpyz(w->last_url, w->decoded_url, URL_MAX);
+                strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
 
                 web_client_disable_wait_receive(w);
                 return HTTP_VALIDATION_OK;
@@ -1290,7 +1053,7 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
 
         // copy the URL, we need it to serve files
         w->last_url[0] = '/';
-        if(url && *url) strncpyz(&w->last_url[1], url, URL_MAX - 1);
+        if(url && *url) strncpyz(&w->last_url[1], url, NETDATA_WEB_REQUEST_URL_SIZE - 1);
         else w->last_url[1] = '\0';
 
         uint32_t hash = simple_hash(tok);
@@ -1506,7 +1269,7 @@ void web_client_process_request(struct web_client *w) {
             break;
 
         case HTTP_VALIDATION_INCOMPLETE:
-            if(w->response.data->len > TOO_BIG_REQUEST) {
+            if(w->response.data->len > NETDATA_WEB_REQUEST_MAX_SIZE) {
                 strcpy(w->last_url, "too big request");
 
                 debug(D_WEB_CLIENT_ACCESS, "%llu: Received request is too big (%zu bytes).", w->id, w->response.data->len);
@@ -1714,7 +1477,7 @@ ssize_t web_client_send_deflate(struct web_client *w)
 
         // reset the compressor output buffer
         w->response.zstream.next_out = w->response.zbuffer;
-        w->response.zstream.avail_out = ZLIB_CHUNK;
+        w->response.zstream.avail_out = NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE;
 
         // ask for FINISH if we have all the input
         int flush = Z_SYNC_FLUSH;
@@ -1734,7 +1497,7 @@ ssize_t web_client_send_deflate(struct web_client *w)
             return(-1);
         }
 
-        w->response.zhave = ZLIB_CHUNK - w->response.zstream.avail_out;
+        w->response.zhave = NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE - w->response.zstream.avail_out;
         w->response.zsent = 0;
 
         // keep track of the bytes passed through the compressor
@@ -1880,7 +1643,7 @@ ssize_t web_client_receive(struct web_client *w)
         return web_client_read_file(w);
 
     // do we have any space for more data?
-    buffer_need_bytes(w->response.data, WEB_REQUEST_LENGTH);
+    buffer_need_bytes(w->response.data, NETDATA_WEB_REQUEST_RECEIVE_SIZE);
 
     ssize_t left = w->response.data->size - w->response.data->len;
     ssize_t bytes = recv(w->ifd, &w->response.data->buffer[w->response.data->len], (size_t) (left - 1), MSG_DONTWAIT);
@@ -1901,160 +1664,4 @@ ssize_t web_client_receive(struct web_client *w)
     }
 
     return(bytes);
-}
-
-// --------------------------------------------------------------------------------------
-// the thread of a single client - for the MULTI-THREADED web server
-
-// 1. waits for input and output, using async I/O
-// 2. it processes HTTP requests
-// 3. it generates HTTP responses
-// 4. it copies data from input to output if mode is FILECOPY
-
-static void web_client_main_cleanup(void *ptr) {
-    struct web_client *w = ptr;
-
-    if(!web_client_check_obsolete(w)) {
-        WEB_CLIENT_IS_OBSOLETE(w);
-    }
-
-    w->running = 0;
-}
-
-void *web_client_main(void *ptr) {
-    netdata_thread_cleanup_push(web_client_main_cleanup, ptr);
-
-    struct web_client *w = ptr;
-    w->running = 1;
-
-    struct pollfd fds[2], *ifd, *ofd;
-    int retval, timeout;
-    nfds_t fdmax = 0;
-
-    while(!netdata_exit) {
-        if(unlikely(web_client_check_dead(w))) {
-            debug(D_WEB_CLIENT, "%llu: client is dead.", w->id);
-            break;
-        }
-        else if(unlikely(!web_client_has_wait_receive(w) && !web_client_has_wait_send(w))) {
-            debug(D_WEB_CLIENT, "%llu: client is not set for neither receiving nor sending data.", w->id);
-            break;
-        }
-
-        if(unlikely(w->ifd < 0 || w->ofd < 0)) {
-            error("%llu: invalid file descriptor, ifd = %d, ofd = %d (required 0 <= fd", w->id, w->ifd, w->ofd);
-            break;
-        }
-
-        if(w->ifd == w->ofd) {
-            fds[0].fd = w->ifd;
-            fds[0].events = 0;
-            fds[0].revents = 0;
-
-            if(web_client_has_wait_receive(w)) fds[0].events |= POLLIN;
-            if(web_client_has_wait_send(w))    fds[0].events |= POLLOUT;
-
-            fds[1].fd = -1;
-            fds[1].events = 0;
-            fds[1].revents = 0;
-
-            ifd = ofd = &fds[0];
-
-            fdmax = 1;
-        }
-        else {
-            fds[0].fd = w->ifd;
-            fds[0].events = 0;
-            fds[0].revents = 0;
-            if(web_client_has_wait_receive(w)) fds[0].events |= POLLIN;
-            ifd = &fds[0];
-
-            fds[1].fd = w->ofd;
-            fds[1].events = 0;
-            fds[1].revents = 0;
-            if(web_client_has_wait_send(w))    fds[1].events |= POLLOUT;
-            ofd = &fds[1];
-
-            fdmax = 2;
-        }
-
-        debug(D_WEB_CLIENT, "%llu: Waiting socket async I/O for %s %s", w->id, web_client_has_wait_receive(w)?"INPUT":"", web_client_has_wait_send(w)?"OUTPUT":"");
-        errno = 0;
-        timeout = web_client_timeout * 1000;
-        retval = poll(fds, fdmax, timeout);
-
-        if(unlikely(netdata_exit)) break;
-
-        if(unlikely(retval == -1)) {
-            if(errno == EAGAIN || errno == EINTR) {
-                debug(D_WEB_CLIENT, "%llu: EAGAIN received.", w->id);
-                continue;
-            }
-
-            debug(D_WEB_CLIENT, "%llu: LISTENER: poll() failed (input fd = %d, output fd = %d). Closing client.", w->id, w->ifd, w->ofd);
-            break;
-        }
-        else if(unlikely(!retval)) {
-            debug(D_WEB_CLIENT, "%llu: Timeout while waiting socket async I/O for %s %s", w->id, web_client_has_wait_receive(w)?"INPUT":"", web_client_has_wait_send(w)?"OUTPUT":"");
-            break;
-        }
-
-        if(unlikely(netdata_exit)) break;
-
-        int used = 0;
-        if(web_client_has_wait_send(w) && ofd->revents & POLLOUT) {
-            used++;
-            if(web_client_send(w) < 0) {
-                debug(D_WEB_CLIENT, "%llu: Cannot send data to client. Closing client.", w->id);
-                break;
-            }
-        }
-
-        if(unlikely(netdata_exit)) break;
-
-        if(web_client_has_wait_receive(w) && (ifd->revents & POLLIN || ifd->revents & POLLPRI)) {
-            used++;
-            if(web_client_receive(w) < 0) {
-                debug(D_WEB_CLIENT, "%llu: Cannot receive data from client. Closing client.", w->id);
-                break;
-            }
-
-            if(w->mode == WEB_CLIENT_MODE_NORMAL) {
-                debug(D_WEB_CLIENT, "%llu: Attempting to process received data.", w->id);
-                web_client_process_request(w);
-
-                // if the sockets are closed, may have transferred this client
-                // to plugins.d
-                if(unlikely(w->mode == WEB_CLIENT_MODE_STREAM))
-                    break;
-            }
-        }
-
-        if(unlikely(!used)) {
-            debug(D_WEB_CLIENT_ACCESS, "%llu: Received error on socket.", w->id);
-            break;
-        }
-    }
-
-    if(w->mode != WEB_CLIENT_MODE_STREAM)
-        log_connection(w, "DISCONNECTED");
-
-            web_client_request_done(w);
-
-    debug(D_WEB_CLIENT, "%llu: done...", w->id);
-
-    // close the sockets/files now
-    // to free file descriptors
-    if(w->ifd == w->ofd) {
-        if(w->ifd != -1) close(w->ifd);
-    }
-    else {
-        if(w->ifd != -1) close(w->ifd);
-        if(w->ofd != -1) close(w->ofd);
-    }
-    w->ifd = -1;
-    w->ofd = -1;
-
-    netdata_thread_cleanup_pop(1);
-    return NULL;
 }

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -174,7 +174,8 @@ extern uid_t web_files_gid(void);
 
 extern int web_client_permission_denied(struct web_client *w);
 
-extern struct web_client *web_client_create(int listener);
+extern struct web_client *web_client_create_on_fd(int fd, const char *client_ip, const char *client_port);
+extern struct web_client *web_client_create_on_listenfd(int listener);
 extern struct web_client *web_client_free(struct web_client *w);
 extern ssize_t web_client_send(struct web_client *w);
 extern ssize_t web_client_receive(struct web_client *w);

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -1,9 +1,6 @@
 #ifndef NETDATA_WEB_CLIENT_H
 #define NETDATA_WEB_CLIENT_H 1
 
-#define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
-extern int web_client_timeout;
-
 #ifdef NETDATA_WITH_ZLIB
 extern int web_enable_gzip,
         web_gzip_level,
@@ -21,10 +18,6 @@ typedef enum web_client_mode {
 } WEB_CLIENT_MODE;
 
 typedef enum web_client_flags {
-    WEB_CLIENT_FLAG_OBSOLETE          = 1 << 0, // if set, the listener will remove this client
-    // after setting this, you should not touch
-    // this web_client
-
     WEB_CLIENT_FLAG_DEAD              = 1 << 1, // if set, this client is dead
 
     WEB_CLIENT_FLAG_KEEPALIVE         = 1 << 2, // if set, the web client will be re-used
@@ -48,9 +41,6 @@ typedef enum web_client_flags {
 #define web_client_flag_set(w, flag)   (w)->flags |= flag
 #define web_client_flag_clear(w, flag) (w)->flags &= ~flag
 //#endif
-
-#define WEB_CLIENT_IS_OBSOLETE(w) web_client_flag_set(w, WEB_CLIENT_FLAG_OBSOLETE)
-#define web_client_check_obsolete(w) web_client_flag_check(w, WEB_CLIENT_FLAG_OBSOLETE)
 
 #define WEB_CLIENT_IS_DEAD(w) web_client_flag_set(w, WEB_CLIENT_FLAG_DEAD)
 #define web_client_check_dead(w) web_client_flag_check(w, WEB_CLIENT_FLAG_DEAD)
@@ -81,11 +71,14 @@ typedef enum web_client_flags {
 
 #define web_client_is_corkable(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 
-#define URL_MAX 8192
-#define ZLIB_CHUNK  16384
-#define HTTP_RESPONSE_HEADER_SIZE 4096
-#define COOKIE_MAX 1024
-#define ORIGIN_MAX 1024
+#define NETDATA_WEB_REQUEST_URL_SIZE 8192
+#define NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE 16384
+#define NETDATA_WEB_RESPONSE_HEADER_SIZE 4096
+#define NETDATA_WEB_REQUEST_COOKIE_SIZE 1024
+#define NETDATA_WEB_REQUEST_ORIGIN_HEADER_SIZE 1024
+#define NETDATA_WEB_RESPONSE_INITIAL_SIZE 16384
+#define NETDATA_WEB_REQUEST_RECEIVE_SIZE 16384
+#define NETDATA_WEB_REQUEST_MAX_SIZE 16384
 
 struct response {
     BUFFER *header;                 // our response header
@@ -100,7 +93,7 @@ struct response {
     int zoutput;                    // if set to 1, web_client_send() will send compressed data
 #ifdef NETDATA_WITH_ZLIB
     z_stream zstream;               // zlib stream for sending compressed output to client
-    Bytef zbuffer[ZLIB_CHUNK];      // temporary buffer for storing compressed output
+    Bytef zbuffer[NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE]; // temporary buffer for storing compressed output
     size_t zsent;                   // the compressed bytes we have sent to the client
     size_t zhave;                   // the compressed bytes that we have received from zlib
     int zinitialized:1;
@@ -141,14 +134,14 @@ struct web_client {
     char client_ip[NI_MAXHOST+1];
     char client_port[NI_MAXSERV+1];
 
-    char decoded_url[URL_MAX + 1];  // we decode the URL in this buffer
-    char last_url[URL_MAX+1];       // we keep a copy of the decoded URL here
+    char decoded_url[NETDATA_WEB_REQUEST_URL_SIZE + 1];  // we decode the URL in this buffer
+    char last_url[NETDATA_WEB_REQUEST_URL_SIZE+1];       // we keep a copy of the decoded URL here
 
     struct timeval tv_in, tv_ready;
 
-    char cookie1[COOKIE_MAX+1];
-    char cookie2[COOKIE_MAX+1];
-    char origin[ORIGIN_MAX+1];
+    char cookie1[NETDATA_WEB_REQUEST_COOKIE_SIZE+1];
+    char cookie2[NETDATA_WEB_REQUEST_COOKIE_SIZE+1];
+    char origin[NETDATA_WEB_REQUEST_ORIGIN_HEADER_SIZE+1];
 
     struct response response;
 
@@ -168,21 +161,10 @@ struct web_client {
     size_t pollinfo_filecopy_slot;  // POLLINFO slot of the file read
 };
 
-extern SIMPLE_PATTERN *web_allow_connections_from;
-extern SIMPLE_PATTERN *web_allow_dashboard_from;
-extern SIMPLE_PATTERN *web_allow_registry_from;
-extern SIMPLE_PATTERN *web_allow_badges_from;
-extern SIMPLE_PATTERN *web_allow_streaming_from;
-extern SIMPLE_PATTERN *web_allow_netdataconf_from;
-
 extern uid_t web_files_uid(void);
 extern uid_t web_files_gid(void);
 
 extern int web_client_permission_denied(struct web_client *w);
-
-extern struct web_client *web_client_create_on_fd(int fd, const char *client_ip, const char *client_port);
-extern struct web_client *web_client_create_on_listenfd(int listener);
-extern void web_client_release(struct web_client *w);
 
 extern ssize_t web_client_send(struct web_client *w);
 extern ssize_t web_client_receive(struct web_client *w);
@@ -191,16 +173,11 @@ extern ssize_t web_client_read_file(struct web_client *w);
 extern void web_client_process_request(struct web_client *w);
 extern void web_client_request_done(struct web_client *w);
 
-extern void *web_client_main(void *ptr);
-
 extern int web_client_api_request_v1_data_group(char *name, int def);
 extern const char *group_method2string(int group);
 
 extern void buffer_data_options2string(BUFFER *wb, uint32_t options);
 
 extern int mysendfile(struct web_client *w, char *filename);
-
-extern void web_client_multi_threaded_web_server_stop_all_threads(void);
-extern void web_client_cache_destroy(void);
 
 #endif

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -7,8 +7,7 @@ static LISTEN_SOCKETS api_sockets = {
         .backlog         = API_LISTEN_BACKLOG
 };
 
-WEB_SERVER_MODE web_server_mode = WEB_SERVER_MODE_MULTI_THREADED;
-int web_server_is_multithreaded = 1;
+WEB_SERVER_MODE web_server_mode = WEB_SERVER_MODE_STATIC_THREADED;
 
 // --------------------------------------------------------------------------------------
 

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -21,6 +21,13 @@ typedef enum web_server_mode {
     WEB_SERVER_MODE_NONE
 } WEB_SERVER_MODE;
 
+extern SIMPLE_PATTERN *web_allow_connections_from;
+extern SIMPLE_PATTERN *web_allow_dashboard_from;
+extern SIMPLE_PATTERN *web_allow_registry_from;
+extern SIMPLE_PATTERN *web_allow_badges_from;
+extern SIMPLE_PATTERN *web_allow_streaming_from;
+extern SIMPLE_PATTERN *web_allow_netdataconf_from;
+
 extern WEB_SERVER_MODE web_server_mode;
 
 extern WEB_SERVER_MODE web_server_mode_id(const char *mode);
@@ -30,5 +37,8 @@ extern void *socket_listen_main_multi_threaded(void *ptr);
 extern void *socket_listen_main_single_threaded(void *ptr);
 extern void *socket_listen_main_static_threaded(void *ptr);
 extern int api_listen_sockets_setup(void);
+
+#define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
+extern int web_client_timeout;
 
 #endif /* NETDATA_WEB_SERVER_H */

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -16,6 +16,7 @@
 
 typedef enum web_server_mode {
     WEB_SERVER_MODE_SINGLE_THREADED,
+    WEB_SERVER_MODE_STATIC_THREADED,
     WEB_SERVER_MODE_MULTI_THREADED,
     WEB_SERVER_MODE_NONE
 } WEB_SERVER_MODE;
@@ -27,6 +28,7 @@ extern const char *web_server_mode_name(WEB_SERVER_MODE id);
 
 extern void *socket_listen_main_multi_threaded(void *ptr);
 extern void *socket_listen_main_single_threaded(void *ptr);
+extern void *socket_listen_main_static_threaded(void *ptr);
 extern int api_listen_sockets_setup(void);
 
 #endif /* NETDATA_WEB_SERVER_H */

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -22,6 +22,7 @@ typedef enum web_server_mode {
 } WEB_SERVER_MODE;
 
 extern WEB_SERVER_MODE web_server_mode;
+extern int web_server_is_multithreaded;
 
 extern WEB_SERVER_MODE web_server_mode_id(const char *mode);
 extern const char *web_server_mode_name(WEB_SERVER_MODE id);

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -22,7 +22,6 @@ typedef enum web_server_mode {
 } WEB_SERVER_MODE;
 
 extern WEB_SERVER_MODE web_server_mode;
-extern int web_server_is_multithreaded;
 
 extern WEB_SERVER_MODE web_server_mode_id(const char *mode);
 extern const char *web_server_mode_name(WEB_SERVER_MODE id);


### PR DESCRIPTION
This PR adds a third web server in netdata: **static-threaded**.

This is a multi-threaded web server, but the number of threads are static, they are configured at `netdata.conf`.

This web server is now the default. If not configured otherwise, it will use as many threads as the number of processors on the system, up to 6. That is, by default it will enable 1-6 threads depending on the number of the CPUs found. Editing netdata.conf and setting `[web].web server threads = N` will enable any number of threads you like.

This web server follows the paradigm modern web servers use: a number of threads are started, all listening on the same sockets. The kernel distributes new incoming connections to one of the threads in a round-robin fashion. Each thread is capable of serving multiple requests concurrently utilizing non-blocking I/O.

Features of the new web server:

1. **speed**

   this web server is based on `poll()`, which is said that to be the fastest in Linux for up to 100 concurrent connections per thread (faster than `epoll()` at that scale). 

2. **lower cpu resources**

   since all threads are pre-spawned, the overhead of each new connection is minimized.

3. **better control on resources**

    this web server minimizes memory use, page faults, memory arenas, number of threads, etc. So, it architecturally provides the best system protection against DDoS.

So, in netdata we have the following web servers:

`[web].mode`|description
:----------------:|:--------------
single-threaded|a simple single threaded web server based on `select()`. This has a hard limit of 1024 connections (limitation of `select()`).
multi-threaded|a web server that spawns a new thread for every connection. The listener uses `poll()` but each thread spawned uses `select()` on the single connected socket. This wastes resources (mainly page faults and memory arenas), since each connection uses a new thread.
static-threaded|a web server that spawns a pre-defined number of threads, all based on `poll()`. It does not have a limit on the number of connections and it does not waste resources.

---

fixed 2 bugs:

1. under single-threaded web server, if a client was refused connection, netdata would crash (didn't check for a NULL return value).

2. when the system does not have the `accept4()` call, the one emulated by netdata had an issue that if it was called with invalid flags, there was a file descriptor leakage - thankfully netdata never supplied invalid flags, so this was not actually a problem.
