### PR TITLE
added API parameter gtime=SECS to support server side convertion of units

### DIFF
--- a/src/health.c
+++ b/src/health.c
@@ -428,6 +428,7 @@ void *health_main(void *ptr) {
                                                   , rc->after
                                                   , rc->before
                                                   , rc->group
+                                                  , 0
                                                   , rc->options
                                                   , &rc->db_after
                                                   , &rc->db_before

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -72,11 +72,11 @@ extern void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb);
 
 extern int rrdset2anything_api_v1(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points
-                            , long long after, long long before, int group_method, uint32_t options
+                            , long long after, long long before, int group_method, long group_points, uint32_t options
                             , time_t *latest_timestamp);
 
 extern int rrdset2value_api_v1(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points
-                            , long long after, long long before, int group_method, uint32_t options
+                            , long long after, long long before, int group_method, long group_points, uint32_t options
                             , time_t *db_after, time_t *db_before, int *value_is_null);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/src/rrd2json.h
+++ b/src/rrd2json.h
@@ -72,11 +72,11 @@ extern void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb);
 extern void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb);
 
 extern int rrdset2anything_api_v1(RRDSET *st, BUFFER *out, BUFFER *dimensions, uint32_t format, long points
-                            , long long after, long long before, int group_method, long group_points, uint32_t options
+                            , long long after, long long before, int group_method, long group_time, uint32_t options
                             , time_t *latest_timestamp);
 
 extern int rrdset2value_api_v1(RRDSET *st, BUFFER *wb, calculated_number *n, const char *dimensions, long points
-                            , long long after, long long before, int group_method, long group_points, uint32_t options
+                            , long long after, long long before, int group_method, long group_time, uint32_t options
                             , time_t *db_after, time_t *db_before, int *value_is_null);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -611,7 +611,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     char *chart = NULL
     , *before_str = NULL
     , *after_str = NULL
-    , *group_points_str = NULL
+    , *group_time_str = NULL
     , *points_str = NULL;
 
     int group = GROUP_AVERAGE;
@@ -640,7 +640,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         else if(!strcmp(name, "after")) after_str = value;
         else if(!strcmp(name, "before")) before_str = value;
         else if(!strcmp(name, "points")) points_str = value;
-        else if(!strcmp(name, "gpoints")) group_points_str = value;
+        else if(!strcmp(name, "gtime")) group_time_str = value;
         else if(!strcmp(name, "group")) {
             group = web_client_api_request_v1_data_group(value, GROUP_AVERAGE);
         }
@@ -707,7 +707,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     long long before = (before_str && *before_str)?str2l(before_str):0;
     long long after  = (after_str  && *after_str) ?str2l(after_str):0;
     int       points = (points_str && *points_str)?str2i(points_str):0;
-    long      group_points = (group_points_str && *group_points_str)?str2l(group_points_str):0;
+    long      group_time = (group_time_str && *group_time_str)?str2l(group_time_str):0;
 
     debug(D_WEB_CLIENT, "%llu: API command 'data' for chart '%s', dimensions '%s', after '%lld', before '%lld', points '%d', group '%d', format '%u', options '0x%08x'"
           , w->id
@@ -746,7 +746,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         buffer_strcat(w->response.data, "(");
     }
 
-    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_points
+    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_time
                                  , options, &last_timestamp_in_data);
 
     if(format == DATASOURCE_DATATABLE_JSONP) {

--- a/web/netdata-swagger.json
+++ b/web/netdata-swagger.json
@@ -133,6 +133,16 @@
                         "allowEmptyValue": false
                     },
                     {
+                        "name": "gpoints",
+                        "in": "query",
+                        "description": "The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).",
+                        "required": false,
+                        "type": "number",
+                        "format": "integer",
+                        "allowEmptyValue": false,
+                        "default": 0
+                    },
+                    {
                         "name": "format",
                         "in": "query",
                         "description": "The format of the data to be returned.",

--- a/web/netdata-swagger.json
+++ b/web/netdata-swagger.json
@@ -133,9 +133,9 @@
                         "allowEmptyValue": false
                     },
                     {
-                        "name": "gpoints",
+                        "name": "gtime",
                         "in": "query",
-                        "description": "The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).",
+                        "description": "The grouping number of seconds. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gtime=60 will turn them to per-minute).",
                         "required": false,
                         "type": "number",
                         "format": "integer",

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -95,9 +95,9 @@ paths:
           enum: [ 'min', 'max', 'average', 'sum', 'incremental-sum' ]
           default: 'average'
           allowEmptyValue: false
-        - name: gpoints
+        - name: gtime
           in: query
-          description: 'The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).'
+          description: 'The grouping number of seconds. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gtime=60 will turn them to per-minute).'
           required: false
           type: number
           format: integer

--- a/web/netdata-swagger.yaml
+++ b/web/netdata-swagger.yaml
@@ -95,6 +95,14 @@ paths:
           enum: [ 'min', 'max', 'average', 'sum', 'incremental-sum' ]
           default: 'average'
           allowEmptyValue: false
+        - name: gpoints
+          in: query
+          description: 'The grouping number of points. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gpoints=60 will turn them to per-minute).'
+          required: false
+          type: number
+          format: integer
+          allowEmptyValue: false
+          default: 0
         - name: format
           in: query
           description: 'The format of the data to be returned.'


### PR DESCRIPTION
The netdata API already supports a parameter called `points`. This sets the number of points desired to be returned from a `data` API call.

So, if the query asks for 1 hour of data (3600 seconds), setting `points=60` will reduce the 3600 data points to 60 points, using the calculation specified at `group=` (`average`, `sum`, etc). With `group=sum` this call will return 60 points, each summing 60 points of the database, ie. it will return `X / min`.

The above works well, until the chart is zoomed by hand. If the chart is zoomed-in to let's say 1200 seconds, netdata will now return again `points=60`, but this time aggregating only 20 database points, which completely destroys the per-minute expectation.

To fix it, this PR adds another parameter `gtime=SECS`. This works only when `group=average`. Specifying `gtime=60` will instruct netdata to aggregate in multiples of 60 seconds. So, no matter how the chart is zoomed, the result will always be per-minute.

Keep in mind `gtime=A` and `points=B` can work together. So, with `group=average` and one hour of data, we can set `gtime=60` and `points=10`, to have netdata return 10 points, each with the per-minute average of 60 data collection points (i.e. for each of the returned points, netdata will sum 360 database points and divide them by 6 to get the per-minute average).

Using `gtime` we can now switch chart units. Of course the units label is not changed automatically, but the data will adapt.

netdata will apply this to all types of metrics (`absolute`, `incremental`, etc), so this option should used only when there is meaning to do so. 

netdata also supports such responses to be unaligned, providing, e.g. **rolling per minute**.

---

with the addition of PR #3344 (d3pie library) it would be nice to have pie/donut charts for e.g. web server response codes. However, presenting a pie chart with per-second resolution is problematic. For busy servers it would probably be ok, but for servers that are not that busy, the chart will most probably be empty most of the time.

This PR allows adding such pie or gauge charts with different units. So, the main chart will be per-second, but the pie chart will present the same info per minute. 

---

fixes #3350 