### PR TITLE
added API parameter gpoints=N to allow emulating different data collection periods

### DIFF
--- a/src/health.c
+++ b/src/health.c
@@ -428,6 +428,7 @@ void *health_main(void *ptr) {
                                                   , rc->after
                                                   , rc->before
                                                   , rc->group
+                                                  , 0
                                                   , rc->options
                                                   , &rc->db_after
                                                   , &rc->db_before

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -72,11 +72,11 @@ extern void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb);
 
 extern int rrdset2anything_api_v1(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points
-                            , long long after, long long before, int group_method, uint32_t options
+                            , long long after, long long before, int group_method, long group_points, uint32_t options
                             , time_t *latest_timestamp);
 
 extern int rrdset2value_api_v1(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points
-                            , long long after, long long before, int group_method, uint32_t options
+                            , long long after, long long before, int group_method, long group_points, uint32_t options
                             , time_t *db_after, time_t *db_before, int *value_is_null);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/web/netdata-swagger.json
+++ b/web/netdata-swagger.json
@@ -133,6 +133,16 @@
                         "allowEmptyValue": false
                     },
                     {
+                        "name": "gpoints",
+                        "in": "query",
+                        "description": "The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).",
+                        "required": false,
+                        "type": "number",
+                        "format": "integer",
+                        "allowEmptyValue": false,
+                        "default": 0
+                    },
+                    {
                         "name": "format",
                         "in": "query",
                         "description": "The format of the data to be returned.",

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -95,6 +95,14 @@ paths:
           enum: [ 'min', 'max', 'average', 'sum', 'incremental-sum' ]
           default: 'average'
           allowEmptyValue: false
+        - name: gpoints
+          in: query
+          description: 'The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).'
+          required: false
+          type: number
+          format: integer
+          allowEmptyValue: false
+          default: 0
         - name: format
           in: query
           description: 'The format of the data to be returned.'


### PR DESCRIPTION
The netdata API already supports a parameter called `points`. This sets the number of points that must be returned from a `data` API call.

So, if the query asks for 1 hour of data (3600 seconds), setting `points=60` will reduce the 3600 data points to 60 points, using the calculation specified at `method=` (`average`, `sum`, etc). So, with `method=sum` this call will return 60 points, each summing 60 points of the database, ie. it will return `X / min`.

The above works well, until the chart is zoomed by hand. If the chart is zoomed-in to let's say 1200 seconds, netdata will now return again `points=60`, but this time aggregating only 20 database points, which completely destroys the per-minute expectation.

To fix it, this PR adds another parameter `gpoints=N`. This works only when `method=average`. Specifying `gpoints=60` will force netdata to always aggregate in multiples of 60 data collection points. So, no matter how the chart is zoomed, the result will always be per-minute.

Keep in mind `gpoints=A` and `points=B` can work together. So, with `method=average` and one hour of data, we can set `gpoints=60` and `points=10`, to have netdata return 10 points, each with the per-minute average of 60 data collection points (i.e. for each returned points netdata will sum 360 database points and divide them by 6 to get the per-minute average).

Of course, setting `gpoints` to anything above 1, will force the chart to be aligned.

Using `gpoints` we can now switch chart units. Of course the units label is not changed automatically, but the data will adapt.

netdata will apply this to all types of metrics (`absolute`, `incremental`, etc), so this option should used only when there is meaning to do so. 
