### PR TITLE
allow netdata to be compiled without long double; 

### DIFF
--- a/src/appconfig.c
+++ b/src/appconfig.c
@@ -297,10 +297,10 @@ long long appconfig_get_number(struct config *root, const char *section, const c
     return strtoll(s, NULL, 0);
 }
 
-long double appconfig_get_float(struct config *root, const char *section, const char *name, long double value)
+LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
 {
     char buffer[100], *s;
-    sprintf(buffer, "%0.5Lf", value);
+    sprintf(buffer, "%0.5" LONG_DOUBLE_MODIFIER, value);
 
     s = appconfig_get(root, section, name, buffer);
     if(!s) return value;
@@ -407,10 +407,10 @@ long long appconfig_set_number(struct config *root, const char *section, const c
     return value;
 }
 
-long double appconfig_set_float(struct config *root, const char *section, const char *name, long double value)
+LONG_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
 {
     char buffer[100];
-    sprintf(buffer, "%0.5Lf", value);
+    sprintf(buffer, "%0.5" LONG_DOUBLE_MODIFIER, value);
 
     appconfig_set(root, section, name, buffer);
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -35,14 +35,14 @@ extern int appconfig_load(struct config *root, char *filename, int overwrite_use
 
 extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
 extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
-extern long double appconfig_get_float(struct config *root, const char *section, const char *name, long double value);
+extern LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value);
 extern int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
 extern int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value);
 
 extern const char *appconfig_set(struct config *root, const char *section, const char *name, const char *value);
 extern const char *appconfig_set_default(struct config *root, const char *section, const char *name, const char *value);
 extern long long appconfig_set_number(struct config *root, const char *section, const char *name, long long value);
-extern long double appconfig_set_float(struct config *root, const char *section, const char *name, long double value);
+extern LONG_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value);
 extern int appconfig_set_boolean(struct config *root, const char *section, const char *name, int value);
 
 extern int appconfig_exists(struct config *root, const char *section, const char *name);

--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,7 @@
 #include <config.h>
 #endif
 
+
 // ----------------------------------------------------------------------------
 // system include files for all netdata C programs
 
@@ -99,6 +100,7 @@
 
 #ifdef STORAGE_WITH_MATH
 #include <math.h>
+#include <float.h>
 #endif
 
 #if defined(HAVE_INTTYPES_H)

--- a/src/health.c
+++ b/src/health.c
@@ -145,7 +145,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     const char *exec      = (ae->exec)      ? ae->exec      : host->health_default_exec;
     const char *recipient = (ae->recipient) ? ae->recipient : host->health_default_recipient;
 
-    snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '%0.0Lf' '%0.0Lf' '%s' '%u' '%u' '%s' '%s' '%s' '%s'",
+    snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '" CALCULATED_NUMBER_FORMAT_ZERO "' '" CALCULATED_NUMBER_FORMAT_ZERO "' '%s' '%u' '%u' '%s' '%s' '%s' '%s'",
               exec,
               recipient,
               host->registry_hostname,
@@ -192,7 +192,7 @@ done:
 }
 
 static inline void health_process_notifications(RRDHOST *host, ALARM_ENTRY *ae) {
-    debug(D_HEALTH, "Health alarm '%s.%s' = %0.2Lf - changed status from %s to %s",
+    debug(D_HEALTH, "Health alarm '%s.%s' = " CALCULATED_NUMBER_FORMAT_AUTO " - changed status from %s to %s",
          ae->chart?ae->chart:"NOCHART", ae->name,
          ae->new_value,
          rrdcalc_status2string(ae->old_status),

--- a/src/health_config.c
+++ b/src/health_config.c
@@ -44,7 +44,7 @@ static inline int rrdcalc_add_alarm_from_config(RRDHOST *host, RRDCALC *rc) {
 
     rc->id = rrdcalc_get_unique_id(host, rc->chart, rc->name, &rc->next_event_id);
 
-    debug(D_HEALTH, "Health configuration adding alarm '%s.%s' (%u): exec '%s', recipient '%s', green %Lf, red %Lf, lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
+    debug(D_HEALTH, "Health configuration adding alarm '%s.%s' (%u): exec '%s', recipient '%s', green " CALCULATED_NUMBER_FORMAT_AUTO ", red " CALCULATED_NUMBER_FORMAT_AUTO ", lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
             rc->chart?rc->chart:"NOCHART",
             rc->name,
             rc->id,
@@ -99,7 +99,7 @@ static inline int rrdcalctemplate_add_template_from_config(RRDHOST *host, RRDCAL
         }
     }
 
-    debug(D_HEALTH, "Health configuration adding template '%s': context '%s', exec '%s', recipient '%s', green %Lf, red %Lf, lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
+    debug(D_HEALTH, "Health configuration adding template '%s': context '%s', exec '%s', recipient '%s', green " CALCULATED_NUMBER_FORMAT_AUTO ", red " CALCULATED_NUMBER_FORMAT_AUTO ", lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
             rt->name,
             (rt->context)?rt->context:"NONE",
             (rt->exec)?rt->exec:"DEFAULT",

--- a/src/health_log.c
+++ b/src/health_log.c
@@ -77,7 +77,7 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
                         "\t%08x\t%08x\t%08x"
                         "\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
                         "\t%d\t%d\t%d\t%d"
-                        "\t%Lf\t%Lf"
+                        "\t" CALCULATED_NUMBER_FORMAT_AUTO "\t" CALCULATED_NUMBER_FORMAT_AUTO
                         "\n"
                             , (ae->flags & HEALTH_ENTRY_FLAG_SAVED)?'U':'A'
                             , host->hostname
@@ -109,8 +109,8 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
                             , ae->old_status
                             , ae->delay
 
-                            , (long double)ae->new_value
-                            , (long double)ae->old_value
+                            , ae->new_value
+                            , ae->old_value
         ) < 0))
             error("HEALTH [%s]: failed to save alarm log entry to '%s'. Health data may be lost in case of abnormal restart.", host->hostname, host->health_log_filename);
         else {

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -255,13 +255,13 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
                         if(rd->multiplier < 0 || rd->divisor < 0) n = -n;
                         n = calculated_number_round(n);
                         if(!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)) total += n;
-                        buffer_sprintf(wb, "NETDATA_%s_%s=\"%0.0Lf\"      # %s\n", chart, dimension, n, st->units);
+                        buffer_sprintf(wb, "NETDATA_%s_%s=\"" CALCULATED_NUMBER_FORMAT_ZERO "\"      # %s\n", chart, dimension, n, st->units);
                     }
                 }
             }
 
             total = calculated_number_round(total);
-            buffer_sprintf(wb, "NETDATA_%s_VISIBLETOTAL=\"%0.0Lf\"      # %s\n", chart, total, st->units);
+            buffer_sprintf(wb, "NETDATA_%s_VISIBLETOTAL=\"" CALCULATED_NUMBER_FORMAT_ZERO "\"      # %s\n", chart, total, st->units);
             rrdset_unlock(st);
         }
     }
@@ -284,7 +284,7 @@ void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, BUFFER *wb) {
             buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"\"      # %s\n", chart, alarm, rc->units);
         else {
             n = calculated_number_round(n);
-            buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"%0.0Lf\"      # %s\n", chart, alarm, n, rc->units);
+            buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_VALUE=\"" CALCULATED_NUMBER_FORMAT_ZERO "\"      # %s\n", chart, alarm, n, rc->units);
         }
 
         buffer_sprintf(wb, "NETDATA_ALARM_%s_%s_STATUS=\"%s\"\n", chart, alarm, rrdcalc_status2string(rc->status));

--- a/src/rrdcalc.c
+++ b/src/rrdcalc.c
@@ -55,12 +55,12 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
     }
 
     if(!isnan(rc->green) && isnan(st->green)) {
-        debug(D_HEALTH, "Health alarm '%s.%s' green threshold set from %Lf to %Lf.", rc->rrdset->id, rc->name, rc->rrdset->green, rc->green);
+        debug(D_HEALTH, "Health alarm '%s.%s' green threshold set from " CALCULATED_NUMBER_FORMAT_AUTO " to " CALCULATED_NUMBER_FORMAT_AUTO ".", rc->rrdset->id, rc->name, rc->rrdset->green, rc->green);
         st->green = rc->green;
     }
 
     if(!isnan(rc->red) && isnan(st->red)) {
-        debug(D_HEALTH, "Health alarm '%s.%s' red threshold set from %Lf to %Lf.", rc->rrdset->id, rc->name, rc->rrdset->red, rc->red);
+        debug(D_HEALTH, "Health alarm '%s.%s' red threshold set from " CALCULATED_NUMBER_FORMAT_AUTO " to " CALCULATED_NUMBER_FORMAT_AUTO ".", rc->rrdset->id, rc->name, rc->rrdset->red, rc->red);
         st->red = rc->red;
     }
 
@@ -351,7 +351,7 @@ inline RRDCALC *rrdcalc_create(RRDHOST *host, RRDCALCTEMPLATE *rt, const char *c
             error("Health alarm '%s.%s': failed to re-parse critical expression '%s'", chart, rt->name, rt->critical->source);
     }
 
-    debug(D_HEALTH, "Health runtime added alarm '%s.%s': exec '%s', recipient '%s', green %Lf, red %Lf, lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
+    debug(D_HEALTH, "Health runtime added alarm '%s.%s': exec '%s', recipient '%s', green " CALCULATED_NUMBER_FORMAT_AUTO ", red " CALCULATED_NUMBER_FORMAT_AUTO ", lookup: group %d, after %d, before %d, options %u, dimensions '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f",
             (rc->chart)?rc->chart:"NOCHART",
             rc->name,
             (rc->exec)?rc->exec:"DEFAULT",

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -737,7 +737,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
 
         if(unlikely(since_last_usec < 0)) {
             // oops! the database is in the future
-            info("RRD database for chart '%s' on host '%s' is %0.5Lf secs in the future. Adjusting it to current time.", st->id, st->rrdhost->hostname, (long double)-since_last_usec / USEC_PER_SEC);
+            info("RRD database for chart '%s' on host '%s' is %0.5" LONG_DOUBLE_MODIFIER " secs in the future. Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)-since_last_usec / USEC_PER_SEC);
 
             st->last_collected_time.tv_sec  = now.tv_sec - st->update_every;
             st->last_collected_time.tv_usec = now.tv_usec;
@@ -751,7 +751,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
         }
         else if(unlikely((usec_t)since_last_usec > (usec_t)(st->update_every * 10 * USEC_PER_SEC))) {
             // oops! the database is too far behind
-            info("RRD database for chart '%s' on host '%s' is %0.5Lf secs in the past. Adjusting it to current time.", st->id, st->rrdhost->hostname, (long double)since_last_usec / USEC_PER_SEC);
+            info("RRD database for chart '%s' on host '%s' is %0.5" LONG_DOUBLE_MODIFIER " secs in the past. Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)since_last_usec / USEC_PER_SEC);
 
             microseconds = (usec_t)since_last_usec;
         }
@@ -776,7 +776,7 @@ static inline usec_t rrdset_init_last_collected_time(RRDSET *st) {
     usec_t last_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last collected time to %0.3Lf", (long double)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last collected time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -789,7 +789,7 @@ static inline usec_t rrdset_update_last_collected_time(RRDSET *st) {
     st->last_collected_time.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "updated last collected time to %0.3Lf", (long double)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "updated last collected time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -808,7 +808,7 @@ static inline usec_t rrdset_init_last_updated_time(RRDSET *st) {
     usec_t last_updated_ut = st->last_updated.tv_sec * USEC_PER_SEC + st->last_updated.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last updated time to %0.3Lf", (long double)last_updated_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last updated time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_updated_ut / USEC_PER_SEC);
     #endif
 
     return last_updated_ut;
@@ -867,8 +867,8 @@ static inline size_t rrdset_done_interpolate(
 
         #ifdef NETDATA_INTERNAL_CHECKS
         if(iterations < 0) { error("INTERNAL CHECK: %s: iterations calculation wrapped! first_ut = %llu, last_stored_ut = %llu, next_store_ut = %llu, now_collect_ut = %llu", st->name, first_ut, last_stored_ut, next_store_ut, now_collect_ut); }
-        rrdset_debug(st, "last_stored_ut = %0.3Lf (last updated time)", (long double)last_stored_ut/USEC_PER_SEC);
-        rrdset_debug(st, "next_store_ut  = %0.3Lf (next interpolation point)", (long double)next_store_ut/USEC_PER_SEC);
+        rrdset_debug(st, "last_stored_ut = %0.3" LONG_DOUBLE_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
+        rrdset_debug(st, "next_store_ut  = %0.3" LONG_DOUBLE_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
         #endif
 
         last_ut = next_store_ut;
@@ -1107,7 +1107,7 @@ void rrdset_done(RRDSET *st) {
 
     // check if the chart has a long time to be updated
     if(unlikely(st->usec_since_last_update > st->entries * update_every_ut)) {
-        info("host '%s', chart %s: took too long to be updated (%0.3Lf secs). Resetting it.", st->rrdhost->hostname, st->name, (long double)st->usec_since_last_update / USEC_PER_SEC);
+        info("host '%s', chart %s: took too long to be updated (%0.3" LONG_DOUBLE_MODIFIER " secs). Resetting it.", st->rrdhost->hostname, st->name, (LONG_DOUBLE)st->usec_since_last_update / USEC_PER_SEC);
         rrdset_reset(st);
         st->usec_since_last_update = update_every_ut;
         store_this_entry = 0;
@@ -1199,10 +1199,10 @@ void rrdset_done(RRDSET *st) {
         rrdset_done_push(st);
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "last_collect_ut = %0.3Lf (last collection time)", (long double)last_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "now_collect_ut  = %0.3Lf (current collection time)", (long double)now_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "last_stored_ut  = %0.3Lf (last updated time)", (long double)last_stored_ut/USEC_PER_SEC);
-    rrdset_debug(st, "next_store_ut   = %0.3Lf (next interpolation point)", (long double)next_store_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_collect_ut = %0.3" LONG_DOUBLE_MODIFIER " (last collection time)", (LONG_DOUBLE)last_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "now_collect_ut  = %0.3" LONG_DOUBLE_MODIFIER " (current collection time)", (LONG_DOUBLE)now_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_stored_ut  = %0.3" LONG_DOUBLE_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
+    rrdset_debug(st, "next_store_ut   = %0.3" LONG_DOUBLE_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
     #endif
 
     // calculate totals and count the dimensions

--- a/src/rrdvar.c
+++ b/src/rrdvar.c
@@ -247,7 +247,7 @@ static int single_variable2json(void *entry, void *data) {
     if(unlikely(isnan(value) || isinf(value)))
         buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": null", helper->counter?",":"", rv->name);
     else
-        buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5Lf", helper->counter?",":"", rv->name, (long double)value);
+        buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" LONG_DOUBLE_MODIFIER, helper->counter?",":"", rv->name, (LONG_DOUBLE)value);
 
     helper->counter++;
 

--- a/src/statistical.c
+++ b/src/statistical.c
@@ -2,7 +2,7 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
-inline long double sum_and_count(const long double *series, size_t entries, size_t *count) {
+inline LONG_DOUBLE sum_and_count(const LONG_DOUBLE *series, size_t entries, size_t *count) {
     if(unlikely(entries == 0)) {
         if(likely(count))
             *count = 0;
@@ -18,10 +18,10 @@ inline long double sum_and_count(const long double *series, size_t entries, size
     }
 
     size_t i, c = 0;
-    long double sum = 0;
+    LONG_DOUBLE sum = 0;
 
     for(i = 0; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
         c++;
         sum += value;
@@ -36,44 +36,44 @@ inline long double sum_and_count(const long double *series, size_t entries, size
     return sum;
 }
 
-inline long double sum(const long double *series, size_t entries) {
+inline LONG_DOUBLE sum(const LONG_DOUBLE *series, size_t entries) {
     return sum_and_count(series, entries, NULL);
 }
 
-inline long double average(const long double *series, size_t entries) {
+inline LONG_DOUBLE average(const LONG_DOUBLE *series, size_t entries) {
     size_t count = 0;
-    long double sum = sum_and_count(series, entries, &count);
+    LONG_DOUBLE sum = sum_and_count(series, entries, &count);
 
     if(unlikely(count == 0))
         return NAN;
 
-    return sum / (long double)count;
+    return sum / (LONG_DOUBLE)count;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
-long double moving_average(const long double *series, size_t entries, size_t period) {
+LONG_DOUBLE moving_average(const LONG_DOUBLE *series, size_t entries, size_t period) {
     if(unlikely(period <= 0))
         return 0.0;
 
     size_t i, count;
-    long double sum = 0, avg = 0;
-    long double p[period];
+    LONG_DOUBLE sum = 0, avg = 0;
+    LONG_DOUBLE p[period];
 
     for(count = 0; count < period ; count++)
         p[count] = 0.0;
 
     for(i = 0, count = 0; i < entries; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
 
         if(unlikely(count < period)) {
             sum += value;
-            avg = (count == period - 1) ? sum / (long double)period : 0;
+            avg = (count == period - 1) ? sum / (LONG_DOUBLE)period : 0;
         }
         else {
             sum = sum - p[count % period] + value;
-            avg = sum / (long double)period;
+            avg = sum / (LONG_DOUBLE)period;
         }
 
         p[count % period] = value;
@@ -86,8 +86,8 @@ long double moving_average(const long double *series, size_t entries, size_t per
 // --------------------------------------------------------------------------------------------------------------------
 
 static int qsort_compare(const void *a, const void *b) {
-    long double *p1 = (long double *)a, *p2 = (long double *)b;
-    long double n1 = *p1, n2 = *p2;
+    LONG_DOUBLE *p1 = (LONG_DOUBLE *)a, *p2 = (LONG_DOUBLE *)b;
+    LONG_DOUBLE n1 = *p1, n2 = *p2;
 
     if(unlikely(isnan(n1) || isnan(n2))) {
         if(isnan(n1) && !isnan(n2)) return -1;
@@ -105,17 +105,17 @@ static int qsort_compare(const void *a, const void *b) {
     return 0;
 }
 
-inline void sort_series(long double *series, size_t entries) {
-    qsort(series, entries, sizeof(long double), qsort_compare);
+inline void sort_series(LONG_DOUBLE *series, size_t entries) {
+    qsort(series, entries, sizeof(LONG_DOUBLE), qsort_compare);
 }
 
-inline long double *copy_series(const long double *series, size_t entries) {
-    long double *copy = mallocz(sizeof(long double) * entries);
-    memcpy(copy, series, sizeof(long double) * entries);
+inline LONG_DOUBLE *copy_series(const LONG_DOUBLE *series, size_t entries) {
+    LONG_DOUBLE *copy = mallocz(sizeof(LONG_DOUBLE) * entries);
+    memcpy(copy, series, sizeof(LONG_DOUBLE) * entries);
     return copy;
 }
 
-long double median_on_sorted_series(const long double *series, size_t entries) {
+LONG_DOUBLE median_on_sorted_series(const LONG_DOUBLE *series, size_t entries) {
     if(unlikely(entries == 0))
         return NAN;
 
@@ -125,7 +125,7 @@ long double median_on_sorted_series(const long double *series, size_t entries) {
     if(unlikely(entries == 2))
         return (series[0] + series[1]) / 2;
 
-    long double avg;
+    LONG_DOUBLE avg;
     if(entries % 2 == 0) {
         size_t m = entries / 2;
         avg = (series[m] + series[m + 1]) / 2;
@@ -137,7 +137,7 @@ long double median_on_sorted_series(const long double *series, size_t entries) {
     return avg;
 }
 
-long double median(const long double *series, size_t entries) {
+LONG_DOUBLE median(const LONG_DOUBLE *series, size_t entries) {
     if(unlikely(entries == 0))
         return NAN;
 
@@ -147,10 +147,10 @@ long double median(const long double *series, size_t entries) {
     if(unlikely(entries == 2))
         return (series[0] + series[1]) / 2;
 
-    long double *copy = copy_series(series, entries);
+    LONG_DOUBLE *copy = copy_series(series, entries);
     sort_series(copy, entries);
 
-    long double avg = median_on_sorted_series(copy, entries);
+    LONG_DOUBLE avg = median_on_sorted_series(copy, entries);
 
     freez(copy);
     return avg;
@@ -158,18 +158,18 @@ long double median(const long double *series, size_t entries) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-long double moving_median(const long double *series, size_t entries, size_t period) {
+LONG_DOUBLE moving_median(const LONG_DOUBLE *series, size_t entries, size_t period) {
     if(entries <= period)
         return median(series, entries);
 
-    long double *data = copy_series(series, entries);
+    LONG_DOUBLE *data = copy_series(series, entries);
 
     size_t i;
     for(i = period; i < entries; i++) {
         data[i - period] = median(&series[i - period], period);
     }
 
-    long double avg = median(data, entries - period);
+    LONG_DOUBLE avg = median(data, entries - period);
     freez(data);
     return avg;
 }
@@ -177,13 +177,13 @@ long double moving_median(const long double *series, size_t entries, size_t peri
 // --------------------------------------------------------------------------------------------------------------------
 
 // http://stackoverflow.com/a/15150143/4525767
-long double running_median_estimate(const long double *series, size_t entries) {
-    long double median = 0.0f;
-    long double average = 0.0f;
+LONG_DOUBLE running_median_estimate(const LONG_DOUBLE *series, size_t entries) {
+    LONG_DOUBLE median = 0.0f;
+    LONG_DOUBLE average = 0.0f;
     size_t i;
 
     for(i = 0; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
 
         average += ( value - average ) * 0.1f; // rough running average.
@@ -195,7 +195,7 @@ long double running_median_estimate(const long double *series, size_t entries) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-long double standard_deviation(const long double *series, size_t entries) {
+LONG_DOUBLE standard_deviation(const LONG_DOUBLE *series, size_t entries) {
     if(unlikely(entries < 1))
         return NAN;
 
@@ -203,10 +203,10 @@ long double standard_deviation(const long double *series, size_t entries) {
         return series[0];
 
     size_t i, count = 0;
-    long double sum = 0;
+    LONG_DOUBLE sum = 0;
 
     for(i = 0; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
 
         count++;
@@ -219,10 +219,10 @@ long double standard_deviation(const long double *series, size_t entries) {
     if(unlikely(count == 1))
         return sum;
 
-    long double average = sum / (long double)count;
+    LONG_DOUBLE average = sum / (LONG_DOUBLE)count;
 
     for(i = 0, count = 0, sum = 0; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
 
         count++;
@@ -235,29 +235,29 @@ long double standard_deviation(const long double *series, size_t entries) {
     if(unlikely(count == 1))
         return average;
 
-    long double variance = sum / (long double)(count - 1); // remove -1 to have a population stddev
+    LONG_DOUBLE variance = sum / (LONG_DOUBLE)(count - 1); // remove -1 to have a population stddev
 
-    long double stddev = sqrtl(variance);
+    LONG_DOUBLE stddev = sqrtl(variance);
     return stddev;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
-long double single_exponential_smoothing(const long double *series, size_t entries, long double alpha) {
+LONG_DOUBLE single_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha) {
     size_t i, count = 0;
-    long double level = 0, sum = 0;
+    LONG_DOUBLE level = 0, sum = 0;
 
     if(unlikely(isnan(alpha)))
         alpha = 0.3;
 
     for(i = 0; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
         count++;
 
         sum += value;
 
-        long double last_level = level;
+        LONG_DOUBLE last_level = level;
         level = alpha * value + (1.0 - alpha) * last_level;
     }
 
@@ -267,9 +267,9 @@ long double single_exponential_smoothing(const long double *series, size_t entri
 // --------------------------------------------------------------------------------------------------------------------
 
 // http://grisha.org/blog/2016/02/16/triple-exponential-smoothing-forecasting-part-ii/
-long double double_exponential_smoothing(const long double *series, size_t entries, long double alpha, long double beta, long double *forecast) {
+LONG_DOUBLE double_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE *forecast) {
     size_t i, count = 0;
-    long double level = series[0], trend, sum;
+    LONG_DOUBLE level = series[0], trend, sum;
 
     if(unlikely(isnan(alpha)))
         alpha = 0.3;
@@ -285,13 +285,13 @@ long double double_exponential_smoothing(const long double *series, size_t entri
     sum = series[0];
 
     for(i = 1; i < entries ; i++) {
-        long double value = series[i];
+        LONG_DOUBLE value = series[i];
         if(unlikely(isnan(value) || isinf(value))) continue;
         count++;
 
         sum += value;
 
-        long double last_level = level;
+        LONG_DOUBLE last_level = level;
 
         level = alpha * value + (1.0 - alpha) * (level + trend);
         trend = beta * (level - last_level) + (1.0 - beta) * trend;
@@ -327,24 +327,24 @@ long double double_exponential_smoothing(const long double *series, size_t entri
  *   s[t] = γ (Y[t] / a[t]) + (1-γ) s[t-p]
  */
 static int __HoltWinters(
-        const long double *series,
+        const LONG_DOUBLE *series,
         int          entries,      // start_time + h
 
-        long double alpha,        // alpha parameter of Holt-Winters Filter.
-        long double beta,         // beta  parameter of Holt-Winters Filter. If set to 0, the function will do exponential smoothing.
-        long double gamma,        // gamma parameter used for the seasonal component. If set to 0, an non-seasonal model is fitted.
+        LONG_DOUBLE alpha,        // alpha parameter of Holt-Winters Filter.
+        LONG_DOUBLE beta,         // beta  parameter of Holt-Winters Filter. If set to 0, the function will do exponential smoothing.
+        LONG_DOUBLE gamma,        // gamma parameter used for the seasonal component. If set to 0, an non-seasonal model is fitted.
 
         const int *seasonal,
         const int *period,
-        const long double *a,      // Start value for level (a[0]).
-        const long double *b,      // Start value for trend (b[0]).
-        long double *s,            // Vector of start values for the seasonal component (s_1[0] ... s_p[0])
+        const LONG_DOUBLE *a,      // Start value for level (a[0]).
+        const LONG_DOUBLE *b,      // Start value for trend (b[0]).
+        LONG_DOUBLE *s,            // Vector of start values for the seasonal component (s_1[0] ... s_p[0])
 
         /* return values */
-        long double *SSE,          // The final sum of squared errors achieved in optimizing
-        long double *level,        // Estimated values for the level component (size entries - t + 2)
-        long double *trend,        // Estimated values for the trend component (size entries - t + 2)
-        long double *season        // Estimated values for the seasonal component (size entries - t + 2)
+        LONG_DOUBLE *SSE,          // The final sum of squared errors achieved in optimizing
+        LONG_DOUBLE *level,        // Estimated values for the level component (size entries - t + 2)
+        LONG_DOUBLE *trend,        // Estimated values for the trend component (size entries - t + 2)
+        LONG_DOUBLE *season        // Estimated values for the seasonal component (size entries - t + 2)
 )
 {
     if(unlikely(entries < 4))
@@ -352,13 +352,13 @@ static int __HoltWinters(
 
     int start_time = 2;
 
-    long double res = 0, xhat = 0, stmp = 0;
+    LONG_DOUBLE res = 0, xhat = 0, stmp = 0;
     int i, i0, s0;
 
     /* copy start values to the beginning of the vectors */
     level[0] = *a;
     if(beta > 0) trend[0] = *b;
-    if(gamma > 0) memcpy(season, s, *period * sizeof(long double));
+    if(gamma > 0) memcpy(season, s, *period * sizeof(LONG_DOUBLE));
 
     for(i = start_time - 1; i < entries; i++) {
         /* indices for period i */
@@ -404,7 +404,7 @@ static int __HoltWinters(
     return 1;
 }
 
-long double holtwinters(const long double *series, size_t entries, long double alpha, long double beta, long double gamma, long double *forecast) {
+LONG_DOUBLE holtwinters(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE gamma, LONG_DOUBLE *forecast) {
     if(unlikely(isnan(alpha)))
         alpha = 0.3;
 
@@ -416,15 +416,15 @@ long double holtwinters(const long double *series, size_t entries, long double a
 
     int seasonal = 0;
     int period = 0;
-    long double a0 = series[0];
-    long double b0 = 0;
-    long double s[] = {};
+    LONG_DOUBLE a0 = series[0];
+    LONG_DOUBLE b0 = 0;
+    LONG_DOUBLE s[] = {};
 
-    long double errors = 0.0;
+    LONG_DOUBLE errors = 0.0;
     size_t nb_computations = entries;
-    long double *estimated_level  = callocz(nb_computations, sizeof(long double));
-    long double *estimated_trend  = callocz(nb_computations, sizeof(long double));
-    long double *estimated_season = callocz(nb_computations, sizeof(long double));
+    LONG_DOUBLE *estimated_level  = callocz(nb_computations, sizeof(LONG_DOUBLE));
+    LONG_DOUBLE *estimated_trend  = callocz(nb_computations, sizeof(LONG_DOUBLE));
+    LONG_DOUBLE *estimated_season = callocz(nb_computations, sizeof(LONG_DOUBLE));
 
     int ret = __HoltWinters(
             series,
@@ -443,7 +443,7 @@ long double holtwinters(const long double *series, size_t entries, long double a
             estimated_season
     );
 
-    long double value = estimated_level[nb_computations - 1];
+    LONG_DOUBLE value = estimated_level[nb_computations - 1];
 
     if(forecast)
         *forecast = 0.0;

--- a/src/statistical.h
+++ b/src/statistical.h
@@ -1,19 +1,19 @@
 #ifndef NETDATA_STATISTICAL_H
 #define NETDATA_STATISTICAL_H
 
-extern long double average(const long double *series, size_t entries);
-extern long double moving_average(const long double *series, size_t entries, size_t period);
-extern long double median(const long double *series, size_t entries);
-extern long double moving_median(const long double *series, size_t entries, size_t period);
-extern long double running_median_estimate(const long double *series, size_t entries);
-extern long double standard_deviation(const long double *series, size_t entries);
-extern long double single_exponential_smoothing(const long double *series, size_t entries, long double alpha);
-extern long double double_exponential_smoothing(const long double *series, size_t entries, long double alpha, long double beta, long double *forecast);
-extern long double holtwinters(const long double *series, size_t entries, long double alpha, long double beta, long double gamma, long double *forecast);
-extern long double sum_and_count(const long double *series, size_t entries, size_t *count);
-extern long double sum(const long double *series, size_t entries);
-extern long double median_on_sorted_series(const long double *series, size_t entries);
-extern long double *copy_series(const long double *series, size_t entries);
-extern void sort_series(long double *series, size_t entries);
+extern LONG_DOUBLE average(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE moving_average(const LONG_DOUBLE *series, size_t entries, size_t period);
+extern LONG_DOUBLE median(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE moving_median(const LONG_DOUBLE *series, size_t entries, size_t period);
+extern LONG_DOUBLE running_median_estimate(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE standard_deviation(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE single_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha);
+extern LONG_DOUBLE double_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE *forecast);
+extern LONG_DOUBLE holtwinters(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE gamma, LONG_DOUBLE *forecast);
+extern LONG_DOUBLE sum_and_count(const LONG_DOUBLE *series, size_t entries, size_t *count);
+extern LONG_DOUBLE sum(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE median_on_sorted_series(const LONG_DOUBLE *series, size_t entries);
+extern LONG_DOUBLE *copy_series(const LONG_DOUBLE *series, size_t entries);
+extern void sort_series(LONG_DOUBLE *series, size_t entries);
 
 #endif //NETDATA_STATISTICAL_H

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -36,7 +36,7 @@
 // data specific to each metric type
 
 typedef struct statsd_metric_gauge {
-    long double value;
+    LONG_DOUBLE value;
 } STATSD_METRIC_GAUGE;
 
 typedef struct statsd_metric_counter { // counter and meter
@@ -65,7 +65,7 @@ typedef struct statsd_histogram_extensions {
 
     size_t size;
     size_t used;
-    long double *values;   // dynamic array of values collected
+    LONG_DOUBLE *values;   // dynamic array of values collected
 } STATSD_METRIC_HISTOGRAM_EXTENSIONS;
 
 typedef struct statsd_metric_histogram { // histogram and timer
@@ -395,8 +395,8 @@ static inline STATSD_METRIC *statsd_find_or_add_metric(STATSD_INDEX *index, cons
 // --------------------------------------------------------------------------------------------------------------------
 // statsd parsing numbers
 
-static inline long double statsd_parse_float(const char *v, long double def) {
-    long double value;
+static inline LONG_DOUBLE statsd_parse_float(const char *v, LONG_DOUBLE def) {
+    LONG_DOUBLE value;
 
     if(likely(v && *v)) {
         char *e = NULL;
@@ -472,7 +472,7 @@ static inline void statsd_process_counter(STATSD_METRIC *m, const char *value, c
         // magic loading of metric, without affecting anything
     }
     else {
-        m->counter.value += llrintl((long double) statsd_parse_int(value, 1) / statsd_parse_float(sampling, 1.0));
+        m->counter.value += llrintl((LONG_DOUBLE) statsd_parse_int(value, 1) / statsd_parse_float(sampling, 1.0));
 
         m->events++;
         m->count++;
@@ -502,7 +502,7 @@ static inline void statsd_process_histogram(STATSD_METRIC *m, const char *value,
         if (unlikely(m->histogram.ext->used == m->histogram.ext->size)) {
             netdata_mutex_lock(&m->histogram.ext->mutex);
             m->histogram.ext->size += statsd.histogram_increase_step;
-            m->histogram.ext->values = reallocz(m->histogram.ext->values, sizeof(long double) * m->histogram.ext->size);
+            m->histogram.ext->values = reallocz(m->histogram.ext->values, sizeof(LONG_DOUBLE) * m->histogram.ext->size);
             netdata_mutex_unlock(&m->histogram.ext->mutex);
         }
 
@@ -1650,7 +1650,7 @@ static inline void statsd_flush_timer_or_histogram(STATSD_METRIC *m, const char 
     int updated = 0;
     if(m->count && !m->reset && m->histogram.ext->used > 0) {
         size_t len = m->histogram.ext->used;
-        long double *series = m->histogram.ext->values;
+        LONG_DOUBLE *series = m->histogram.ext->values;
         sort_series(series, len);
 
         m->histogram.ext->last_min = (collected_number)roundl(series[0] * statsd.decimal_detail);

--- a/src/storage_number.c
+++ b/src/storage_number.c
@@ -175,7 +175,7 @@ int print_calculated_number(char *str, calculated_number value) {
     calculated_number integral, fractional;
 
 #ifdef STORAGE_WITH_MATH
-    fractional = modfl(value, &integral) * 10000000.0;
+    fractional = calculated_number_modf(value, &integral) * 10000000.0;
 #else
     fractional = ((unsigned long long)(value * 10000000ULL) % 10000000ULL);
 #endif

--- a/src/storage_number.h
+++ b/src/storage_number.h
@@ -1,8 +1,36 @@
 #ifndef NETDATA_STORAGE_NUMBER_H
 #define NETDATA_STORAGE_NUMBER_H
 
+#ifdef NETDATA_WITHOUT_LONG_DOUBLE
+
+#define powl pow
+#define modfl modf
+#define llrintl llrint
+#define roundl round
+#define sqrtl sqrt
+#define copysignl copysign
+#define strtold strtod
+
+typedef double calculated_number;
+#define CALCULATED_NUMBER_FORMAT "%0.7f"
+#define CALCULATED_NUMBER_FORMAT_ZERO "%0.0f"
+#define CALCULATED_NUMBER_FORMAT_AUTO "%f"
+
+#define LONG_DOUBLE_MODIFIER "f"
+typedef double LONG_DOUBLE;
+
+#else
+
 typedef long double calculated_number;
 #define CALCULATED_NUMBER_FORMAT "%0.7Lf"
+#define CALCULATED_NUMBER_FORMAT_ZERO "%0.0Lf"
+#define CALCULATED_NUMBER_FORMAT_AUTO "%Lf"
+
+#define LONG_DOUBLE_MODIFIER "Lf"
+typedef long double LONG_DOUBLE;
+
+#endif
+
 //typedef long long calculated_number;
 //#define CALCULATED_NUMBER_FORMAT "%lld"
 
@@ -14,6 +42,7 @@ typedef long double collected_number;
 #define COLLECTED_NUMBER_FORMAT "%0.7Lf"
 */
 
+#define calculated_number_modf(x, y) modfl(x, y)
 #define calculated_number_llrint(x) llrintl(x)
 #define calculated_number_round(x) roundl(x)
 #define calculated_number_fabs(x) fabsl(x)

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -21,7 +21,7 @@ static int check_number_printing(void) {
     int i, failed = 0;
     for(i = 0; values[i].correct ; i++) {
         print_calculated_number(netdata, values[i].n);
-        snprintfz(system, 49, "%0.12Lf", values[i].n);
+        snprintfz(system, 49, "%0.12" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)values[i].n);
 
         int ok = 1;
         if(strcmp(netdata, values[i].correct) != 0) {
@@ -128,8 +128,8 @@ int check_storage_number(calculated_number n, int debug) {
             p, pdiff, pcdiff
         );
         if(len != strlen(buffer)) fprintf(stderr, "ERROR: printed number %s is reported to have length %zu but it has %zu\n", buffer, len, strlen(buffer));
-        if(dcdiff > ACCURACY_LOSS) fprintf(stderr, "WARNING: packing number " CALCULATED_NUMBER_FORMAT " has accuracy loss %0.7Lf %%\n", n, dcdiff);
-        if(pcdiff > ACCURACY_LOSS) fprintf(stderr, "WARNING: re-parsing the packed, unpacked and printed number " CALCULATED_NUMBER_FORMAT " has accuracy loss %0.7Lf %%\n", n, pcdiff);
+        if(dcdiff > ACCURACY_LOSS) fprintf(stderr, "WARNING: packing number " CALCULATED_NUMBER_FORMAT " has accuracy loss " CALCULATED_NUMBER_FORMAT " %%\n", n, dcdiff);
+        if(pcdiff > ACCURACY_LOSS) fprintf(stderr, "WARNING: re-parsing the packed, unpacked and printed number " CALCULATED_NUMBER_FORMAT " has accuracy loss " CALCULATED_NUMBER_FORMAT " %%\n", n, pcdiff);
     }
 
     if(len != strlen(buffer)) return 1;
@@ -172,10 +172,10 @@ void benchmark_storage_number(int loop, int multiplier) {
     their = (calculated_number)sizeof(calculated_number) * (calculated_number)loop;
 
     if(mine > their) {
-        fprintf(stderr, "\nNETDATA NEEDS %0.2Lf TIMES MORE MEMORY. Sorry!\n", (long double)(mine / their));
+        fprintf(stderr, "\nNETDATA NEEDS %0.2" LONG_DOUBLE_MODIFIER " TIMES MORE MEMORY. Sorry!\n", (LONG_DOUBLE)(mine / their));
     }
     else {
-        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2Lf TIMES LESS MEMORY.\n", (long double)(their / mine));
+        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2" LONG_DOUBLE_MODIFIER " TIMES LESS MEMORY.\n", (LONG_DOUBLE)(their / mine));
     }
 
     fprintf(stderr, "\nNETDATA FLOATING POINT\n");
@@ -208,7 +208,7 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5Lf, system %0.5Lf, total %0.5Lf\n", (long double)(user / 1000000.0), (long double)(system / 1000000.0), (long double)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     // ------------------------------------------------------------------------
 
@@ -232,13 +232,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     their = total;
 
-    fprintf(stderr, "user %0.5Lf, system %0.5Lf, total %0.5Lf\n", (long double)(user / 1000000.0), (long double)(system / 1000000.0), (long double)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER ", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     if(mine > total) {
-        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2Lf %%\n", (long double)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2Lf %%\n", (long double)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -266,13 +266,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5Lf, system %0.5Lf, total %0.5Lf\n", (long double)(user / 1000000.0), (long double)(system / 1000000.0), (long double)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER ", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     if(mine > their) {
-        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2Lf %%\n", (long double)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2Lf %%\n", (long double)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -344,23 +344,23 @@ int unit_test_str2ld() {
     int i;
     for(i = 0; values[i] ; i++) {
         char *e_mine = "hello", *e_sys = "world";
-        long double mine = str2ld(values[i], &e_mine);
-        long double sys = strtold(values[i], &e_sys);
+        LONG_DOUBLE mine = str2ld(values[i], &e_mine);
+        LONG_DOUBLE sys = strtold(values[i], &e_sys);
 
         if(isnan(mine)) {
             if(!isnan(sys)) {
-                fprintf(stderr, "Value '%s' is parsed as %Lf, but system believes it is %Lf.\n", values[i], mine, sys);
+                fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys);
                 return -1;
             }
         }
         else if(isinf(mine)) {
             if(!isinf(sys)) {
-                fprintf(stderr, "Value '%s' is parsed as %Lf, but system believes it is %Lf.\n", values[i], mine, sys);
+                fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys);
                 return -1;
             }
         }
         else if(mine != sys && abs(mine-sys) > 0.000001) {
-            fprintf(stderr, "Value '%s' is parsed as %Lf, but system believes it is %Lf, delta %Lf.\n", values[i], mine, sys, sys-mine);
+            fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ", delta %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys, sys-mine);
             return -1;
         }
 
@@ -369,7 +369,7 @@ int unit_test_str2ld() {
             return -1;
         }
 
-        fprintf(stderr, "str2ld() parsed value '%s' exactly the same way with strtold(), returned %Lf vs %Lf\n", values[i], mine, sys);
+        fprintf(stderr, "str2ld() parsed value '%s' exactly the same way with strtold(), returned %" LONG_DOUBLE_MODIFIER " vs %" LONG_DOUBLE_MODIFIER "\n", values[i], mine, sys);
     }
 
     return 0;

--- a/src/web_buffer_svg.c
+++ b/src/web_buffer_svg.c
@@ -386,16 +386,16 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
         }
 
         if(isgreaterequal(abs, 1000)) {
-            len = snprintfz(value_string, value_string_len, "%0.0Lf", (long double) value);
+            len = snprintfz(value_string, value_string_len, "%0.0" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
             trim_zeros = 0;
         }
-        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1Lf", (long double) value);
-        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2Lf", (long double) value);
-        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2Lf", (long double) value);
-        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4Lf", (long double) value);
-        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5Lf", (long double) value);
-        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6Lf", (long double) value);
-        else                                 len = snprintfz(value_string, value_string_len, "%0.7Lf", (long double) value);
+        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else                                 len = snprintfz(value_string, value_string_len, "%0.7" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
 
         if(unlikely(trim_zeros)) {
             int l;
@@ -422,7 +422,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
     }
     else {
         if(precision > 50) precision = 50;
-        snprintfz(value_string, value_string_len, "%0.*Lf%s%s", precision, (long double) value, separator, units);
+        snprintfz(value_string, value_string_len, "%0.*" LONG_DOUBLE_MODIFIER "%s%s", precision, (LONG_DOUBLE) value, separator, units);
     }
 
     return value_string;


### PR DESCRIPTION
fixes #3352 
This PR allows netdata to be compiled without `long double` (i.e. use `double`).

To use it, pass `-DNETDATA_WITHOUT_LONG_DOUBLE=1` to `CFLAGS`, like this:

```sh
CFLAGS="-O3 -DNETDATA_WITHOUT_LONG_DOUBLE=1" ./netdata-installer.sh
```

