### PR TITLE
global XSS protection for netdata

### DIFF
--- a/src/health_json.c
+++ b/src/health_json.c
@@ -2,8 +2,12 @@
 #include "common.h"
 
 static inline void health_string2json(BUFFER *wb, const char *prefix, const char *label, const char *value, const char *suffix) {
-    if(value && *value)
-        buffer_sprintf(wb, "%s\"%s\":\"%s\"%s", prefix, label, value, suffix);
+    if(value && *value) {
+        buffer_sprintf(wb, "%s\"%s\":\"", prefix, label);
+        buffer_strcat_htmlescape(wb, value);
+        buffer_strcat(wb, "\"");
+        buffer_strcat(wb, suffix);
+    }
     else
         buffer_sprintf(wb, "%s\"%s\":null%s", prefix, label, suffix);
 }

--- a/src/health_json.c
+++ b/src/health_json.c
@@ -31,7 +31,6 @@ static inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, R
                     "\t\t\"exec_code\": %d,\n"
                     "\t\t\"source\": \"%s\",\n"
                     "\t\t\"units\": \"%s\",\n"
-                    "\t\t\"info\": \"%s\",\n"
                     "\t\t\"when\": %lu,\n"
                     "\t\t\"duration\": %lu,\n"
                     "\t\t\"non_clear_duration\": %lu,\n"
@@ -59,7 +58,6 @@ static inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, R
                    , ae->exec_code
                    , ae->source
                    , ae->units?ae->units:""
-                   , ae->info?ae->info:""
                    , (unsigned long)ae->when
                    , (unsigned long)ae->duration
                    , (unsigned long)ae->non_clear_duration
@@ -72,6 +70,8 @@ static inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, R
                    , ae->new_value_string
                    , ae->old_value_string
     );
+
+    health_string2json(wb, "\t\t", "info", ae->info?ae->info:"", ",\n");
 
     if(unlikely(ae->flags & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)) {
         buffer_strcat(wb, "\t\t\"no_clear_notification\": true,\n");

--- a/src/web_buffer.c
+++ b/src/web_buffer.c
@@ -160,8 +160,6 @@ void buffer_strcat(BUFFER *wb, const char *txt)
 
 void buffer_strcat_htmlescape(BUFFER *wb, const char *txt)
 {
-    char b[2] = { [0] = '\0', [1] = '\0' };
-
     while(*txt) {
         switch(*txt) {
             case '&': buffer_strcat(wb, "&amp;"); break;
@@ -171,12 +169,14 @@ void buffer_strcat_htmlescape(BUFFER *wb, const char *txt)
             case '/': buffer_strcat(wb, "&#x2F;"); break;
             case '\'': buffer_strcat(wb, "&#x27;"); break;
             default: {
-                b[0] = *txt;
-                buffer_strcat(wb, b);
+                buffer_need_bytes(wb, 1);
+                wb->buffer[wb->len++] = *txt;
             }
         }
         txt++;
     }
+
+    buffer_overflow_check(wb);
 }
 
 void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...)

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -106,6 +106,7 @@ var NETDATA = window.NETDATA || {};
 
     NETDATA.xss = {
         enabled: (typeof netdataCheckXSS === 'undefined')?false:netdataCheckXSS,
+        enabled_for_data: (typeof netdataCheckXSS === 'undefined')?false:netdataCheckXSS,
 
         string: function (s) {
             if (typeof s === 'string' || typeof s === 'number' || typeof s === 'boolean')
@@ -168,15 +169,23 @@ var NETDATA = window.NETDATA || {};
 
         checkOptional: function(name, obj, ignore_regex) {
             if(this.enabled === true) {
-                // console.log('XSS: checking "' + name + '"...');
+                console.log('XSS: checking optional "' + name + '"...');
                 return this.object(name, obj, ignore_regex);
             }
             return obj;
         },
 
         checkAlways: function(name, obj, ignore_regex) {
-            // console.log('XSS: checking "' + name + '"...');
+            console.log('XSS: checking always "' + name + '"...');
             return this.object(name, obj, ignore_regex);
+        },
+
+        checkData: function(name, obj, ignore_regex) {
+            if(this.enabled_for_data === true) {
+                console.log('XSS: checking data "' + name + '"...');
+                return this.object(name, obj, ignore_regex);
+            }
+            return obj;
         }
     };
 
@@ -4977,7 +4986,7 @@ var NETDATA = window.NETDATA || {};
                 var data = this.getSnapshotData(key);
                 if (data !== null) {
                     ok = true;
-                    data = NETDATA.xss.checkAlways('/api/v1/data', data, this.library.xssRegexIgnore);
+                    data = NETDATA.xss.checkData('/api/v1/data', data, this.library.xssRegexIgnore);
                     this.updateChartWithData(data);
                 }
                 else {
@@ -5009,7 +5018,7 @@ var NETDATA = window.NETDATA || {};
                 xhrFields: { withCredentials: true } // required for the cookie
             })
             .done(function(data) {
-                data = NETDATA.xss.checkOptional('/api/v1/data', data, that.library.xssRegexIgnore);
+                data = NETDATA.xss.checkData('/api/v1/data', data, that.library.xssRegexIgnore);
 
                 that.xhr = undefined;
                 that.retries_on_data_failures = 0;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -111,7 +111,6 @@ var NETDATA = window.NETDATA || {};
         string: function (s) {
             if (typeof s === 'string' || typeof s === 'number' || typeof s === 'boolean')
                 return s.toString()
-                    .replace(/&/g, '&amp;')
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;')
                     .replace(/"/g, '&quot;')

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -166,26 +166,17 @@ var NETDATA = window.NETDATA || {};
             }
         },
 
-        checkOptional: function(name, obj, ignore_pattern) {
+        checkOptional: function(name, obj, ignore_regex) {
             if(this.enabled === true) {
-                var regex;
-                if(typeof ignore_pattern !== 'undefined')
-                    regex = new RegExp(ignore_pattern);
-
-                //console.log('XSS: checking "' + name + '"...');
-                return this.object(name, obj, regex);
+                // console.log('XSS: checking "' + name + '"...');
+                return this.object(name, obj, ignore_regex);
             }
             return obj;
         },
 
-        checkAlways: function(name, obj, ignore_pattern) {
-            //console.log('XSS: checking "' + name + '"...');
-
-            var regex;
-            if(typeof ignore_pattern === 'string')
-                regex = new RegExp(ignore_pattern);
-
-            return this.object(name, obj, regex);
+        checkAlways: function(name, obj, ignore_regex) {
+            // console.log('XSS: checking "' + name + '"...');
+            return this.object(name, obj, ignore_regex);
         }
     };
 
@@ -4986,6 +4977,7 @@ var NETDATA = window.NETDATA || {};
                 var data = this.getSnapshotData(key);
                 if (data !== null) {
                     ok = true;
+                    data = NETDATA.xss.checkAlways('/api/v1/data', data, this.library.xssRegexIgnore);
                     this.updateChartWithData(data);
                 }
                 else {
@@ -5017,6 +5009,8 @@ var NETDATA = window.NETDATA || {};
                 xhrFields: { withCredentials: true } // required for the cookie
             })
             .done(function(data) {
+                data = NETDATA.xss.checkOptional('/api/v1/data', data, that.library.xssRegexIgnore);
+
                 that.xhr = undefined;
                 that.retries_on_data_failures = 0;
                 ok = true;
@@ -8373,6 +8367,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: NETDATA.dygraphToolboxPanAndZoom,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.data$'),
             format: function(state) { void(state); return 'json'; },
             options: function(state) { return 'ms|flip' + (this.isLogScale(state)?'|abs':'').toString(); },
             legend: function(state) {
@@ -8417,6 +8412,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
             format: function(state) { void(state); return 'array'; },
             options: function(state) { void(state); return 'flip|abs'; },
             legend: function(state) { void(state); return null; },
@@ -8436,6 +8432,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
             format: function(state) { void(state); return 'ssvcomma'; },
             options: function(state) { void(state); return 'null2zero|flip|abs'; },
             legend: function(state) { void(state); return null; },
@@ -8455,6 +8452,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.data$'),
             format: function(state) { void(state); return 'json'; },
             options: function(state) { void(state); return 'objectrows|ms'; },
             legend: function(state) { void(state); return null; },
@@ -8474,6 +8472,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.rows$'),
             format: function(state) { void(state); return 'datatable'; },
             options: function(state) { void(state); return ''; },
             legend: function(state) { void(state); return null; },
@@ -8493,6 +8492,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.data$'),
             format: function(state) { void(state); return 'json'; },
             options: function(state) { void(state); return ''; },
             legend: function(state) { void(state); return null; },
@@ -8512,6 +8512,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
             format: function(state) { void(state); return 'csvjsonarray'; },
             options: function(state) { void(state); return 'milliseconds'; },
             legend: function(state) { void(state); return null; },
@@ -8531,6 +8532,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.data$'),
             format: function(state) { void(state); return 'json'; },
             options: function(state) { void(state); return 'objectrows|ms'; },
             legend: function(state) { void(state); return null; },
@@ -8550,6 +8552,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result.data$'),
             format: function(state) { void(state); return 'json'; },
             options: function(state) { void(state); return ''; },
             legend: function(state) { void(state); return null; },
@@ -8569,6 +8572,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
             format: function(state) { void(state); return 'array'; },
             options: function(state) { void(state); return 'absolute'; },
             legend: function(state) { void(state); return null; },
@@ -8589,6 +8593,7 @@ var NETDATA = window.NETDATA || {};
             toolboxPanAndZoom: null,
             initialized: false,
             enabled: true,
+            xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
             format: function(state) { void(state); return 'array'; },
             options: function(state) { void(state); return 'absolute'; },
             legend: function(state) { void(state); return null; },
@@ -9012,7 +9017,7 @@ var NETDATA = window.NETDATA || {};
                 xhrFields: { withCredentials: true } // required for the cookie
             })
                 .done(function(data) {
-                    data = NETDATA.xss.checkOptional('/api/v1/alarms', data, '.*\.(calc|calc_parsed|warn|warn_parsed|crit|crit_parsed)$');
+                    data = NETDATA.xss.checkOptional('/api/v1/alarms', data /*, '.*\.(calc|calc_parsed|warn|warn_parsed|crit|crit_parsed)$' */);
 
                     if(NETDATA.alarms.first_notification_id === 0 && typeof data.latest_alarm_log_unique_id === 'number')
                         NETDATA.alarms.first_notification_id = data.latest_alarm_log_unique_id;
@@ -9198,12 +9203,12 @@ var NETDATA = window.NETDATA || {};
                     xhrFields: { withCredentials: true } // required for the cookie
                 })
                 .done(function(data) {
+                    data = NETDATA.xss.checkOptional('/api/v1/registry?action=hello', data);
+
                     if(typeof data.status !== 'string' || data.status !== 'ok') {
                         NETDATA.error(408, host + ' response: ' + JSON.stringify(data));
                         data = null;
                     }
-
-                    data = NETDATA.xss.checkOptional('/api/v1/registry?action=hello', data);
 
                     if(typeof callback === 'function')
                         return callback(data);

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -168,20 +168,20 @@ var NETDATA = window.NETDATA || {};
 
         checkOptional: function(name, obj, ignore_regex) {
             if(this.enabled === true) {
-                console.log('XSS: checking optional "' + name + '"...');
+                //console.log('XSS: checking optional "' + name + '"...');
                 return this.object(name, obj, ignore_regex);
             }
             return obj;
         },
 
         checkAlways: function(name, obj, ignore_regex) {
-            console.log('XSS: checking always "' + name + '"...');
+            //console.log('XSS: checking always "' + name + '"...');
             return this.object(name, obj, ignore_regex);
         },
 
         checkData: function(name, obj, ignore_regex) {
             if(this.enabled_for_data === true) {
-                console.log('XSS: checking data "' + name + '"...');
+                //console.log('XSS: checking data "' + name + '"...');
                 return this.object(name, obj, ignore_regex);
             }
             return obj;

--- a/web/index.html
+++ b/web/index.html
@@ -3206,6 +3206,7 @@
             $('#loadSnapshotImport').addClass('disabled');
 
             if(tmpSnapshotData === null) {
+                loadSnapshotPreflightEmpty();
                 loadSnapshotModalLog('danger', 'no data have been loaded');
                 return;
             }
@@ -3272,7 +3273,11 @@
                         urlOptions.highlight = false;
                     }
 
+                    netdataCheckXSS = false; // disable the modal - this does not affect XSS checks, since dashboard.js is already loaded
+                    NETDATA.xss.enabled = true;             // we should not do any remote requests, but if we do, check them
+                    NETDATA.xss.enabled_for_data = true;    // check also snapshot data - that have been excluded from the initial check, due to compression
                     initializeDynamicDashboard();
+                    loadSnapshotPreflightEmpty();
                 });
             });
         };
@@ -4318,6 +4323,13 @@
                 NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], netdataSnapshotData.after_ms, netdataSnapshotData.before_ms);
             }
 
+            if(typeof netdataCheckXSS !== 'undefined' && netdataCheckXSS === true) {
+                setTimeout(function() {
+                    document.getElementById('netdataXssModalServer').innerText = netdataServer;
+                    $('#xssModal').modal('show');
+                }, 1000);
+            }
+
             // var netdataEnded = performance.now();
             // console.log('start up time: ' + (netdataEnded - netdataStarted).toString() + ' ms');
         }
@@ -4574,6 +4586,39 @@
                         <i class="fas fa-copyright"></i> Copyright (c) 2015,2016 hhurz, <a href="http://rawgit.com/hhurz/tableExport.jquery.plugin/master/tableExport.js" target="_blank">MIT License</a>
 
                     </small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="xssModal" tabindex="-1" role="dialog" aria-labelledby="xssModalLabel">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="xssModalLabel">XSS Protection</h4>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        This dashboard is now rendering data of server:
+                    </p>
+                    <p style="font-size: 1.25em;">
+                        <code id="netdataXssModalServer"></code>
+                    </p>
+                    <p>
+                        To protect your privacy, the dashboard is <b>checking all data transferred</b> for cross site scripting (XSS).
+                        This is CPU intensive, so your browser might be a bit slower.
+                    </p>
+                    <p>
+                        If you <b>trust</b> the remote server, you can disable XSS protection, to speed it up.
+                        <br/>
+                        If you <b>don't trust</b> the remote server, you better keep it on. The dashboard will be a bit slower,
+                        but better be safe, than sorry...
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <a href="#" onclick="NETDATA.xss.enabled = true; NETDATA.xss.enabled_for_data = true; return false;" type="button" class="btn btn-success" data-dismiss="modal">Keep protecting me</a>
+                    <a href="#" onclick="NETDATA.xss.enabled = false; NETDATA.xss.enabled_for_data = false; return false;" type="button" class="btn btn-danger" data-dismiss="modal">I don't need this, the server is mine</a>
                 </div>
             </div>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -3386,6 +3386,7 @@
             document.getElementById('loadSnapshotInfo').innerHTML = '';
             document.getElementById('loadSnapshotTimeRange').innerHTML = '';
             document.getElementById('loadSnapshotComments').innerHTML = '';
+            loadSnapshotModalLog('success', 'Browse for a snapshot file (or drag it and drop it here), then click <b>Import</b> to render it.');
             $('#loadSnapshotImport').addClass('disabled');
         };
 

--- a/web/index.html
+++ b/web/index.html
@@ -3285,7 +3285,7 @@
                 document.getElementById('loadSnapshotFilename').innerHTML = filename;
                 var result = null;
                 try {
-                    result = NETDATA.xss.checkAlways('snapshot', JSON.parse(e.target.result), '^(snapshot\.info|snapshot\.data)$');
+                    result = NETDATA.xss.checkAlways('snapshot', JSON.parse(e.target.result), /^(snapshot\.info|snapshot\.data)$/);
 
                     //console.log(result);
                     var date_after = new Date(result.after_ms);
@@ -5629,6 +5629,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180128-2"></script>
+    <script type="text/javascript" src="dashboard.js?v20180129-1"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -2812,9 +2812,63 @@
             }
         }
 
+        // an object to keep initilization configuration
+        // needed due to the async nature of the XSS modal
+        var initializeConfig = {
+            url: null,
+            custom_info: true,
+        };
+
+        function loadCustomDashboardInfo(url, callback) {
+            loadJs(url, function () {
+                $.extend(true, netdataDashboard, customDashboard);
+                callback();
+            });
+        }
+
+        function initializeChartsAndCustomInfo() {
+            NETDATA.alarms.callback = alarmsCallback;
+
+            // download all the charts the server knows
+            NETDATA.chartRegistry.downloadAll(initializeConfig.url, function(data) {
+                if(data !== null) {
+                    if (initializeConfig.custom_info === true && typeof data.custom_info !== 'undefined' && data.custom_info !== "" && netdataSnapshotData === null) {
+                        //console.log('loading custom dashboard decorations from server ' + initializeConfig.url);
+                        loadCustomDashboardInfo(NETDATA.serverDefault + data.custom_info, function () {
+                            initializeDynamicDashboardWithData(data);
+                        });
+                    }
+                    else {
+                        //console.log('not loading custom dashboard decorations from server ' + initializeConfig.url);
+                        initializeDynamicDashboardWithData(data);
+                    }
+                }
+            });
+        }
+
+        function xssModalDisableXss() {
+            //console.log('disabling xss checks');
+            NETDATA.xss.enabled = false;
+            NETDATA.xss.enabled_for_data = false;
+            initializeConfig.custom_info = true;
+            initializeChartsAndCustomInfo();
+            return false;
+        }
+
+        function xssModalKeepXss() {
+            //console.log('keeping xss checks');
+            NETDATA.xss.enabled = true;
+            NETDATA.xss.enabled_for_data = true;
+            initializeConfig.custom_info = false;
+            initializeChartsAndCustomInfo();
+            return false;
+        }
+
         function initializeDynamicDashboard(netdata_url) {
             if(typeof netdata_url === 'undefined' || netdata_url === null)
                 netdata_url = NETDATA.serverDefault;
+
+            initializeConfig.url = netdata_url;
 
             // initialize clickable alarms
             NETDATA.alarms.chart_div_offset = -50;
@@ -2822,22 +2876,14 @@
             NETDATA.alarms.chart_div_animation_duration = 0;
 
             NETDATA.pause(function() {
-                NETDATA.alarms.callback = alarmsCallback;
-
-                // download all the charts the server knows
-                NETDATA.chartRegistry.downloadAll(netdata_url, function(data) {
-                    if(data !== null) {
-                        if(typeof data.custom_info !== 'undefined' && data.custom_info !== "" && netdataSnapshotData === null) {
-                            loadJs(NETDATA.serverDefault + data.custom_info, function () {
-                                $.extend(true, netdataDashboard, customDashboard);
-                                initializeDynamicDashboardWithData(data);
-                            });
-                        }
-                        else {
-                            initializeDynamicDashboardWithData(data);
-                        }
-                    }
-                });
+                if(typeof netdataCheckXSS !== 'undefined' && netdataCheckXSS === true) {
+                    //$("#loadOverlay").css("display","none");
+                    document.getElementById('netdataXssModalServer').innerText = initializeConfig.url;
+                    $('#xssModal').modal('show');
+                }
+                else {
+                    initializeChartsAndCustomInfo();
+                }
             });
         }
 
@@ -3276,8 +3322,8 @@
                     netdataCheckXSS = false; // disable the modal - this does not affect XSS checks, since dashboard.js is already loaded
                     NETDATA.xss.enabled = true;             // we should not do any remote requests, but if we do, check them
                     NETDATA.xss.enabled_for_data = true;    // check also snapshot data - that have been excluded from the initial check, due to compression
-                    initializeDynamicDashboard();
                     loadSnapshotPreflightEmpty();
+                    initializeDynamicDashboard();
                 });
             });
         };
@@ -4323,13 +4369,6 @@
                 NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], netdataSnapshotData.after_ms, netdataSnapshotData.before_ms);
             }
 
-            if(typeof netdataCheckXSS !== 'undefined' && netdataCheckXSS === true) {
-                setTimeout(function() {
-                    document.getElementById('netdataXssModalServer').innerText = netdataServer;
-                    $('#xssModal').modal('show');
-                }, 1000);
-            }
-
             // var netdataEnded = performance.now();
             // console.log('start up time: ' + (netdataEnded - netdataStarted).toString() + ' ms');
         }
@@ -4591,34 +4630,35 @@
         </div>
     </div>
 
-    <div class="modal fade" id="xssModal" tabindex="-1" role="dialog" aria-labelledby="xssModalLabel">
+    <div class="modal fade" id="xssModal" tabindex="-1" role="dialog" aria-labelledby="xssModalLabel" data-keyboard="false" data-backdrop="static" style="z-index: 3000">
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title" id="xssModalLabel">XSS Protection</h4>
                 </div>
                 <div class="modal-body">
                     <p>
-                        This dashboard is now rendering data of server:
+                        This dashboard is about to render data from server:
                     </p>
                     <p style="font-size: 1.25em;">
                         <code id="netdataXssModalServer"></code>
                     </p>
                     <p>
-                        To protect your privacy, the dashboard is <b>checking all data transferred</b> for cross site scripting (XSS).
-                        This is CPU intensive, so your browser might be a bit slower.
+                        To protect your privacy, the dashboard will <b>check all data transferred</b> for cross site scripting (XSS).
+                        <br/>This is CPU intensive, so your browser might be a bit slower.
                     </p>
                     <p>
-                        If you <b>trust</b> the remote server, you can disable XSS protection, to speed it up.
-                        <br/>
-                        If you <b>don't trust</b> the remote server, you better keep it on. The dashboard will be a bit slower,
-                        but better be safe, than sorry...
+                        If you <b>trust</b> the remote server, you can disable XSS protection.<br/>
+                        In this case, any remote dashboard decoration code (javascript) will also run.
+                    </p>
+                    <p>
+                        If you <b>don't trust</b> the remote server, you should keep the protection on.<br/>
+                        The dashboard will run slower and remote dashboard decoration code will not run, but better be safe than sorry...
                     </p>
                 </div>
                 <div class="modal-footer">
-                    <a href="#" onclick="NETDATA.xss.enabled = true; NETDATA.xss.enabled_for_data = true; return false;" type="button" class="btn btn-success" data-dismiss="modal">Keep protecting me</a>
-                    <a href="#" onclick="NETDATA.xss.enabled = false; NETDATA.xss.enabled_for_data = false; return false;" type="button" class="btn btn-danger" data-dismiss="modal">I don't need this, the server is mine</a>
+                    <a href="#" onclick="return xssModalKeepXss();" type="button" class="btn btn-success" data-dismiss="modal">Keep protecting me</a>
+                    <a href="#" onclick="return xssModalDisableXss();" type="button" class="btn btn-danger" data-dismiss="modal">I don't need this, the server is mine</a>
                 </div>
             </div>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -674,6 +674,7 @@
                 if(urlOptions.server !== null && urlOptions.server !== '') {
                     netdataServerStatic = document.location.origin.toString() + document.location.pathname.toString();
                     netdataServer = urlOptions.server;
+                    netdataCheckXSS = true;
                 }
                 else
                     urlOptions.server = null;
@@ -3278,12 +3279,14 @@
 
 
         function loadSnapshotPreflightFile(file) {
+            var filename = NETDATA.xss.string(file.name);
             var fr = new FileReader();
             fr.onload = function(e) {
-                document.getElementById('loadSnapshotFilename').innerHTML = file.name;
+                document.getElementById('loadSnapshotFilename').innerHTML = filename;
                 var result = null;
                 try {
-                    result = JSON.parse(e.target.result);
+                    result = NETDATA.xss.checkAlways('snapshot', JSON.parse(e.target.result), '^(snapshot\.info|snapshot\.data)$');
+
                     //console.log(result);
                     var date_after = new Date(result.after_ms);
                     var date_before = new Date(result.before_ms);
@@ -3300,7 +3303,7 @@
                     if (typeof result.data_size === 'undefined')
                         result.data_size = 0;
 
-                    document.getElementById('loadSnapshotFilename').innerHTML = '<code>' + file.name + '</code>';
+                    document.getElementById('loadSnapshotFilename').innerHTML = '<code>' + filename + '</code>';
                     document.getElementById('loadSnapshotHostname').innerHTML = '<b>' + result.hostname + '</b>, netdata version: <b>' + result.netdata_version.toString() + '</b>';
                     document.getElementById('loadSnapshotURL').innerHTML = result.url;
                     document.getElementById('loadSnapshotCharts').innerHTML = result.charts.charts_count.toString() + ' charts, ' + result.charts.dimensions_count.toString() + ' dimensions, ' + result.data_points.toString() + ' points per dimension, ' + Math.round(result.duration_ms / result.data_points).toString() + ' ms per point';
@@ -4666,6 +4669,7 @@
                     </p>
                 </div>
                 <div class="modal-footer">
+                    <span style="display: inline-block; padding-right: 20px;">Snapshot files contain both data and javascript code. Make sure <b>you trust the files</b> you import!</span>
                     <a id="loadSnapshotImport" href="#" onclick="loadSnapshot(); return false;" type="button" class="btn btn-success disabled">Import</a>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
@@ -5625,6 +5629,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180127-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20180128-2"></script>
 </body>
 </html>


### PR DESCRIPTION
netdata suffers from XSS in these cases:

1. loading snapshots
2. accessing remote servers via the `;server=URL` URL hash parameter
3. registry data

This PR adds a global XSS protection for netdata.

I have received an email from a folk, explaining this in detail to me. I hope he will join this discussion.

Also, XSS cannot be solved completely, since netdata actually relies on it in certain cases, this PR makes sure netdata has basic protection against it.

So, here is what it does:

## snapshots

When snapshots are loaded, the data of the snapshot are checked for XSS and properly escaped before hitting the screen. The snapshot however includes also javascript functions that control various aspects of the dashboard. I have added a note at the snapshot modal to state the fact:

![image](https://user-images.githubusercontent.com/2662304/35487553-63791766-0485-11e8-8bfa-2c051650c985.png)

## registry

The registry requests are now always checked for XSS.

## remote servers (via `;server=URL` at the URL hash)

The dashboard checks all API calls for XSS. When loading such a dashboard, this modal appears:

![screenshot from 2018-01-30 00-30-05](https://user-images.githubusercontent.com/2662304/35537934-c1ff2be8-0554-11e8-9996-32899ece4cd3.png)
