### PR TITLE
rename kubernetes containers; statsd file includes

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1045,10 +1045,15 @@ static STATSD_APP_CHART_DIM *add_dimension_to_app_chart(
 }
 
 static int statsd_readfile(const char *path, const char *filename, STATSD_APP *app, STATSD_APP_CHART *chart, DICTIONARY *dict) {
-    debug(D_STATSD, "STATSD configuration reading file '%s/%s'", path, filename);
+    info("STATSD configuration reading file '%s/%s'", path, filename);
 
     char *buffer = mallocz(STATSD_CONF_LINE_MAX + 1);
-    snprintfz(buffer, STATSD_CONF_LINE_MAX, "%s/%s", path, filename);
+
+    if(filename[0] == '/')
+        strncpyz(buffer, filename, STATSD_CONF_LINE_MAX);
+    else
+        snprintfz(buffer, STATSD_CONF_LINE_MAX, "%s/%s", path, filename);
+
     FILE *fp = fopen(buffer, "r");
     if(!fp) {
         error("STATSD: cannot open file '%s'.", buffer);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1044,22 +1044,17 @@ static STATSD_APP_CHART_DIM *add_dimension_to_app_chart(
     return dim;
 }
 
-int statsd_readfile(const char *path, const char *filename) {
+static int statsd_readfile(const char *path, const char *filename, STATSD_APP *app, STATSD_APP_CHART *chart, DICTIONARY *dict) {
     debug(D_STATSD, "STATSD configuration reading file '%s/%s'", path, filename);
 
-    char buffer[STATSD_CONF_LINE_MAX + 1];
-
-    FILE *fp = NULL;
+    char *buffer = mallocz(STATSD_CONF_LINE_MAX + 1);
     snprintfz(buffer, STATSD_CONF_LINE_MAX, "%s/%s", path, filename);
-    fp = fopen(buffer, "r");
+    FILE *fp = fopen(buffer, "r");
     if(!fp) {
         error("STATSD: cannot open file '%s'.", buffer);
+        freez(buffer);
         return -1;
     }
-
-    STATSD_APP *app = NULL;
-    STATSD_APP_CHART *chart = NULL;
-    DICTIONARY *dict = NULL;
 
     size_t line = 0;
     char *s;
@@ -1072,7 +1067,18 @@ int statsd_readfile(const char *path, const char *filename) {
             debug(D_STATSD, "STATSD: ignoring line %zu of file '%s/%s', it is empty.", line, path, filename);
             continue;
         }
+
         debug(D_STATSD, "STATSD: processing line %zu of file '%s/%s': %s", line, path, filename, buffer);
+
+        if(*s == 'i' && strncmp(s, "include", 7) == 0) {
+            s = trim(&s[7]);
+            if(s && *s)
+                statsd_readfile(path, s, app, chart, dict);
+            else
+                error("STATSD: ignoring line %zu of file '%s/%s', include filename is empty", line, path, s);
+
+            continue;
+        }
 
         int len = (int) strlen(s);
         if (*s == '[' && s[len - 1] == ']') {
@@ -1296,6 +1302,7 @@ int statsd_readfile(const char *path, const char *filename) {
         }
     }
 
+    freez(buffer);
     fclose(fp);
     return 0;
 }
@@ -1336,7 +1343,7 @@ static void statsd_readdir(const char *path) {
 
         else if((de->d_type == DT_LNK || de->d_type == DT_REG || de->d_type == DT_UNKNOWN) &&
                 len > 5 && !strcmp(&de->d_name[len - 5], ".conf")) {
-            statsd_readfile(path, de->d_name);
+            statsd_readfile(path, de->d_name, NULL, NULL, NULL);
         }
 
         else debug(D_STATSD, "STATSD: ignoring file '%s'", de->d_name);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -1045,7 +1045,7 @@ static STATSD_APP_CHART_DIM *add_dimension_to_app_chart(
 }
 
 static int statsd_readfile(const char *path, const char *filename, STATSD_APP *app, STATSD_APP_CHART *chart, DICTIONARY *dict) {
-    info("STATSD configuration reading file '%s/%s'", path, filename);
+    debug(D_STATSD, "STATSD configuration reading file '%s/%s'", path, filename);
 
     char *buffer = mallocz(STATSD_CONF_LINE_MAX + 1);
 

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -213,7 +213,8 @@ void read_cgroup_plugin_configuration() {
                     " *docker* "
                     " *lxc* "
                     " *qemu* "
-                    " *.libvirt-qemu "                    //  #3010
+                    " *kubepods* "                        // #3396
+                    " *.libvirt-qemu "                    // #3010
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);
 
@@ -839,9 +840,9 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     pid_t cgroup_pid;
     char buffer[CGROUP_CHARTID_LINE_MAX + 1];
 
-    snprintfz(buffer, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->chart_id);
+    snprintfz(buffer, CGROUP_CHARTID_LINE_MAX, "exec %s '%s' '%s'", cgroups_rename_script, cg->chart_id, cg->id);
 
-    debug(D_CGROUP, "executing command '%s' for cgroup '%s'", buffer, cg->id);
+    debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", buffer, cg->id);
     FILE *fp = mypopen(buffer, &cgroup_pid);
     if(fp) {
         // debug(D_CGROUP, "reading from command '%s' for cgroup '%s'", buffer, cg->id);


### PR DESCRIPTION
1. rename cgroups on kubernets clusters with kops - fixes #3369 
2. statsd.d config files now support `include filename` to include another file at the exact position the include line is placed.
