### PR TITLE
sendmail in docker container

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -11,7 +11,7 @@ DEBIAN_FRONTEND=noninteractive
 # install dependencies for build
 
 apt-get -qq update
-apt-get -y install zlib1g-dev uuid-dev libmnl-dev gcc make curl git autoconf autogen automake pkg-config netcat-openbsd jq
+apt-get -y install zlib1g-dev uuid-dev libmnl-dev gcc make curl git autoconf autogen automake pkg-config netcat-openbsd jq heirloom-mailx mailutils
 apt-get -y install autoconf-archive lm-sensors nodejs python python-mysqldb python-yaml
 
 # use the provided installer
@@ -23,7 +23,7 @@ apt-get -y install autoconf-archive lm-sensors nodejs python python-mysqldb pyth
 cd /
 rm -rf /netdata.git
 
-dpkg -P zlib1g-dev uuid-dev libmnl-dev gcc make git autoconf autogen automake pkg-config
+dpkg -P zlib1g-dev uuid-dev libmnl-dev gcc git autoconf autogen automake pkg-config
 apt-get -y autoremove
 apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
It would be great if netdata docker container could send alerts right ?

With this update in the docker file, we can have health_alarm_notify.conf as such:

    env MAILRC=/dev/null smtp=smtps://{{ mail_dns }} smtp-auth-user={{ netdata_email }} smtp-auth-password={{ netdata_email_password }}
    sendmail="/usr/bin/mailx"

As reported by sudo -u netdata
/usr/libexec/netdata/plugins.d/alarm-notify.sh test::

    2018-01-18 10:34:48: alarm-notify.sh: INFO: sent email notification for: 2ef9fd259fe7 test.chart.test_alarm is CLEAR to 'root'
    # OK
