### PR TITLE
prevent static-threaded web server from closing the streaming socket

### DIFF
--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -1060,10 +1060,15 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
         error("Failed to create new STREAM receive thread for client.");
 
     // prevent the caller from closing the streaming socket
-    if(w->ifd == w->ofd)
-        w->ifd = w->ofd = -1;
-    else
-        w->ifd = -1;
+    if(web_server_mode == WEB_SERVER_MODE_STATIC_THREADED) {
+        web_client_flag_set(w, WEB_CLIENT_FLAG_DONT_CLOSE_SOCKET);
+    }
+    else {
+        if(w->ifd == w->ofd)
+            w->ifd = w->ofd = -1;
+        else
+            w->ifd = -1;
+    }
 
     buffer_flush(w->response.data);
     return 200;

--- a/src/socket.c
+++ b/src/socket.c
@@ -1064,8 +1064,11 @@ inline void poll_close_fd(POLLINFO *pi) {
         pi->del_callback(pi);
     }
 
-    // info("POLLFD: closing fd %d", pf->fd);
-    close(pf->fd);
+    if(likely(!(pi->flags & POLLINFO_FLAG_DONT_CLOSE))) {
+        if(close(pf->fd) == -1)
+            error("Failed to close() poll_events() socket %d", pf->fd);
+    }
+
     pf->fd = -1;
     pf->events = 0;
     pf->revents = 0;

--- a/src/socket.h
+++ b/src/socket.h
@@ -58,9 +58,12 @@ extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flag
 
 #define POLLINFO_FLAG_SERVER_SOCKET 0x00000001
 #define POLLINFO_FLAG_CLIENT_SOCKET 0x00000002
+#define POLLINFO_FLAG_DONT_CLOSE    0x00000004
+
+typedef struct poll POLLJOB;
 
 typedef struct pollinfo {
-    struct poll *p; // the parent
+    POLLJOB *p; // the parent
     size_t slot;    // the slot id
 
     int fd;             // the file descriptor
@@ -85,7 +88,7 @@ typedef struct pollinfo {
     struct pollinfo *next;
 } POLLINFO;
 
-typedef struct poll {
+struct poll {
     size_t slots;
     size_t used;
     size_t min;
@@ -100,7 +103,9 @@ typedef struct poll {
     void  (*del_callback)(POLLINFO *pi);
     int   (*rcv_callback)(POLLINFO *pi, short int *events);
     int   (*snd_callback)(POLLINFO *pi, short int *events);
-} POLLJOB;
+};
+
+#define pollinfo_from_slot(p, slot) (&((p)->inf[(slot)]))
 
 extern int poll_default_snd_callback(POLLINFO *pi, short int *events);
 extern int poll_default_rcv_callback(POLLINFO *pi, short int *events);

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -29,7 +29,9 @@ typedef enum web_client_flags {
     WEB_CLIENT_FLAG_TRACKING_REQUIRED = 1 << 6, // if set, we need to send cookies
 
     WEB_CLIENT_FLAG_TCP_CLIENT        = 1 << 7, // if set, the client is using a TCP socket
-    WEB_CLIENT_FLAG_UNIX_CLIENT       = 1 << 8  // if set, the client is using a UNIX socket
+    WEB_CLIENT_FLAG_UNIX_CLIENT       = 1 << 8, // if set, the client is using a UNIX socket
+
+    WEB_CLIENT_FLAG_DONT_CLOSE_SOCKET = 1 << 9,  // don't close the socket when cleaning up (static-threaded web server)
 } WEB_CLIENT_FLAGS;
 
 //#ifdef HAVE_C___ATOMIC

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -6,7 +6,7 @@
 // 2. multi-threaded, based on poll() that spawns threads to handle the requests, based on select()
 // 3. static-threaded, based on poll() using a fixed number of threads (configured at netdata.conf)
 
-WEB_SERVER_MODE web_server_mode = WEB_SERVER_MODE_MULTI_THREADED;
+WEB_SERVER_MODE web_server_mode = WEB_SERVER_MODE_STATIC_THREADED;
 
 // --------------------------------------------------------------------------------------
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -954,8 +954,8 @@ static int web_server_file_read_callback(POLLINFO *pi, short int *events) {
     ssize_t ret = unlikely(web_client_read_file(w));
 
     if(likely(web_client_has_wait_send(w))) {
-        POLLJOB *p = pi->p;                         // our POLLJOB
-        POLLINFO *wpi = &p->inf[w->pollinfo_slot];  // POLLINFO of the client socket
+        POLLJOB *p = pi->p;                                        // our POLLJOB
+        POLLINFO *wpi = pollinfo_from_slot(p, w->pollinfo_slot);  // POLLINFO of the client socket
 
         debug(D_WEB_CLIENT, "%llu: SIGNALING W TO SEND (iFD %d, oFD %d)", w->id, pi->fd, wpi->fd);
         p->fds[wpi->slot].events |= POLLOUT;
@@ -1014,11 +1014,13 @@ static void web_server_del_callback(POLLINFO *pi) {
 
     w->pollinfo_slot = 0;
     if(unlikely(w->pollinfo_filecopy_slot)) {
-        POLLJOB *p = pi->p;                                  // our POLLJOB
-        POLLINFO *fpi = &p->inf[w->pollinfo_filecopy_slot];  // POLLINFO of the client socket
+        POLLINFO *fpi = pollinfo_from_slot(pi->p, w->pollinfo_filecopy_slot);  // POLLINFO of the client socket
         debug(D_WEB_CLIENT, "%llu: THE CLIENT WILL BE FRED BY READING FILE JOB ON FD %d", w->id, fpi->fd);
     }
     else {
+        if(web_client_flag_check(w, WEB_CLIENT_FLAG_DONT_CLOSE_SOCKET))
+            pi->flags |= POLLINFO_FLAG_DONT_CLOSE;
+
         debug(D_WEB_CLIENT, "%llu: CLOSING CLIENT FD %d", w->id, pi->fd);
         web_client_release(w);
     }


### PR DESCRIPTION
1. fixes the bug introduced with #3248 
2. which was quickly patched with #3259 

Now the static-threaded web server, is again the default.