### PR TITLE
fixed paths at cgroup-network

### DIFF
--- a/plugins.d/cgroup-network-helper.sh
+++ b/plugins.d/cgroup-network-helper.sh
@@ -70,12 +70,6 @@ debug() {
     fatal "BASH version 4 or later is required (this is ${BASH_VERSION})."
 
 # -----------------------------------------------------------------------------
-# defaults to allow running this script by hand
-
-[ -z "${NETDATA_PLUGINS_DIR}"  ] && NETDATA_PLUGINS_DIR="$(dirname "${0}")"
-[ -z "${NETDATA_CONFIG_DIR}"   ] && NETDATA_CONFIG_DIR="$(dirname "${0}")/../../../../etc/netdata"
-
-# -----------------------------------------------------------------------------
 # parse the arguments
 
 pid=


### PR DESCRIPTION
fixes #3269

More security constrains:

1. the path to `cgroup-network-helper.sh` is decided at compile time and cannot be changed at run time.
2. the cgroup path passed to `cgroup-network` has a very limited set of characters supported.
 