### PR TITLE
check if netdata is really started;

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -506,10 +506,20 @@ install_netdata_service() {
 
     if [ "${UID}" -eq 0 ]
     then
-        if [ "${uname}" = "FreeBSD" ]
+        if [ "${uname}" = "Darwin" ]
         then
+
+            echo >&2 "hm... I don't know how to install a startup script for MacOS X"
+            return 1
+
+        elif [ "${uname}" = "FreeBSD" ]
+        then
+
             run cp system/netdata-freebsd /etc/rc.d/netdata && \
+                NETDATA_START_CMD="service netdata start" && \
+                NETDATA_STOP_CMD="service netdata stop" && \
                 return 0
+
         elif issystemd
         then
             # systemd is running on this system

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -502,9 +502,15 @@ NETDATA_START_CMD="netdata"
 NETDATA_STOP_CMD="killall netdata"
 
 install_netdata_service() {
+    local uname="$(uname 2>/dev/null)"
+
     if [ "${UID}" -eq 0 ]
     then
-        if issystemd
+        if [ "${uname}" = "FreeBSD" ]
+        then
+            run cp system/netdata-freebsd /etc/rc.d/netdata && \
+                return 0
+        elif issystemd
         then
             # systemd is running on this system
             NETDATA_START_CMD="systemctl start netdata"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -687,7 +687,8 @@ fi
 
 # the owners of the web files
 NETDATA_WEB_USER="$(  config_option "web" "web files owner" "${NETDATA_USER}" )"
-NETDATA_WEB_GROUP="$( config_option "web" "web files group" "${NETDATA_WEB_USER}" )"
+[ "${UID}" = "0" -a "${NETDATA_USER}" != "${NETDATA_WEB_USER}" ] && NETDATA_GROUP="${NETDATA_WEB_USER}"
+NETDATA_WEB_GROUP="$( config_option "web" "web files group" "${NETDATA_GROUP}" )"
 
 # port
 defport=19999

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -746,7 +746,7 @@ do
         run mkdir -p "${x}" || exit 1
     fi
 
-    run chown -R "${NETDATA_USER}:${NETDATA_USER}" "${x}"
+    run chown -R "${NETDATA_USER}:${NETDATA_GROUP}" "${x}"
     #run find "${x}" -type f -exec chmod 0660 {} \;
     #run find "${x}" -type d -exec chmod 0770 {} \;
 done

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -687,7 +687,11 @@ fi
 
 # the owners of the web files
 NETDATA_WEB_USER="$(  config_option "web" "web files owner" "${NETDATA_USER}" )"
-[ "${UID}" = "0" -a "${NETDATA_USER}" != "${NETDATA_WEB_USER}" ] && NETDATA_GROUP="${NETDATA_WEB_USER}"
+if [ "${UID}" = "0" -a "${NETDATA_USER}" != "${NETDATA_WEB_USER}" ]
+then
+    NETDATA_GROUP="$(id -g -n ${NETDATA_WEB_USER})"
+    [ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_WEB_USER}"
+fi
 NETDATA_WEB_GROUP="$( config_option "web" "web files group" "${NETDATA_GROUP}" )"
 
 # port
@@ -702,6 +706,27 @@ NETDATA_LOG_DIR="$( config_option "global" "log directory" "${NETDATA_PREFIX}/va
 NETDATA_CONF_DIR="$( config_option "global" "config directory" "${NETDATA_PREFIX}/etc/netdata" )"
 NETDATA_RUN_DIR="${NETDATA_PREFIX}/var/run"
 
+cat <<OPTIONSEOF
+
+    Permissions
+    - netdata user     : ${NETDATA_USER}
+    - netdata group    : ${NETDATA_GROUP}
+    - web files user   : ${NETDATA_WEB_USER}
+    - web files group  : ${NETDATA_WEB_GROUP}
+    - root user        : ${ROOT_USER}
+
+    Directories
+    - netdata conf dir : ${NETDATA_CONF_DIR}
+    - netdata log dir  : ${NETDATA_LOG_DIR}
+    - netdata run dir  : ${NETDATA_RUN_DIR}
+    - netdata lib dir  : ${NETDATA_LIB_DIR}
+    - netdata web dir  : ${NETDATA_WEB_DIR}
+    - netdata cache dir: ${NETDATA_CACHE_DIR}
+
+    Other
+    - netdata port     : ${NETDATA_PORT}
+
+OPTIONSEOF
 
 # -----------------------------------------------------------------------------
 progress "Fix permissions of netdata directories (using user '${NETDATA_USER}')"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -869,11 +869,13 @@ else
     download_netdata_conf "${NETDATA_USER}" "${NETDATA_PREFIX}/etc/netdata/netdata.conf" "http://localhost:${NETDATA_PORT}/netdata.conf"
 fi
 
-# -----------------------------------------------------------------------------
-progress "Check KSM (kernel memory deduper)"
+if [ "$(uname)" = "Linux" ]
+then
+    # -------------------------------------------------------------------------
+    progress "Check KSM (kernel memory deduper)"
 
-ksm_is_available_but_disabled() {
-    cat <<KSM1
+    ksm_is_available_but_disabled() {
+        cat <<KSM1
 
 ${TPUT_BOLD}Memory de-duplication instructions${TPUT_RESET}
 
@@ -888,10 +890,10 @@ To enable it run:
 If you enable it, you will save 40-60% of netdata memory.
 
 KSM1
-}
+    }
 
-ksm_is_not_available() {
-    cat <<KSM2
+    ksm_is_not_available() {
+        cat <<KSM2
 
 ${TPUT_BOLD}Memory de-duplication not present in your kernel${TPUT_RESET}
 
@@ -903,17 +905,19 @@ To enable it, you need a kernel built with CONFIG_KSM=y
 If you can have it, you will save 40-60% of netdata memory.
 
 KSM2
-}
+    }
 
-if [ -f "/sys/kernel/mm/ksm/run" ]
-    then
-    if [ $(cat "/sys/kernel/mm/ksm/run") != "1" ]
+    if [ -f "/sys/kernel/mm/ksm/run" ]
         then
-        ksm_is_available_but_disabled
+        if [ $(cat "/sys/kernel/mm/ksm/run") != "1" ]
+            then
+            ksm_is_available_but_disabled
+        fi
+    else
+        ksm_is_not_available
     fi
-else
-    ksm_is_not_available
 fi
+
 
 # -----------------------------------------------------------------------------
 progress "Check version.txt"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -678,9 +678,11 @@ if [ "${UID}" = "0" ]
     then
     NETDATA_USER="$( config_option "global" "run as user" "netdata" )"
     NETDATA_GROUP="${NETDATA_USER}"
+    ROOT_USER="root"
 else
     NETDATA_USER="${USER}"
     NETDATA_GROUP="$(id -g -n ${NETDATA_USER})"
+    ROOT_USER="${NETDATA_USER}"
 fi
 
 # the owners of the web files
@@ -719,7 +721,7 @@ do
         run mkdir -p "${NETDATA_CONF_DIR}/${x}" || exit 1
     fi
 done
-run chown -R "root:${NETDATA_GROUP}" "${NETDATA_CONF_DIR}"
+run chown -R "${ROOT_USER}:${NETDATA_GROUP}" "${NETDATA_CONF_DIR}"
 run find "${NETDATA_CONF_DIR}" -type f -exec chmod 0640 {} \;
 run find "${NETDATA_CONF_DIR}" -type d -exec chmod 0755 {} \;
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -677,10 +677,11 @@ config_option() {
 if [ "${UID}" = "0" ]
     then
     NETDATA_USER="$( config_option "global" "run as user" "netdata" )"
+    NETDATA_GROUP="${NETDATA_USER}"
 else
     NETDATA_USER="${USER}"
+    NETDATA_GROUP="$(id -g -n ${NETDATA_USER})"
 fi
-NETDATA_GROUP="${NETDATA_USER}"
 
 # the owners of the web files
 NETDATA_WEB_USER="$(  config_option "web" "web files owner" "${NETDATA_USER}" )"

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -8,6 +8,7 @@ CLEANFILES = \
 	netdata.service \
 	netdata-init-d \
 	netdata-lsb \
+	netdata-freebsd \
 	$(NULL)
 
 include $(top_srcdir)/build/subst.inc
@@ -20,6 +21,7 @@ nodist_noinst_DATA = \
 	netdata.service \
 	netdata-init-d \
 	netdata-lsb \
+	netdata-freebsd \
 	$(NULL)
 
 dist_noinst_DATA = \
@@ -28,5 +30,6 @@ dist_noinst_DATA = \
 	netdata.service.in \
 	netdata-init-d.in \
 	netdata-lsb.in \
+	netdata-freebsd.in \
 	netdata.conf \
 	$(NULL)

--- a/system/netdata-freebsd.in
+++ b/system/netdata-freebsd.in
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+. /etc/rc.subr
+
+name=netdata
+rcvar=netdata_enable
+
+pidfile="@localstatedir_POST@/run/netdata.pid"
+
+command="@sbindir_POST@/netdata"
+command_args="-P ${pidfile}"
+
+required_files="@sysconfdir_POST@/netdata/netdata.conf"
+
+start_precmd="netdata_prestart"
+stop_postcmd="netdata_poststop"
+
+extra_commands="reloadhealth savedb"
+
+reloadhealth_cmd="netdata_reloadhealth"
+savedb_cmd="netdata_savedb"
+
+netdata_prestart()
+{
+	return 0
+}
+
+netdata_poststop()
+{
+	return 0
+}
+
+netdata_reloadhealth()
+{
+    kill -USR2 `cat ${pidfile}`
+    return 0
+}
+
+netdata_savedb()
+{
+    kill -USR1 `cat ${pidfile}`
+    return 0
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/system/netdata-freebsd.in
+++ b/system/netdata-freebsd.in
@@ -32,13 +32,15 @@ netdata_poststop()
 
 netdata_reloadhealth()
 {
-    kill -USR2 `cat ${pidfile}`
+    p=`cat ${pidfile}`
+    kill -USR2 ${p} && echo "Sent USR2 (reload health) to pid ${p}"
     return 0
 }
 
 netdata_savedb()
 {
-    kill -USR1 `cat ${pidfile}`
+    p=`cat ${pidfile}`
+    kill -USR2 ${p} && echo "Sent USR1 (save db) to pid ${p}"
     return 0
 }
 

--- a/web/dashboard.css
+++ b/web/dashboard.css
@@ -462,7 +462,7 @@ body {
     float: left;
     left: 0;
     width: 64%;
-    margin-left: 18%;
+    margin-left: 18% !important;
     text-align: center;
     color: #999999;
     font-weight: bold;
@@ -474,7 +474,7 @@ body {
     float: left;
     left: 0;
     width: 60%;
-    margin-left: 20%;
+    margin-left: 20% !important;
     text-align: center;
     color: #999999;
     font-weight: normal;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -162,7 +162,7 @@ var NETDATA = window.NETDATA || {};
     NETDATA.themes = {
         white: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-3.3.7.css',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20180115-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.css?v20180120-1',
             background: '#FFFFFF',
             foreground: '#000000',
             grid: '#F0F0F0',
@@ -180,7 +180,7 @@ var NETDATA = window.NETDATA || {};
         },
         slate: {
             bootstrap_css: NETDATA.serverStatic + 'css/bootstrap-slate-flat-3.3.7.css?v20161229-1',
-            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20180115-1',
+            dashboard_css: NETDATA.serverStatic + 'dashboard.slate.css?v20180120-1',
             background: '#272b30',
             foreground: '#C8C8C8',
             grid: '#283236',

--- a/web/dashboard.slate.css
+++ b/web/dashboard.slate.css
@@ -480,7 +480,7 @@ code {
     float: left;
     left: 0;
     width: 64%;
-    margin-left: 18%;
+    margin-left: 18% !important;
     text-align: center;
     color: #676b70;
     font-weight: bold;
@@ -492,7 +492,7 @@ code {
     float: left;
     left: 0;
     width: 60%;
-    margin-left: 20%;
+    margin-left: 20% !important;
     text-align: center;
     color: #676b70;
     font-weight: normal;


### PR DESCRIPTION
- [x] The installers check that netdata was really started, after calling `systemctl` or `service` to start netdata.  fixes #3321 

Also:

- [x] added a freebsd init file
- [x] removed errors about apps.plugins when apps.plugin is not compiles (MacOS)
- [x] removed info about KSM when not under Linux
- [x] allowed a non-root installation to work without errors on all systems (Linux, FreeBSD, MacOS)
- [x] fixed a minor text alignment issue when easypiecharts are rendered under reveal.js
