### PR TITLE
prevent date, time and units from wrapping, at the chart legends

### DIFF
--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -225,12 +225,18 @@ body {
     font-size: 10px;
     font-weight: normal;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-title-time {
     font-size: 11px;
     font-weight: bold;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-title-units {
@@ -241,6 +247,9 @@ body {
     vertical-align: top;
     font-weight: normal;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-series {

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -160,7 +160,7 @@ var NETDATA = window.NETDATA || {};
     NETDATA.themes = {
         white: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-3.3.7.css',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20180113-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20180115-1',
             background: '#FFFFFF',
             foreground: '#000000',
             grid: '#F0F0F0',
@@ -178,7 +178,7 @@ var NETDATA = window.NETDATA || {};
         },
         slate: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-slate-flat-3.3.7.css?v20161229-1',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20180113-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20180115-1',
             background: '#272b30',
             foreground: '#C8C8C8',
             grid: '#283236',

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -239,12 +239,18 @@ code {
     font-size: 10px;
     font-weight: normal;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-title-time {
     font-size: 11px;
     font-weight: bold;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-title-units {
@@ -255,6 +261,9 @@ code {
     vertical-align: top;
     font-weight: normal;
     margin-top: 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .netdata-legend-series {

--- a/web/index.html
+++ b/web/index.html
@@ -5622,6 +5622,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180114-4"></script>
+    <script type="text/javascript" src="dashboard.js?v20180115-1"></script>
 </body>
 </html>


### PR DESCRIPTION
The problem:

![peek 2018-01-15 01-29](https://user-images.githubusercontent.com/2662304/34922074-8d8be58a-f993-11e7-910a-aac31aec7818.gif)


The solution:

![peek 2018-01-15 01-30](https://user-images.githubusercontent.com/2662304/34922082-ae23d0f0-f993-11e7-912d-0761897595ee.gif)
