### PR TITLE
Add new dimension in fronius plugin: solar_consumption

### DIFF
--- a/node.d/fronius.node.js
+++ b/node.d/fronius.node.js
@@ -24,6 +24,7 @@ var fronius = {
     consumptionLoadId: "p_load",
     autonomyId: "rel_autonomy",
     consumptionSelfId: "rel_selfconsumption",
+    solarConsumptionId: "solar_consumption",
     energyTodayId: "e_day",
     energyYearId: "e_year",
 
@@ -101,6 +102,7 @@ var fronius = {
         var dim = {};
         dim[fronius.autonomyId] = this.createBasicDimension(fronius.autonomyId, "autonomy", 1);
         dim[fronius.consumptionSelfId] = this.createBasicDimension(fronius.consumptionSelfId, "self_consumption", 1);
+        dim[fronius.solarConsumptionId] = this.createBasicDimension(fronius.solarConsumptionId, "solar_consumption", 1);
 
         chart = {
             id: id,                                         // the unique id of the chart
@@ -255,10 +257,17 @@ var fronius = {
 
     parseAutonomyChart: function (service, site) {
         var selfConsumption = site.rel_SelfConsumption;
+        var solarConsumption = 0;
+        var load = Math.abs(site.P_Load);
+        var power= Math.max(site.P_PV, 0);
+        if (load >= power) solarConsumption = 100;
+        else if (power <= 0) solarConsumption = 0;
+        else solarConsumption = 100 / power * load;
         return this.getChart(this.getSiteAutonomyChart(service, "autonomy"),
             [
                 this.getDimension(this.autonomyId, Math.round(site.rel_Autonomy)),
-                this.getDimension(this.consumptionSelfId, Math.round(selfConsumption === null ? 100 : selfConsumption))
+                this.getDimension(this.consumptionSelfId, Math.round(selfConsumption === null ? 100 : selfConsumption)),
+                this.getDimension(this.solarConsumptionId, Math.round(solarConsumption))
             ]
         );
     },

--- a/tests/node.d/fronius.chart.spec.js
+++ b/tests/node.d/fronius.chart.spec.js
@@ -68,7 +68,7 @@ describe("fronius chart creation", function () {
         expect(result.type).toBe(netdata.chartTypes.area);
         expect(result.family).toBe("autonomy");
         expect(result.context).toBe("fronius.autonomy");
-        expect(Object.keys(result.dimensions).length).toBe(2);
+        expect(Object.keys(result.dimensions).length).toBe(3);
         expect(result.dimensions[subject.autonomyId].name).toBe("autonomy");
         expect(result.dimensions[subject.consumptionSelfId].name).toBe("self_consumption");
     });

--- a/tests/node.d/fronius.parse.spec.js
+++ b/tests/node.d/fronius.parse.spec.js
@@ -234,6 +234,32 @@ describe("fronius parsing for autonomy", function () {
         expect(result.name).toBe(subject.consumptionSelfId);
         expect(result.value).toBe(0);
     });
+
+    it("should return 0 for solarConsumption if PV is null", function () {
+        site.P_PV = null;
+        var result = subject.parseAutonomyChart(service, site).dimensions[2];
+
+        expect(result.name).toBe(subject.solarConsumptionId);
+        expect(result.value).toBe(0);
+    });
+
+    it("should return 100 for solarConsumption if Load is higher than solar power", function () {
+        site.P_PV = 500;
+        site.P_Load = -1500;
+        var result = subject.parseAutonomyChart(service, site).dimensions[2];
+
+        expect(result.name).toBe(subject.solarConsumptionId);
+        expect(result.value).toBe(100);
+    });
+
+    it("should return 50 for solarConsumption if Load is half than solar power", function () {
+        site.P_PV = 3000;
+        site.P_Load = -1500;
+        var result = subject.parseAutonomyChart(service, site).dimensions[2];
+
+        expect(result.name).toBe(subject.solarConsumptionId);
+        expect(result.value).toBe(50);
+    });
 });
 
 describe("fronius parsing for energy", function () {


### PR DESCRIPTION
rel_SelfConsumption indicates the consumption in % when using grid AND solar power income in regard to Load.

The new dimension considers solar power as the only source, which is more interesting to people when doing statistics.

`solar_consumption` is `0%` if there is no solar power (night or snowfall). It is `100%` if the load is greater than solar power. If the panels produce double the load, the consumption is `50%`.