### PR TITLE
system.ram plugin: treat Slab memory as Cached

### DIFF
--- a/src/proc_meminfo.c
+++ b/src/proc_meminfo.c
@@ -137,7 +137,8 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     // http://stackoverflow.com/questions/3019748/how-to-reliably-measure-available-memory-in-linux
-    unsigned long long MemUsed = MemTotal - MemFree - Cached - Buffers;
+    unsigned long long MemCached = Cached + Slab;
+    unsigned long long MemUsed = MemTotal - MemFree - MemCached - Buffers;
 
     if(do_ram) {
         {
@@ -169,7 +170,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
             rrddim_set_by_pointer(st_system_ram, rd_free,    MemFree);
             rrddim_set_by_pointer(st_system_ram, rd_used,    MemUsed);
-            rrddim_set_by_pointer(st_system_ram, rd_cached,  Cached);
+            rrddim_set_by_pointer(st_system_ram, rd_cached,  MemCached);
             rrddim_set_by_pointer(st_system_ram, rd_buffers, Buffers);
 
             rrdset_done(st_system_ram);


### PR DESCRIPTION
Hi,
the system.ram plugin seems (on Linux) to treat slab memory as "used" while the "free" command shows it as "cache".
![system ram-high_slab](https://user-images.githubusercontent.com/2484686/34936142-850209d8-f9e0-11e7-85c8-14348455b1ed.png)
This is what free shows:
```
# free -h
              total        used        free      shared  buff/cache   available
Mem:           125G         45G        1.4G        868M         78G         29G
Swap:           63G        6.6G         57G
```

The man page of free says that cache is calculated from Cached and Slab in /proc/meminfo, netdata only uses the Cached field.

For your reference, this is the content of /proc/meminfo at (approx.) the time I captured the screenshot above:
[meminfo.txt](https://github.com/firehol/netdata/files/1631199/meminfo.txt)

The memory isn't actually "used" - after running "echo 2 > /proc/sys/vm/drop_caches" the red bar on netdata gets much smaller. I think netdata should include Slab as well for cached memory. This pull request contains my suggestions for the change.

Thanks,
Adalbert