### PR TITLE
do not loose the last byte of web file copies; 

### DIFF
--- a/src/web_client.c
+++ b/src/web_client.c
@@ -1596,7 +1596,7 @@ ssize_t web_client_read_file(struct web_client *w)
         return 0;
 
     ssize_t left = w->response.rlen - w->response.data->len;
-    ssize_t bytes = read(w->ifd, &w->response.data->buffer[w->response.data->len], (size_t) (left - 1));
+    ssize_t bytes = read(w->ifd, &w->response.data->buffer[w->response.data->len], (size_t)left);
     if(likely(bytes > 0)) {
         size_t old = w->response.data->len;
         w->response.data->len += bytes;


### PR DESCRIPTION
fixes #https://github.com/firehol/netdata/issues/1956#issuecomment-357945409

Recent changes to the web server, made netdata loose the last byte of all static files served via its web server.

The problem was only visible when gzip was disabled, because the client received wrong number of bytes.