### PR TITLE
basic protections of static-threaded web server

### DIFF
--- a/src/backends.c
+++ b/src/backends.c
@@ -500,11 +500,11 @@ inline uint32_t backend_parse_data_source(const char *source, uint32_t mode) {
 
 static void backends_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *backends_main(void *ptr) {

--- a/src/health.c
+++ b/src/health.c
@@ -340,11 +340,11 @@ static inline int check_if_resumed_from_suspention(void) {
 
 static void health_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *health_main(void *ptr) {

--- a/src/main.c
+++ b/src/main.c
@@ -99,7 +99,8 @@ void web_server_threading_selection(void) {
 }
 
 void web_server_config_options(void) {
-    web_client_timeout = (int) config_get_number(CONFIG_SECTION_WEB, "disconnect idle clients after seconds", DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS);
+    web_client_timeout = (int) config_get_number(CONFIG_SECTION_WEB, "disconnect idle clients after seconds", web_client_timeout);
+    web_client_first_request_timeout = (int) config_get_number(CONFIG_SECTION_WEB, "timeout for first request", web_client_first_request_timeout);
 
     respect_web_browser_do_not_track_policy = config_get_boolean(CONFIG_SECTION_WEB, "respect do not track policy", respect_web_browser_do_not_track_policy);
     web_x_frame_options = config_get(CONFIG_SECTION_WEB, "x-frame-options response header", "");

--- a/src/main.h
+++ b/src/main.h
@@ -1,6 +1,10 @@
 #ifndef NETDATA_MAIN_H
 #define NETDATA_MAIN_H 1
 
+#define NETDATA_MAIN_THREAD_RUNNING   CONFIG_BOOLEAN_YES
+#define NETDATA_MAIN_THREAD_EXITING  (CONFIG_BOOLEAN_YES + 1)
+#define NETDATA_MAIN_THREAD_EXITED    CONFIG_BOOLEAN_NO
+
 /**
  * This struct contains information about command line options.
  */

--- a/src/plugin_checks.c
+++ b/src/plugin_checks.c
@@ -4,11 +4,11 @@
 
 static void checks_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *checks_main(void *ptr) {

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -68,11 +68,11 @@ static struct freebsd_module {
 
 static void freebsd_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *freebsd_main(void *ptr) {
@@ -82,7 +82,7 @@ void *freebsd_main(void *ptr) {
 
     // initialize FreeBSD plugin
     if (freebsd_plugin_init())
-        netdata_exit = 1;
+        netdata_cleanup_and_exit(1);
 
     // check the enabled status for each module
     int i;

--- a/src/plugin_idlejitter.c
+++ b/src/plugin_idlejitter.c
@@ -4,11 +4,11 @@
 
 static void cpuidlejitter_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *cpuidlejitter_main(void *ptr) {

--- a/src/plugin_macos.c
+++ b/src/plugin_macos.c
@@ -2,11 +2,11 @@
 
 static void macos_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *macos_main(void *ptr) {

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -753,19 +753,18 @@ static void nfacct_send_metrics() {
 
 static void nfacct_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
+    info("cleaning up...");
 
 #ifdef DO_NFACCT
-        nfacct_cleanup();
+    nfacct_cleanup();
 #endif
 
 #ifdef DO_NFSTAT
-        nfstat_cleanup();
+    nfstat_cleanup();
 #endif
 
-        static_thread->enabled = 0;
-    }
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *nfacct_main(void *ptr) {

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -66,11 +66,11 @@ static struct proc_module {
 
 static void proc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *proc_main(void *ptr) {

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -330,11 +330,11 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
 static void diskspace_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *proc_diskspace_main(void *ptr) {

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -832,24 +832,24 @@ static pid_t tc_child_pid = 0;
 
 static void tc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        if(tc_child_pid) {
-            info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);
-            if(killpid(tc_child_pid, SIGTERM) != -1) {
-                siginfo_t info;
+    info("cleaning up...");
 
-                info("TC: waiting for tc plugin child process pid %d to exit...", tc_child_pid);
-                waitid(P_PID, (id_t) tc_child_pid, &info, WEXITED);
-                // info("TC: finished tc plugin child process pid %d.", tc_child_pid);
-            }
+    if(tc_child_pid) {
+        info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);
+        if(killpid(tc_child_pid, SIGTERM) != -1) {
+            siginfo_t info;
 
-            tc_child_pid = 0;
+            info("TC: waiting for tc plugin child process pid %d to exit...", tc_child_pid);
+            waitid(P_PID, (id_t) tc_child_pid, &info, WEXITED);
+            // info("TC: finished tc plugin child process pid %d.", tc_child_pid);
         }
 
-        static_thread->enabled = 0;
+        tc_child_pid = 0;
     }
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *tc_main(void *ptr) {

--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -568,20 +568,19 @@ void *pluginsd_worker_thread(void *arg) {
 
 static void pluginsd_main_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
+    info("cleaning up...");
 
-        struct plugind *cd;
-        for (cd = pluginsd_root; cd; cd = cd->next) {
-            if (cd->enabled && !cd->obsolete) {
-                info("stopping plugin thread: %s", cd->id);
-                netdata_thread_cancel(cd->thread);
-            }
+    struct plugind *cd;
+    for (cd = pluginsd_root; cd; cd = cd->next) {
+        if (cd->enabled && !cd->obsolete) {
+            info("stopping plugin thread: %s", cd->id);
+            netdata_thread_cancel(cd->thread);
         }
-
-        info("cleanup completed.");
-        static_thread->enabled = 0;
     }
+
+    info("cleanup completed.");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *pluginsd_main(void *ptr) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -1410,14 +1410,15 @@ void poll_events(LISTEN_SOCKETS *sockets
         }
 
         if(now - last_check > p.checks_every) {
+            last_check = now;
+
             // security checks
             for(i = 0; i <= p.max; i++) {
                 POLLINFO *pi = &p.inf[i];
 
                 if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
                     if (unlikely(pi->send_count == 0 && (now - pi->connected_t) >= p.complete_request_timeout)) {
-                        errno = 0;
-                        error("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' has not sent a complete request in %zu seconds - closing it. "
+                        info("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' has not sent a complete request in %zu seconds - closing it. "
                               , i
                               , pi->fd
                               , pi->client_ip ? pi->client_ip : "<undefined-ip>"
@@ -1427,8 +1428,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                         poll_close_fd(pi);
                     }
                     else if(unlikely(pi->recv_count && now - ((pi->last_received_t > pi->last_sent_t) ? pi->last_received_t : pi->last_sent_t) >= p.idle_timeout )) {
-                        errno = 0;
-                        error("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' is idle for more than %zu seconds - closing it. "
+                        info("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' is idle for more than %zu seconds - closing it. "
                               , i
                               , pi->fd
                               , pi->client_ip ? pi->client_ip : "<undefined-ip>"

--- a/src/socket.c
+++ b/src/socket.c
@@ -1035,6 +1035,14 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
     pi->rcv_callback = rcv_callback;
     pi->snd_callback = snd_callback;
 
+    pi->connected_t = now_boottime_sec();
+    pi->last_received_t = 0;
+    pi->last_sent_t = 0;
+    pi->last_sent_t = 0;
+    pi->recv_count = 0;
+    pi->send_count = 0;
+
+    netdata_thread_disable_cancelability();
     p->used++;
     if(unlikely(pi->slot > p->max))
         p->max = pi->slot;
@@ -1046,6 +1054,7 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
     if(pi->flags & POLLINFO_FLAG_SERVER_SOCKET) {
         p->min = pi->slot;
     }
+    netdata_thread_enable_cancelability();
 
     debug(D_POLLFD, "POLLFD: ADD: completed, slots = %zu, used = %zu, min = %zu, max = %zu, next free = %zd", p->slots, p->used, p->min, p->max, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
 
@@ -1060,13 +1069,15 @@ inline void poll_close_fd(POLLINFO *pi) {
 
     if(unlikely(pf->fd == -1)) return;
 
+    netdata_thread_disable_cancelability();
+
     if(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET) {
         pi->del_callback(pi);
-    }
 
-    if(likely(!(pi->flags & POLLINFO_FLAG_DONT_CLOSE))) {
-        if(close(pf->fd) == -1)
-            error("Failed to close() poll_events() socket %d", pf->fd);
+        if(likely(!(pi->flags & POLLINFO_FLAG_DONT_CLOSE))) {
+            if(close(pf->fd) == -1)
+                error("Failed to close() poll_events() socket %d", pf->fd);
+        }
     }
 
     pf->fd = -1;
@@ -1102,6 +1113,7 @@ inline void poll_close_fd(POLLINFO *pi) {
             }
         }
     }
+    netdata_thread_enable_cancelability();
 
     debug(D_POLLFD, "POLLFD: DEL: completed, slots = %zu, used = %zu, min = %zu, max = %zu, next free = %zd", p->slots, p->used, p->min, p->max, p->first_free?(ssize_t)p->first_free->slot:(ssize_t)-1);
 }
@@ -1164,7 +1176,7 @@ static void poll_events_cleanup(void *data) {
     freez(p->inf);
 }
 
-static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, short int revents) {
+static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, short int revents, time_t now) {
     short int events = pf->events;
     int fd = pf->fd;
     pf->revents = 0;
@@ -1179,6 +1191,9 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
 
     if(revents & POLLIN || revents & POLLPRI) {
         // receiving data
+
+        pi->last_received_t = now;
+        pi->recv_count++;
 
         if(likely(pi->flags & POLLINFO_FLAG_SERVER_SOCKET)) {
             // new connection
@@ -1259,6 +1274,15 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
                 poll_close_fd(pi);
                 return;
             }
+
+#ifdef NETDATA_INTERNAL_CHECKS
+            // this is common - it is used for web server file copies
+            if(!(pf->events & (POLLIN|POLLOUT))) {
+                error("POLLFD: LISTENER: after reading, client slot %zu (fd %d) from '%s:%s' was left without expecting input or output. ", i, fd, pi->client_ip?pi->client_ip:"<undefined-ip>", pi->client_port?pi->client_port:"<undefined-port>");
+                //poll_close_fd(pi);
+                //return;
+            }
+#endif
         }
     }
 
@@ -1266,8 +1290,17 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
         // sending data
         debug(D_POLLFD, "POLLFD: LISTENER: sending data to socket on slot %zu (fd %d)", i, fd);
 
+        pi->last_sent_t = now;
+        pi->send_count++;
+
         pf->events = 0;
         if (pi->snd_callback(pi, &pf->events) == -1) {
+            poll_close_fd(pi);
+            return;
+        }
+
+        if(unlikely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET && !(pf->events & (POLLIN|POLLOUT)))) {
+            error("POLLFD: LISTENER: after sending, client slot %zu (fd %d) from '%s:%s' was left without expecting input or output - closing it. ", i, fd, pi->client_ip?pi->client_ip:"<undefined-ip>", pi->client_port?pi->client_port:"<undefined-port>");
             poll_close_fd(pi);
             return;
         }
@@ -1318,6 +1351,10 @@ void poll_events(LISTEN_SOCKETS *sockets
             .inf = NULL,
             .first_free = NULL,
 
+            .complete_request_timeout = 30,
+            .idle_timeout = web_client_timeout,
+            .checks_every = (web_client_timeout / 3) + 1,
+
             .access_list = access_list,
 
             .add_callback = add_callback?add_callback:poll_default_add_callback,
@@ -1346,13 +1383,15 @@ void poll_events(LISTEN_SOCKETS *sockets
         info("POLLFD: LISTENER: listening on '%s'", (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN");
     }
 
-    int timeout = -1; // wait forever
+    int timeout = 1; // wait forever
+    time_t last_check = now_boottime_sec();
 
     netdata_thread_cleanup_push(poll_events_cleanup, &p);
 
     while(!netdata_exit) {
         debug(D_POLLFD, "POLLFD: LISTENER: Waiting on %zu sockets...", p.max + 1);
         retval = poll(p.fds, p.max + 1, timeout);
+        time_t now = now_boottime_sec();
 
         if(unlikely(retval == -1)) {
             error("POLLFD: LISTENER: poll() failed while waiting on %zu sockets.", p.max + 1);
@@ -1360,16 +1399,46 @@ void poll_events(LISTEN_SOCKETS *sockets
         }
         else if(unlikely(!retval)) {
             debug(D_POLLFD, "POLLFD: LISTENER: poll() timeout.");
-            continue;
+        }
+        else {
+            for (i = 0; i <= p.max; i++) {
+                struct pollfd *pf     = &p.fds[i];
+                short int     revents = pf->revents;
+                if (unlikely(revents))
+                    poll_events_process(&p, &p.inf[i], pf, revents, now);
+            }
         }
 
-        if(unlikely(netdata_exit)) break;
+        if(now - last_check > p.checks_every) {
+            // security checks
+            for(i = 0; i <= p.max; i++) {
+                POLLINFO *pi = &p.inf[i];
 
-        for(i = 0 ; i <= p.max ; i++) {
-            struct pollfd *pf = &p.fds[i];
-            short int revents = pf->revents;
-            if(unlikely(revents))
-                poll_events_process(&p, &p.inf[i], pf, revents);
+                if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
+                    if (unlikely(pi->send_count == 0 && (now - pi->connected_t) >= p.complete_request_timeout)) {
+                        errno = 0;
+                        error("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' has not sent a complete request in %zu seconds - closing it. "
+                              , i
+                              , pi->fd
+                              , pi->client_ip ? pi->client_ip : "<undefined-ip>"
+                              , pi->client_port ? pi->client_port : "<undefined-port>"
+                              , (size_t) p.complete_request_timeout
+                        );
+                        poll_close_fd(pi);
+                    }
+                    else if(unlikely(pi->recv_count && now - ((pi->last_received_t > pi->last_sent_t) ? pi->last_received_t : pi->last_sent_t) >= p.idle_timeout )) {
+                        errno = 0;
+                        error("POLLFD: LISTENER: client slot %zu (fd %d) from '%s:%s' is idle for more than %zu seconds - closing it. "
+                              , i
+                              , pi->fd
+                              , pi->client_ip ? pi->client_ip : "<undefined-ip>"
+                              , pi->client_port ? pi->client_port : "<undefined-port>"
+                              , (size_t) p.idle_timeout
+                        );
+                        poll_close_fd(pi);
+                    }
+                }
+            }
         }
     }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -1351,7 +1351,7 @@ void poll_events(LISTEN_SOCKETS *sockets
             .inf = NULL,
             .first_free = NULL,
 
-            .complete_request_timeout = 30,
+            .complete_request_timeout = web_client_first_request_timeout,
             .idle_timeout = web_client_timeout,
             .checks_every = (web_client_timeout / 3) + 1,
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -63,15 +63,22 @@ extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flag
 typedef struct poll POLLJOB;
 
 typedef struct pollinfo {
-    POLLJOB *p; // the parent
-    size_t slot;    // the slot id
+    POLLJOB *p;             // the parent
+    size_t slot;            // the slot id
 
-    int fd;             // the file descriptor
-    int socktype;       // the client socket type
-    char *client_ip;    // the connected client IP
-    char *client_port;  // the connected client port
+    int fd;                 // the file descriptor
+    int socktype;           // the client socket type
+    char *client_ip;        // the connected client IP
+    char *client_port;      // the connected client port
 
-    uint32_t flags;     // internal flags
+    time_t connected_t;     // the time the socket connected
+    time_t last_received_t; // the time the socket last received data
+    time_t last_sent_t;     // the time the socket last sent data
+
+    size_t recv_count;      // the number of times the socket was ready for inbound traffic
+    size_t send_count;      // the number of times the socket was ready for outbound traffic
+
+    uint32_t flags;         // internal flags
 
     // callbacks for this socket
     void  (*del_callback)(struct pollinfo *pi);
@@ -93,6 +100,11 @@ struct poll {
     size_t used;
     size_t min;
     size_t max;
+
+    time_t complete_request_timeout;
+    time_t idle_timeout;
+    time_t checks_every;
+
     struct pollfd *fds;
     struct pollinfo *inf;
     struct pollinfo *first_free;

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2676,11 +2676,11 @@ void update_cgroup_charts(int update_every) {
 
 static void cgroup_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        static_thread->enabled = 0;
-    }
+    info("cleaning up...");
+
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *cgroups_main(void *ptr) {

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -211,6 +211,8 @@ static void web_client_cache_destroy(void) {
     web_client_cache_verify(1);
 #endif
 
+    netdata_thread_disable_cancelability();
+
     struct web_client *w, *t;
 
     w = web_clients_cache.used;
@@ -230,6 +232,8 @@ static void web_client_cache_destroy(void) {
     }
     web_clients_cache.avail = NULL;
     web_clients_cache.avail_count = 0;
+
+    netdata_thread_enable_cancelability();
 }
 
 static struct web_client *web_client_get_from_cache_or_allocate() {
@@ -241,6 +245,8 @@ static struct web_client *web_client_get_from_cache_or_allocate() {
     if(unlikely(web_clients_cache.pid != 0 && web_clients_cache.pid != gettid()))
         error("Oops! wrong thread accessing the cache. Expected %d, found %d", (int)web_clients_cache.pid, (int)gettid());
 #endif
+
+    netdata_thread_disable_cancelability();
 
     struct web_client *w = web_clients_cache.avail;
 
@@ -269,6 +275,9 @@ static struct web_client *web_client_get_from_cache_or_allocate() {
     // initialize it
     w->id = web_client_connected();
     w->mode = WEB_CLIENT_MODE_NORMAL;
+
+    netdata_thread_enable_cancelability();
+
     return w;
 }
 
@@ -283,12 +292,16 @@ static void web_client_release(struct web_client *w) {
 
     debug(D_WEB_CLIENT_ACCESS, "%llu: Closing web client from %s port %s.", w->id, w->client_ip, w->client_port);
 
+    log_connection(w, "DISCONNECTED");
     web_client_request_done(w);
     web_client_disconnected();
+
+    netdata_thread_disable_cancelability();
 
     if(web_server_mode != WEB_SERVER_MODE_STATIC_THREADED) {
         if (w->ifd != -1) close(w->ifd);
         if (w->ofd != -1 && w->ofd != w->ifd) close(w->ofd);
+        w->ifd = w->ofd = -1;
     }
 
     // unlink it from the used
@@ -309,6 +322,8 @@ static void web_client_release(struct web_client *w) {
         web_clients_cache.avail = w;
         web_clients_cache.avail_count++;
     }
+
+    netdata_thread_enable_cancelability();
 }
 
 
@@ -580,25 +595,24 @@ static struct pollfd *socket_listen_main_multi_threaded_fds = NULL;
 
 static void socket_listen_main_multi_threaded_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;
-    if(static_thread->enabled) {
-        static_thread->enabled = 0;
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        info("cleaning up...");
+    info("cleaning up...");
 
-        info("releasing allocated memory...");
-        freez(socket_listen_main_multi_threaded_fds);
+    info("releasing allocated memory...");
+    freez(socket_listen_main_multi_threaded_fds);
 
-        info("closing all sockets...");
-        listen_sockets_close(&api_sockets);
+    info("closing all sockets...");
+    listen_sockets_close(&api_sockets);
 
-        info("stopping all running web server threads...");
-        web_client_multi_threaded_web_server_stop_all_threads();
+    info("stopping all running web server threads...");
+    web_client_multi_threaded_web_server_stop_all_threads();
 
-        info("freeing web clients cache...");
-        web_client_cache_destroy();
+    info("freeing web clients cache...");
+    web_client_cache_destroy();
 
-        info("cleanup completed.");
-    }
+    info("cleanup completed.");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 #define CLEANUP_EVERY_EVENTS 60
@@ -734,20 +748,16 @@ static inline int single_threaded_unlink_client(struct web_client *w, fd_set *if
 
 static void socket_listen_main_single_threaded_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;
-    if(static_thread->enabled) {
-        static_thread->enabled = 0;
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-        info("cleaning up...");
+    info("closing all sockets...");
+    listen_sockets_close(&api_sockets);
 
-        info("closing all sockets...");
-        listen_sockets_close(&api_sockets);
+    info("freeing web clients cache...");
+    web_client_cache_destroy();
 
-        info("freeing web clients cache...");
-        web_client_cache_destroy();
-
-        info("cleanup completed.");
-        debug(D_WEB_CLIENT, "LISTENER: exit!");
-    }
+    info("cleanup completed.");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *socket_listen_main_single_threaded(void *ptr) {
@@ -1141,41 +1151,42 @@ void *socket_listen_main_static_threaded_worker(void *ptr) {
 
 static void socket_listen_main_static_threaded_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
-    if(static_thread->enabled) {
-        int i, found = 0, max = 2 * USEC_PER_SEC, step = 50000;
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
+
+    int i, found = 0, max = 2 * USEC_PER_SEC, step = 50000;
+
+    // we start from 1, - 0 is self
+    for(i = 1; i < static_threaded_workers_count; i++) {
+        if(static_workers_private_data[i].running) {
+            found++;
+            info("stopping worker %d", i + 1);
+            netdata_thread_cancel(static_workers_private_data[i].thread);
+        }
+        else
+            info("found stopped worker %d", i + 1);
+    }
+
+    while(found && max > 0) {
+        max -= step;
+        info("Waiting %d static web threads to finish...", found);
+        sleep_usec(step);
+        found = 0;
 
         // we start from 1, - 0 is self
         for(i = 1; i < static_threaded_workers_count; i++) {
-            if(static_workers_private_data[i].running) {
+            if (static_workers_private_data[i].running)
                 found++;
-                info("stopping worker %d", i + 1);
-                netdata_thread_cancel(static_workers_private_data[i].thread);
-            }
-            else
-                info("found stopped worker %d", i + 1);
         }
-
-        while(found && max > 0) {
-            max -= step;
-            info("Waiting %d static web threads to finish...", found);
-            sleep_usec(step);
-            found = 0;
-
-            // we start from 1, - 0 is self
-            for(i = 1; i < static_threaded_workers_count; i++) {
-                if (static_workers_private_data[i].running)
-                    found++;
-            }
-        }
-
-        if(found)
-            error("%d static web threads are taking too long to finish. Giving up.", found);
-
-        info("closing all web server sockets...");
-        listen_sockets_close(&api_sockets);
-
-        static_thread->enabled = 0;
     }
+
+    if(found)
+        error("%d static web threads are taking too long to finish. Giving up.", found);
+
+    info("closing all web server sockets...");
+    listen_sockets_close(&api_sockets);
+
+    info("all static web threads stopped.");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 void *socket_listen_main_static_threaded(void *ptr) {

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -400,6 +400,7 @@ static struct web_client *web_client_create_on_listenfd(int listener) {
 // 4. it copies data from input to output if mode is FILECOPY
 
 int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
+int web_client_first_request_timeout = DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST;
 
 static void multi_threaded_web_client_worker_main_cleanup(void *ptr) {
     struct web_client *w = ptr;

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -38,7 +38,9 @@ extern void *socket_listen_main_single_threaded(void *ptr);
 extern void *socket_listen_main_static_threaded(void *ptr);
 extern int api_listen_sockets_setup(void);
 
+#define DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST 60
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
 extern int web_client_timeout;
+extern int web_client_first_request_timeout;
 
 #endif /* NETDATA_WEB_SERVER_H */


### PR DESCRIPTION
1. adds basic web server protections (static-threaded); fixes #3291;

   - the static-threaded web server now respects `disconnect idle clients after seconds` setting.
   - new setting added called `timeout for first request` to disconnect clients that are too slow to send requests.

2. also some improvements on the exit strategy of netdata
