### PR TITLE
fix number printing, rounding bug

### DIFF
--- a/src/storage_number.c
+++ b/src/storage_number.c
@@ -162,6 +162,7 @@ int print_calculated_number(char *str, calculated_number value)
 */
 
 int print_calculated_number(char *str, calculated_number value) {
+    // info("printing number " CALCULATED_NUMBER_FORMAT, value);
     char integral_str[50], fractional_str[50];
 
     char *wstr = str;
@@ -179,25 +180,34 @@ int print_calculated_number(char *str, calculated_number value) {
     fractional = ((unsigned long long)(value * 10000000ULL) % 10000000ULL);
 #endif
 
+    unsigned long long integral_int = (unsigned long long)integral;
+    unsigned long long fractional_int = (unsigned long long)calculated_number_llrint(fractional);
+    if(unlikely(fractional_int >= 10000000)) {
+        integral_int += 1;
+        fractional_int -= 10000000;
+    }
+
+    // info("integral " CALCULATED_NUMBER_FORMAT " (%llu), fractional " CALCULATED_NUMBER_FORMAT " (%llu)", integral, integral_int, fractional, fractional_int);
+
     char *istre;
-    if(integral == 0.0) {
+    if(unlikely(integral_int == 0)) {
         integral_str[0] = '0';
         istre = &integral_str[1];
     }
     else
         // convert the integral part to string (reversed)
-        istre = print_number_llu_r_smart(integral_str, (unsigned long long)integral);
+        istre = print_number_llu_r_smart(integral_str, integral_int);
 
     // copy reversed the integral string
     istre--;
     while( istre >= integral_str ) *wstr++ = *istre--;
 
-    if(fractional != 0.0) {
+    if(likely(fractional_int != 0)) {
         // add a dot
         *wstr++ = '.';
 
         // convert the fractional part to string (reversed)
-        char *fstre = print_number_llu_r_smart(fractional_str, (unsigned long long)calculated_number_llrint(fractional));
+        char *fstre = print_number_llu_r_smart(fractional_str, fractional_int);
 
         // prepend zeros to reach 7 digits length
         int decimal = 7;
@@ -216,5 +226,6 @@ int print_calculated_number(char *str, calculated_number value) {
     }
 
     *wstr = '\0';
+    // info("printed number '%s'", str);
     return (int)(wstr - str);
 }

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -1,5 +1,41 @@
 #include "common.h"
 
+static int check_number_printing(void) {
+    struct {
+        calculated_number n;
+        const char *correct;
+    } values[] = {
+            { .n = 0, .correct = "0" },
+            { .n = 0.0000001,   .correct = "0.0000001" },
+            { .n = 0.00000009,  .correct = "0.0000001" },
+            { .n = 0.000000001, .correct = "0" },
+            { .n = 99.99999999999999999, .correct = "100" },
+            { .n = -99.99999999999999999, .correct = "-100" },
+            { .n = 123.4567890123456789, .correct = "123.456789" },
+            { .n = 9999.9999999, .correct = "9999.9999999" },
+            { .n = -9999.9999999, .correct = "-9999.9999999" },
+            { .n = 0, .correct = NULL },
+    };
+
+    char netdata[50], system[50];
+    int i, failed = 0;
+    for(i = 0; values[i].correct ; i++) {
+        print_calculated_number(netdata, values[i].n);
+        snprintfz(system, 49, "%0.12Lf", values[i].n);
+
+        int ok = 1;
+        if(strcmp(netdata, values[i].correct) != 0) {
+            ok = 0;
+            failed++;
+        }
+
+        fprintf(stderr, "'%s' (system) printed as '%s' (netdata): %s\n", system, netdata, ok?"OK":"FAILED");
+    }
+
+    if(failed) return 1;
+    return 0;
+}
+
 static int check_rrdcalc_comparisons(void) {
     RRDCALC_STATUS a, b;
 
@@ -1163,6 +1199,9 @@ static int test_variable_renames(void) {
 
 int run_all_mockup_tests(void)
 {
+    if(check_number_printing())
+        return 1;
+
     if(check_rrdcalc_comparisons())
         return 1;
 


### PR DESCRIPTION
ok, this in unbelievable... (and embarrassing at the same time)

netdata has its own number printing functions. The reason is simple. Since netdata APIs return JSON data, numbers are printed.

Run `netdata -W unittest` and you will get:

```
INTERNAL LONG DOUBLE PRINTING: user 0.50391, system 0.02537, total 0.52929
SYSTEM   LONG DOUBLE PRINTING: user 6.10134, system 0.02674, total 6.12808
NETDATA CODE IS  F A S T E R  1057.80 %
```

So, it is a bit faster than the system functions.

But there was a bug: The number `99.999999999999999999` (which are common when working with long double variables) was printed as `99.1` !

The reason was that netdata used `modfl()` to split the number into its integral and fractional part.
The integral part (99) was printed and then to print the fractional multiplied it by 10000000 (7 digits is the precision of the database format), converted to integer with `llrint()` and printed it.

However, `llrint()` rounded the number of the nearest integer, so it was overflown and only a ` 1 ` was printed. Thus `99.1`.

This PR fixes it.
