### PR TITLE
intersection observer improvements

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5622,6 +5622,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180115-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20180115-2"></script>
 </body>
 </html>


### PR DESCRIPTION
improvements for #3280 

added option to enable/disable intersection observer (still enabled by default); detected a case that the 
chart library draws the chart while hidden and triggered a redraw when this happens; 

may solve #3289
