### PR TITLE
prevent text selection on the charts toolbox, after double click

### DIFF
--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -147,6 +147,12 @@ body {
     z-index: 20;
     padding: 0px;
     margin: 0px;
+
+    /* prevent text selection after double click */
+    -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+    -moz-user-select: none; /* mozilla browsers */
+    -khtml-user-select: none; /* webkit (konqueror) browsers */
+    -ms-user-select: none; /* IE10+ */
 }
 
 .netdata-legend-toolbox-button {
@@ -165,6 +171,12 @@ body {
     padding: 0px;
     margin: 0px;
     cursor: pointer;
+
+    /* prevent text selection after double click */
+    -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+    -moz-user-select: none; /* mozilla browsers */
+    -khtml-user-select: none; /* webkit (konqueror) browsers */
+    -ms-user-select: none; /* IE10+ */
 }
 
 .netdata-message {

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -160,7 +160,7 @@ var NETDATA = window.NETDATA || {};
     NETDATA.themes = {
         white: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-3.3.7.css',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20171208-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20180113-1',
             background: '#FFFFFF',
             foreground: '#000000',
             grid: '#F0F0F0',
@@ -178,7 +178,7 @@ var NETDATA = window.NETDATA || {};
         },
         slate: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-slate-flat-3.3.7.css?v20161229-1',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20171208-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20180113-1',
             background: '#272b30',
             foreground: '#C8C8C8',
             grid: '#283236',

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -161,6 +161,12 @@ code {
     z-index: 20;
     padding: 0px;
     margin: 0px;
+
+    /* prevent text selection after double click */
+    -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+    -moz-user-select: none; /* mozilla browsers */
+    -khtml-user-select: none; /* webkit (konqueror) browsers */
+    -ms-user-select: none; /* IE10+ */
 }
 
 .netdata-legend-toolbox-button {
@@ -179,6 +185,12 @@ code {
     padding: 0px;
     margin: 0px;
     cursor: pointer;
+
+    /* prevent text selection after double click */
+    -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+    -moz-user-select: none; /* mozilla browsers */
+    -khtml-user-select: none; /* webkit (konqueror) browsers */
+    -ms-user-select: none; /* IE10+ */
 }
 
 .netdata-message {

--- a/web/index.html
+++ b/web/index.html
@@ -5622,6 +5622,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180106-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20180113-1"></script>
 </body>
 </html>


### PR DESCRIPTION
on safari, double clicking a charts toolbox button, selected the whole legend.
this PR fixes it.
