### PR TITLE
Enable compatible FreeBSD alarms

### DIFF
--- a/conf.d/health.d/cpu.conf
+++ b/conf.d/health.d/cpu.conf
@@ -39,3 +39,17 @@ template: 20min_steal_cpu
    delay: down 1h multiplier 1.5 max 2h
     info: average CPU steal time for the last 20 minutes
       to: sysadmin
+
+## FreeBSD
+template: 10min_cpu_usage
+      on: system.cpu
+      os: freebsd
+   hosts: *
+  lookup: average -10m unaligned of user,system,interrupt
+   units: %
+   every: 1m
+    warn: $this > (($status >= $WARNING)  ? (75) : (85))
+    crit: $this > (($status == $CRITICAL) ? (85) : (95))
+   delay: down 15m multiplier 1.5 max 1h
+    info: average cpu utilization for the last 10 minutes (excluding nice)
+      to: sysadmin

--- a/conf.d/health.d/disks.conf
+++ b/conf.d/health.d/disks.conf
@@ -11,7 +11,7 @@
 
 template: disk_space_usage
       on: disk.space
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
     calc: $used * 100 / ($avail + $used)
@@ -25,7 +25,7 @@ families: *
 
 template: disk_inode_usage
       on: disk.inodes
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
     calc: $used * 100 / ($avail + $used)
@@ -51,7 +51,7 @@ families: *
 
 template: disk_fill_rate
       on: disk.space
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
   lookup: min -10m at -50m unaligned of avail
@@ -67,7 +67,7 @@ families: *
 
 template: out_of_disk_space_time
       on: disk.space
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
     calc: ($disk_fill_rate > 0) ? ($avail / $disk_fill_rate) : (inf)
@@ -89,7 +89,7 @@ families: *
 
 template: 10min_disk_utilization
       on: disk.util
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
   lookup: average -10m unaligned

--- a/conf.d/health.d/ipc.conf
+++ b/conf.d/health.d/ipc.conf
@@ -3,7 +3,7 @@
 
    alarm: semaphores_used
       on: system.ipc_semaphores
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: $semaphores * 100 / $ipc.semaphores.max
    units: %
@@ -16,7 +16,7 @@
 
    alarm: semaphore_arrays_used
       on: system.ipc_semaphore_arrays
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: $arrays * 100 / $ipc.semaphores.arrays.max
    units: %

--- a/conf.d/health.d/ipc.conf
+++ b/conf.d/health.d/ipc.conf
@@ -3,7 +3,7 @@
 
    alarm: semaphores_used
       on: system.ipc_semaphores
-      os: linux freebsd
+      os: linux
    hosts: *
     calc: $semaphores * 100 / $ipc.semaphores.max
    units: %
@@ -16,7 +16,7 @@
 
    alarm: semaphore_arrays_used
       on: system.ipc_semaphore_arrays
-      os: linux freebsd
+      os: linux
    hosts: *
     calc: $arrays * 100 / $ipc.semaphores.arrays.max
    units: %

--- a/conf.d/health.d/net.conf
+++ b/conf.d/health.d/net.conf
@@ -98,7 +98,7 @@ families: *
 
 template: 1m_received_packets_rate
       on: net.packets
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
   lookup: average -1m of received
@@ -108,7 +108,7 @@ families: *
 
 template: 10s_received_packets_storm
       on: net.packets
-      os: linux
+      os: linux freebsd
    hosts: *
 families: *
   lookup: average -10s of received
@@ -120,4 +120,3 @@ families: *
 options: no-clear-notification
    info: the % of the rate of received packets in the last 10 seconds, compared to the rate of the last minute (clear notification for this alarm will not be sent)
      to: sysadmin
-

--- a/conf.d/health.d/ram.conf
+++ b/conf.d/health.d/ram.conf
@@ -35,3 +35,30 @@
    delay: down 15m multiplier 1.5 max 1h
     info: estimated amount of RAM available for userspace processes, without causing swapping
       to: sysadmin
+
+## FreeBSD
+alarm: ram_in_use
+   on: system.ram
+   os: freebsd
+hosts: *
+ calc: (($active + $wired) - $used_ram_to_ignore) * 100 / (($active + $wired) - $used_ram_to_ignore + $cached + $free)
+units: %
+every: 10s
+ warn: $this > (($status >= $WARNING)  ? (80) : (90))
+ crit: $this > (($status == $CRITICAL) ? (90) : (98))
+delay: down 15m multiplier 1.5 max 1h
+ info: system RAM usage
+   to: sysadmin
+
+ alarm: ram_available
+    on: system.ram
+    os: freebsd
+ hosts: *
+  calc: ($free + $inactive + $used_ram_to_ignore) * 100 / ($free + $active + $inactive + $wired + $cache + $buffers)
+ units: %
+ every: 10s
+  warn: $this < (($status >= $WARNING)  ? ( 5) : (10))
+  crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
+ delay: down 15m multiplier 1.5 max 1h
+  info: estimated amount of RAM available for userspace processes, without causing swapping
+    to: sysadmin

--- a/conf.d/health.d/softnet.conf
+++ b/conf.d/health.d/softnet.conf
@@ -26,3 +26,17 @@
    delay: down 1h multiplier 1.5 max 2h
     info: number of times, during the last 10min, ksoftirq ran out of sysctl net.core.netdev_budget or time slice, with work remaining (this can be a cause for dropped packets)
       to: silent
+
+
+## FreeBSD
+alarm: 10min_netisr_backlog_exceeded
+   on: system.softnet_stat
+   os: freebsd
+hosts: *
+lookup: sum -10m unaligned absolute of qdrops
+units: packets
+every: 1m
+ warn: $this > 0
+delay: down 1h multiplier 1.5 max 2h
+ info: number of drops in the last 10min, because sysctl net.route.netisr_maxqlen was exceeded (this can be a cause for dropped packets)
+   to: sysadmin

--- a/conf.d/health.d/swap.conf
+++ b/conf.d/health.d/swap.conf
@@ -3,7 +3,7 @@
 
    alarm: 30min_ram_swapped_out
       on: system.swapio
-      os: linux
+      os: linux freebsd
    hosts: *
   lookup: sum -30m unaligned absolute of out
           # we have to convert KB to MB by dividing $this (i.e. the result of the lookup) with 1024
@@ -31,7 +31,7 @@
 
    alarm: used_swap
       on: system.swap
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: $used * 100 / ( $used + $free )
    units: %

--- a/conf.d/health.d/tcp_resets.conf
+++ b/conf.d/health.d/tcp_resets.conf
@@ -41,30 +41,6 @@
     info: average TCP RESETS this host is sending, over the last 10 seconds (this can be an indication that a port scan is made, or that a service running on this host has crashed; clear notification for this alarm will not be sent)
       to: sysadmin
 
-
- ## FreeBSD
-   alarm: 1m_ipv4_tcp_resets_sent
-      on: ipv4.tcphandshake
-      os: freebsd
-   hosts: *
-  lookup: average -1m at -10s unaligned absolute of EstabResets
-   units: tcp resets/s
-   every: 10s
-    info: average TCP RESETS this host is sending, over the last minute
-
-   alarm: 10s_ipv4_tcp_resets_sent
-      on: ipv4.tcphandshake
-      os: freebsd
-   hosts: *
-  lookup: average -10s unaligned absolute of EstabResets
-   units: tcp resets/s
-   every: 10s
-    warn: $this > ((($1m_ipv4_tcp_resets_sent < 5)?(5):($1m_ipv4_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (20)))
-   delay: up 0 down 60m multiplier 1.2 max 2h
-  options: no-clear-notification
-    info: average TCP RESETS this host is sending, over the last 10 seconds (this can be an indication that a port scan is made, or that a service running on this host has crashed; clear notification for this alarm will not be sent)
-      to: sysadmin
-
 # -----------------------------------------------------------------------------
 # tcp resets this host receives
 

--- a/conf.d/health.d/tcp_resets.conf
+++ b/conf.d/health.d/tcp_resets.conf
@@ -5,7 +5,7 @@
 
    alarm: ipv4_tcphandshake_last_collected_secs
       on: ipv4.tcphandshake
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: $now - $last_collected_t
    units: seconds ago
@@ -41,12 +41,36 @@
     info: average TCP RESETS this host is sending, over the last 10 seconds (this can be an indication that a port scan is made, or that a service running on this host has crashed; clear notification for this alarm will not be sent)
       to: sysadmin
 
+
+ ## FreeBSD
+   alarm: 1m_ipv4_tcp_resets_sent
+      on: ipv4.tcphandshake
+      os: freebsd
+   hosts: *
+  lookup: average -1m at -10s unaligned absolute of EstabResets
+   units: tcp resets/s
+   every: 10s
+    info: average TCP RESETS this host is sending, over the last minute
+
+   alarm: 10s_ipv4_tcp_resets_sent
+      on: ipv4.tcphandshake
+      os: freebsd
+   hosts: *
+  lookup: average -10s unaligned absolute of EstabResets
+   units: tcp resets/s
+   every: 10s
+    warn: $this > ((($1m_ipv4_tcp_resets_sent < 5)?(5):($1m_ipv4_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (20)))
+   delay: up 0 down 60m multiplier 1.2 max 2h
+  options: no-clear-notification
+    info: average TCP RESETS this host is sending, over the last 10 seconds (this can be an indication that a port scan is made, or that a service running on this host has crashed; clear notification for this alarm will not be sent)
+      to: sysadmin
+
 # -----------------------------------------------------------------------------
 # tcp resets this host receives
 
    alarm: 1m_ipv4_tcp_resets_received
       on: ipv4.tcphandshake
-      os: linux
+      os: linux freebsd
    hosts: *
   lookup: average -1m at -10s unaligned absolute of AttemptFails
    units: tcp resets/s
@@ -55,7 +79,7 @@
 
    alarm: 10s_ipv4_tcp_resets_received
       on: ipv4.tcphandshake
-      os: linux
+      os: linux freebsd
    hosts: *
   lookup: average -10s unaligned absolute of AttemptFails
    units: tcp resets/s

--- a/conf.d/health.d/udp_errors.conf
+++ b/conf.d/health.d/udp_errors.conf
@@ -5,7 +5,7 @@
 
    alarm: ipv4_udperrors_last_collected_secs
       on: ipv4.udperrors
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: $now - $last_collected_t
    units: seconds ago
@@ -21,7 +21,7 @@
 
    alarm: 1m_ipv4_udp_receive_buffer_errors
       on: ipv4.udperrors
-      os: linux
+      os: linux freebsd
    hosts: *
   lookup: sum -1m unaligned absolute of RcvbufErrors
    units: errors


### PR DESCRIPTION
I went through #3267 , enabling, adapting, and verifying the 'Linux-only' alarms.

A few comments:
disks.conf - Appears to work, but a known bug with the badges is already reported.  I enabled this for now.  See #3253 
ipc.conf - FreeBSD doesn't have ipc.semaphores.max or semaphores.arrays.max, making this unusable.
softnet.conf - I think qdrops is a roughly equivalent choice.
swap.conf - I don't know of a good way to calculate ram_in_swap for FreeBSD.  Maybe there's a reasonable way to do this?
tcp_conn.conf - No metric for tcp_max_connections nor am I sure how this is calculated on Linux
tcp_listen.conf  - This does work, but the FreeBSD package doesn't include the default as an example as it does for every other value.  I used this to test:
[plugin:freebsd:net.inet.tcp.stats]
        TCP listen issues = yes

I didn't see any immediately obvious way to enable these for FreeBSD:
entropy.conf - Fortuna (random) only ever blocks during system boot AFAIK, so probably not needed for FreeBSD?  See https://www.freebsd.org/cgi/man.cgi?query=random&sektion=4
tcp_mem.conf, tcp_orphans.conf, qos.conf - No metrics for these.

Test evidence from the alarms modal:
https://docs.google.com/document/d/e/2PACX-1vRh5MYFoMBe678-FTf77sZIoZI-hOfdbfLmVb6flMu85BXziAL9yV1qi9ROZM-Udjm28NbSZW5T6i46/pub