### PR TITLE
strict netdata files permissions

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -813,7 +813,7 @@ if [ ${UID} -eq 0 ]
     if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network-helper.sh" ]
         then
         run chown root "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network-helper.sh"
-        run chmod 0500 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network-helper.sh"
+        run chmod 0550 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network-helper.sh"
     fi
 
 else

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -194,27 +194,29 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
 
-%caps(cap_dac_read_search,cap_sys_ptrace=ep) %attr(0555,root,root) %{_libexecdir}/%{name}/plugins.d/apps.plugin
+%caps(cap_dac_read_search,cap_sys_ptrace=ep) %attr(0550,root,netdata) %{_libexecdir}/%{name}/plugins.d/apps.plugin
 
 %if %{with netns}
 # cgroup-network detects the network interfaces of CGROUPs
 # it must be able to use setns() and run cgroup-network-helper.sh as root
 # the helper script reads /proc/PID/fdinfo/* files, runs virsh, etc.
-%caps(cap_setuid=ep) %attr(4555,root,root) %{_libexecdir}/%{name}/plugins.d/cgroup-network
-%attr(0555,root,root) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
+%caps(cap_setuid=ep) %attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
+%attr(0550,root,root) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
 %endif
 
 %if %{with freeipmi}
-%caps(cap_setuid=ep) %attr(4555,root,root) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
+%caps(cap_setuid=ep) %attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 %endif
 
-%attr(0700,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
-%attr(0700,netdata,netdata) %dir %{_localstatedir}/log/%{name}
-%attr(0700,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
+%attr(0770,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
+%attr(0770,netdata,netdata) %dir %{_localstatedir}/log/%{name}
+%attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
 
 %dir %{_datadir}/%{name}
 %dir %{_sysconfdir}/%{name}/health.d
 %dir %{_sysconfdir}/%{name}/python.d
+%dir %{_sysconfdir}/%{name}/charts.d
+%dir %{_sysconfdir}/%{name}/node.d
 
 %if %{with systemd}
 %{_unitdir}/netdata.service

--- a/plugins.d/cgroup-network-helper.sh
+++ b/plugins.d/cgroup-network-helper.sh
@@ -23,7 +23,6 @@
 # -----------------------------------------------------------------------------
 
 # the system path is cleared by cgroup-network
-export PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 [ -x /etc/profile ] && source /etc/profile
 
 export LC_ALL=C

--- a/plugins.d/cgroup-network-helper.sh
+++ b/plugins.d/cgroup-network-helper.sh
@@ -23,7 +23,7 @@
 # -----------------------------------------------------------------------------
 
 # the system path is cleared by cgroup-network
-[ -x /etc/profile ] && source /etc/profile
+[ -f /etc/profile ] && source /etc/profile
 
 export LC_ALL=C
 

--- a/src/cgroup-network.c
+++ b/src/cgroup-network.c
@@ -12,15 +12,17 @@ char *host_prefix = "";
 char *pluginsdir = "";
 char *configdir = "";
 
-char environment_variable1[FILENAME_MAX + 1] = "";
-char environment_variable2[FILENAME_MAX + 1] = "";
-char environment_variable3[FILENAME_MAX + 1] = "";
+char environment_variable2[FILENAME_MAX + 50] = "";
+char environment_variable3[FILENAME_MAX + 50] = "";
+char environment_variable4[FILENAME_MAX + 50] = "";
 char *environment[] = {
-        environment_variable1,
+        "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
         environment_variable2,
         environment_variable3,
+        environment_variable4,
         NULL
 };
+
 
 // ----------------------------------------------------------------------------
 // callback required by fatal()
@@ -488,7 +490,7 @@ int verify_path(const char *path) {
     char c;
     const char *s = path;
     while((c = *s++)) {
-        if(c == '$' || c == '`') {
+        if(c == '$' || c == '`' || c == '<' || c == '>') {
             error("invalid character in path '%s'", path);
             return -1;
         }
@@ -512,6 +514,39 @@ int verify_path(const char *path) {
     return 0;
 }
 
+/*
+char *fix_path_variable(void) {
+    const char *path = getenv("PATH");
+    if(!path || !*path) return 0;
+
+    char *p = strdupz(path);
+    char *safe_path = callocz(1, strlen(p) + strlen("PATH=") + 1);
+    strcpy(safe_path, "PATH=");
+
+    int added = 0;
+    char *ptr = p;
+    while(ptr && *ptr) {
+        char *s = strsep(&ptr, ":");
+        if(s && *s) {
+            if(verify_path(s) == -1) {
+                error("the PATH variable includes an invalid path '%s' - removed it.", s);
+            }
+            else {
+                info("the PATH variable includes a valid path '%s'.", s);
+                if(added) strcat(safe_path, ":");
+                strcat(safe_path, s);
+                added++;
+            }
+        }
+    }
+
+    info("unsafe PATH:      '%s'.", path);
+    info("  safe PATH: '%s'.", safe_path);
+
+    freez(p);
+    return safe_path;
+}
+*/
 
 // ----------------------------------------------------------------------------
 // main
@@ -563,9 +598,9 @@ int main(int argc, char **argv) {
     // ------------------------------------------------------------------------
     // build a safe environment for our script
 
-    snprintfz(environment_variable1, FILENAME_MAX, "NETDATA_HOST_PREFIX=%s", host_prefix);
-    snprintfz(environment_variable2, FILENAME_MAX, "NETDATA_PLUGINS_DIR=%s", pluginsdir);
-    snprintfz(environment_variable3, FILENAME_MAX, "NETDATA_CONFIG_DIR=%s", configdir);
+    snprintfz(environment_variable2, sizeof(environment_variable2) - 1, "NETDATA_HOST_PREFIX=%s", host_prefix);
+    snprintfz(environment_variable3, sizeof(environment_variable3) - 1, "NETDATA_PLUGINS_DIR=%s", pluginsdir);
+    snprintfz(environment_variable4, sizeof(environment_variable4) - 1, "NETDATA_CONFIG_DIR=%s", configdir);
 
     // ------------------------------------------------------------------------
 

--- a/src/common.c
+++ b/src/common.c
@@ -904,6 +904,30 @@ void strreverse(char *begin, char *end) {
     }
 }
 
+char *strsep_on_1char(char **ptr, char c) {
+    if(unlikely(!ptr || !*ptr))
+        return NULL;
+
+    // remember the position we started
+    char *s = *ptr;
+
+    // skip separators in front
+    while(*s == c) s++;
+    char *ret = s;
+
+    // find the next separator
+    while(*s++) {
+        if(unlikely(*s == c)) {
+            *s++ = '\0';
+            *ptr = s;
+            return ret;
+        }
+    }
+
+    *ptr = NULL;
+    return ret;
+}
+
 char *mystrsep(char **ptr, char *s) {
     char *p = "";
     while (p && !p[0] && *ptr) p = strsep(ptr, s);

--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -1,14 +1,24 @@
-# NetData Configuration
+# netdata configuration
 #
-# To see defaults, grab one from your instance:
-# http://localhost:19999/netdata.conf
-
-# global netdata configuration
+# You can download the latest version of this file, using:
+#
+#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+# or
+#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+#
+# You can uncomment and change any of the options below.
+# The value shown in the commented settings, is the default value.
+#
 
 [global]
-	run as user = netdata
-	web files owner = root
-	web files group = netdata
-        # Netdata is not designed to be exposed to potentially hostile networks
-        # See https://github.com/firehol/netdata/issues/164
-	bind to = localhost
+    run as user = netdata
+
+    # the default database size - 1 hour
+    history = 3600
+
+    # by default do not expose the netdata port
+    bind to = localhost
+
+[web]
+    web files owner = root
+    web files group = netdata


### PR DESCRIPTION
This PR applies a number of security fixes to netdata files:

1. escalated netdata plugins can only be run by netdata user (this was already true for the static 64bit builds - but installations from source were allowing any user to run them).
2. `/etc/netdata` is now owned `root:netdata` and netdata has only read access on all files.
3. `cgroup-network` now also checks all paths supplied for `<` and `>` (it does not accept them).
4. the default `PATH` for `cgroup-network-helper.sh` is now set by `cgroup-network`.
