### PR TITLE
aarch64/arm64 support for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 # author  : titpetric
 # original: https://github.com/titpetric/netdata
 
-FROM debian:jessie
+FROM debian:stretch
 
 ADD . /netdata.git
-
-RUN echo "deb http://ftp.nl.debian.org/debian/ jessie main" > /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
 
 RUN cd ./netdata.git && chmod +x ./docker-build.sh && sync && sleep 1 && ./docker-build.sh
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,19 @@
+# author  : titpetric
+# original: https://github.com/titpetric/netdata
+
+FROM resin/aarch64-debian:stretch
+
+RUN [ "cross-build-start"]
+
+ADD . /netdata.git
+
+RUN cd ./netdata.git && chmod +x ./docker-build.sh && sync && sleep 1 && ./docker-build.sh
+
+WORKDIR /
+
+ENV NETDATA_PORT 19999
+EXPOSE $NETDATA_PORT
+
+CMD /usr/sbin/netdata -D -s /host -p ${NETDATA_PORT}
+
+RUN [ "cross-build-end"]

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -1,7 +1,7 @@
 # author  : titpetric
 # original: https://github.com/titpetric/netdata
 
-FROM resin/armv7hf-debian:jessie
+FROM resin/armv7hf-debian:stretch
 
 RUN [ "cross-build-start"]
 


### PR DESCRIPTION
* Change for request #3384 
* Added support for aarch64
* Updated to Debian stretch (nodejs wasn't in the jessie release on aarch64, and it's been stable for 6+ months now, probably time to update and keep them all in sync anyway)