### PR TITLE
Add charts for postgres

### DIFF
--- a/conf.d/python.d/postgres.conf
+++ b/conf.d/python.d/postgres.conf
@@ -82,9 +82,18 @@
 # a postgres user for netdata and add its password below to allow
 # netdata connect.
 #
-# Without superuser access, netdata won't be able to generate the write
-# ahead log and the background writer charts.
+# Postgres supported versions are : 
+# - 9.3 (without autovacuum)
+# - 9.4
+# - 9.5
+# - 9.6
+# - 10
 #
+# Superuser access is needed for theses charts:
+#   Write-Ahead Logs
+#   Archive Write-Ahead Logs
+#
+# Autovacuum charts is allowed since Postgres 9.4
 # ----------------------------------------------------------------------
 
 socket:

--- a/python.d/postgres.chart.py
+++ b/python.d/postgres.chart.py
@@ -32,6 +32,8 @@ METRICS = dict(
               'tup_updated',
               'tup_deleted',
               'conflicts',
+              'temp_files',
+              'temp_bytes',
               'size'],
     BACKENDS=['backends_active',
               'backends_idle'],
@@ -39,11 +41,20 @@ METRICS = dict(
                  'index_size'],
     TABLE_STATS=['table_size',
                  'table_count'],
+    WAL=['written_wal',
+         'recycled_wal',
+         'total_wal'],
     ARCHIVE=['ready_count',
              'done_count',
              'file_count'],
-    BGWRITER=['writer_scheduled',
-              'writer_requested'],
+    BGWRITER=['checkpoint_scheduled',
+              'checkpoint_requested',
+              'buffers_checkpoint',
+              'buffers_clean',
+              'maxwritten_clean',
+              'buffers_backend',
+              'buffers_alloc',
+              'buffers_backend_fsync'],
     LOCKS=['ExclusiveLock',
            'RowShareLock',
            'SIReadLock',
@@ -52,17 +63,41 @@ METRICS = dict(
            'AccessShareLock',
            'ShareRowExclusiveLock',
            'ShareLock',
-           'RowExclusiveLock']
+           'RowExclusiveLock'],
+    AUTOVACUUM=['analyze',
+                'vacuum_analyze',
+                'vacuum',
+                'vacuum_freeze',
+                'brin_summarize'],
+    STANDBY_DELTA=['sent_delta',
+                       'write_delta',
+                       'flush_delta',
+                       'replay_delta']
 )
 
 QUERIES = dict(
+    WAL="""
+SELECT
+  count(*) as total_wal,
+  count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
+  count(*) FILTER (WHERE type = 'written') AS written_wal
+FROM
+  (SELECT wal.name,
+     pg_{0}file_name(pg_current_{0}_{1}()),
+     CASE WHEN wal.name > pg_{0}file_name(pg_current_{0}_{1}()) THEN 'recycled'
+       ELSE 'written'
+     END AS type
+  FROM pg_catalog.pg_ls_dir('pg_{0}') AS wal(name)
+  WHERE name ~ '^[0-9A-F]{{24}}$'
+  ORDER BY (pg_stat_file('pg_{0}/'||name)).modification, wal.name DESC) sub;
+""",
     ARCHIVE="""
 SELECT
     CAST(COUNT(*) AS INT) AS file_count,
     CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.ready$$r$ as INT)), 0) AS INT) AS ready_count,
     CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.done$$r$ AS INT)), 0) AS INT) AS done_count
 FROM
-    pg_catalog.pg_ls_dir('{0}/archive_status') AS archive_files (archive_file);
+    pg_catalog.pg_ls_dir('pg_{0}/archive_status') AS archive_files (archive_file);
 """,
     BACKENDS="""
 SELECT
@@ -86,28 +121,37 @@ WHERE relkind = 'i';""",
     DATABASE="""
 SELECT
   datname AS database_name,
-  sum(numbackends) AS connections,
-  sum(xact_commit) AS xact_commit,
-  sum(xact_rollback) AS xact_rollback,
-  sum(blks_read) AS blks_read,
-  sum(blks_hit) AS blks_hit,
-  sum(tup_returned) AS tup_returned,
-  sum(tup_fetched) AS tup_fetched,
-  sum(tup_inserted) AS tup_inserted,
-  sum(tup_updated) AS tup_updated,
-  sum(tup_deleted) AS tup_deleted,
-  sum(conflicts) AS conflicts,
-  pg_database_size(datname) AS size
+  numbackends AS connections,
+  xact_commit AS xact_commit,
+  xact_rollback AS xact_rollback,
+  blks_read AS blks_read,
+  blks_hit AS blks_hit,
+  tup_returned AS tup_returned,
+  tup_fetched AS tup_fetched,
+  tup_inserted AS tup_inserted,
+  tup_updated AS tup_updated,
+  tup_deleted AS tup_deleted,
+  conflicts AS conflicts,
+  pg_database_size(datname) AS size,
+  temp_files AS temp_files,
+  temp_bytes AS temp_bytes
 FROM pg_stat_database
 WHERE datname IN %(databases)s
-GROUP BY datname;
+;
 """,
     BGWRITER="""
 SELECT
-  checkpoints_timed AS writer_scheduled,
-  checkpoints_req AS writer_requested
-FROM pg_stat_bgwriter;""",
-   LOCKS="""
+  checkpoints_timed AS checkpoint_scheduled,
+  checkpoints_req AS checkpoint_requested,
+  buffers_checkpoint * current_setting('block_size')::numeric buffers_checkpoint,
+  buffers_clean * current_setting('block_size')::numeric buffers_clean,
+  maxwritten_clean,
+  buffers_backend * current_setting('block_size')::numeric buffers_backend,
+  buffers_alloc * current_setting('block_size')::numeric buffers_alloc,
+  buffers_backend_fsync
+FROM pg_stat_bgwriter;
+""",
+    LOCKS="""
 SELECT
   pg_database.datname as database_name,
   mode,
@@ -123,12 +167,39 @@ FROM pg_stat_database
 WHERE has_database_privilege((SELECT current_user), datname, 'connect')
 AND NOT datname ~* '^template\d+';
 """,
+    FIND_STANDBY="""
+SELECT application_name
+FROM pg_stat_replication
+WHERE application_name IS NOT NULL
+GROUP BY application_name;
+""",
+    STANDBY_DELTA="""
+SELECT application_name,
+  pg_{0}_{1}_diff(pg_current_{0}_{1}() , sent_{1}) AS sent_delta,
+  pg_{0}_{1}_diff(pg_current_{0}_{1}() , write_{1}) AS write_delta,
+  pg_{0}_{1}_diff(pg_current_{0}_{1}() , flush_{1}) AS flush_delta,
+  pg_{0}_{1}_diff(pg_current_{0}_{1}() , replay_{1}) AS replay_delta
+FROM pg_stat_replication
+WHERE application_name IS NOT NULL
+""",
     IF_SUPERUSER="""
 SELECT current_setting('is_superuser') = 'on' AS is_superuser;
-    """,
+""",
     DETECT_SERVER_VERSION="""
 SHOW server_version_num;
-    """
+""",
+    AUTOVACUUM="""
+SELECT
+  count(*) FILTER (WHERE query LIKE  'autovacuum: ANALYZE%%') AS analyze,
+  count(*) FILTER (WHERE query LIKE  'autovacuum: VACUUM ANALYZE%%') AS vacuum_analyze,
+  count(*) FILTER (WHERE query LIKE  'autovacuum: VACUUM%%'
+                     AND query NOT LIKE  'autovacuum: VACUUM ANALYZE%%'
+                     AND query NOT LIKE  '%%to prevent wraparound%%') AS vacuum,
+  count(*) FILTER (WHERE query LIKE  '%%to prevent wraparound%%') AS vacuum_freeze,
+  count(*) FILTER (WHERE query LIKE  'autovacuum: BRIN summarize%%') AS brin_summarize
+FROM pg_stat_activity
+WHERE query NOT LIKE '%%pg_stat_activity%%';
+"""
 )
 
 
@@ -138,8 +209,11 @@ QUERY_STATS = {
     QUERIES['LOCKS']: METRICS['LOCKS']
 }
 
-ORDER = ['db_stat_transactions', 'db_stat_tuple_read', 'db_stat_tuple_returned', 'db_stat_tuple_write', 'database_size',
-         'backend_process', 'index_count', 'index_size', 'table_count', 'table_size', 'wal', 'background_writer']
+ORDER = ['db_stat_temp_bytes', 'db_stat_temp_files', 'db_stat_blks', 'db_stat_tuple_returned', 'db_stat_tuple_write',
+         'db_stat_transactions','db_stat_connections', 'database_size', 'backend_process', 'index_count', 'index_size',
+         'table_count', 'table_size', 'wal', 'archive_wal', 'checkpointer', 'stat_bgwriter_alloc', 'stat_bgwriter_checkpoint',
+         'stat_bgwriter_backend', 'stat_bgwriter_backend_fsync' , 'stat_bgwriter_bgwriter', 'stat_bgwriter_maxwritten',
+         'standby_delta','autovacuum']
 
 CHARTS = {
     'db_stat_transactions': {
@@ -155,8 +229,8 @@ CHARTS = {
         'lines': [
             ['connections', 'connections', 'absolute']
         ]},
-    'db_stat_tuple_read': {
-        'options': [None, 'Tuple reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_tuple_read', 'line'],
+    'db_stat_blks': {
+        'options': [None, 'Disk blocks reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_blks', 'line'],
         'lines': [
             ['blks_read', 'disk', 'incremental'],
             ['blks_hit', 'cache', 'incremental']
@@ -175,6 +249,16 @@ CHARTS = {
             ['tup_updated', 'updated', 'incremental'],
             ['tup_deleted', 'deleted', 'incremental'],
             ['conflicts', 'conflicts', 'incremental']
+        ]},
+    'db_stat_temp_bytes': {
+        'options': [None, 'Temp files written to disk', 'KB/s', 'db statistics', 'postgres.db_stat_temp_bytes', 'line'],
+        'lines': [
+            ['temp_bytes', 'size', 'incremental', 1, 1024]
+        ]},
+    'db_stat_temp_files': {
+        'options': [None, 'Temp files written to disk', 'files', 'db statistics', 'postgres.db_stat_temp_files', 'line'],
+        'lines': [
+            ['temp_files', 'files', 'incremental']
         ]},
     'database_size': {
         'options': [None, 'Database size', 'MB', 'database size', 'postgres.db_size', 'stacked'],
@@ -208,17 +292,71 @@ CHARTS = {
             ['table_size', 'size', 'absolute', 1, 1024 * 1024]
         ]},
     'wal': {
-        'options': [None, 'Write-Ahead Logging Statistics', 'files/s', 'write ahead log', 'postgres.wal', 'line'],
+        'options': [None, 'Write-Ahead Logs', 'files', 'wal', 'postgres.wal', 'line'],
+        'lines': [
+            ['written_wal', 'written', 'absolute'],
+            ['recycled_wal', 'recycled', 'absolute'],
+            ['total_wal', 'total', 'absolute']
+        ]},
+    'archive_wal': {
+        'options': [None, 'Archive Write-Ahead Logs', 'files/s', 'archive wal', 'postgres.archive_wal', 'line'],
         'lines': [
             ['file_count', 'total', 'incremental'],
             ['ready_count', 'ready', 'incremental'],
             ['done_count', 'done', 'incremental']
         ]},
-    'background_writer': {
-        'options': [None, 'Checkpoints', 'writes/s', 'background writer', 'postgres.background_writer', 'line'],
+    'checkpointer': {
+        'options': [None, 'Checkpoints', 'writes', 'checkpointer', 'postgres.checkpointer', 'line'],
         'lines': [
-            ['writer_scheduled', 'scheduled', 'incremental'],
-            ['writer_requested', 'requested', 'incremental']
+            ['checkpoint_scheduled', 'scheduled', 'incremental'],
+            ['checkpoint_requested', 'requested', 'incremental']
+        ]},
+    'stat_bgwriter_alloc': {
+        'options': [None, 'Buffers allocated', 'kilobytes/s', 'bgwriter', 'postgres.stat_bgwriter_alloc', 'line'],
+        'lines': [
+            ['buffers_alloc', 'alloc', 'incremental', 8, 1024]
+        ]},
+    'stat_bgwriter_checkpoint': {
+        'options': [None, 'Buffers written during checkpoints', 'kilobytes/s', 'bgwriter', 'postgres.stat_bgwriter_checkpoint', 'line'],
+        'lines': [
+            ['buffers_checkpoint', 'checkpoint', 'incremental', 8, 1024]
+        ]},
+    'stat_bgwriter_backend': {
+        'options': [None, 'Buffers written directly by a backend', 'kilobytes/s', 'bgwriter', 'postgres.stat_bgwriter_backend', 'line'],
+        'lines': [
+            ['buffers_backend', 'backend', 'incremental', 8, 1024]
+        ]},
+    'stat_bgwriter_backend_fsync': {
+        'options': [None, 'Fsync by backend', 'times', 'bgwriter', 'postgres.stat_bgwriter_backend_fsync', 'line'],
+        'lines': [
+            ['buffers_backend_fsync', 'backend fsync', 'incremental']
+        ]},
+    'stat_bgwriter_bgwriter': {
+        'options': [None, 'Buffers written by the background writer', 'kilobytes/s', 'bgwriter', 'postgres.bgwriter_bgwriter', 'line'],
+        'lines': [
+            ['buffers_clean', 'clean', 'incremental', 8, 1024]
+        ]},
+    'stat_bgwriter_maxwritten': {
+        'options': [None, 'Too many buffers written', 'times', 'bgwriter', 'postgres.stat_bgwriter_maxwritten', 'line'],
+        'lines': [
+            ['maxwritten_clean', 'maxwritten', 'incremental']
+        ]},
+    'autovacuum': {
+        'options': [None, 'Autovacuum workers', 'workers', 'autovacuum', 'postgres.autovacuum', 'line'],
+        'lines': [
+            ['analyze', 'analyze', 'absolute'],
+            ['vacuum', 'vacuum', 'absolute'],
+            ['vacuum_analyze', 'vacuum analyze', 'absolute'],
+            ['vacuum_freeze', 'vacuum freeze', 'absolute'],
+            ['brin_summarize', 'brin summarize', 'absolute']
+        ]},
+    'standby_delta': {
+        'options': [None, 'Standby delta', 'kilobytes', 'replication delta', 'postgres.standby_delta', 'line'],
+        'lines': [
+            ['sent_delta', 'sent delta', 'absolute', 1, 1024],
+            ['write_delta', 'write delta', 'absolute', 1, 1024],
+            ['flush_delta', 'flush delta', 'absolute', 1, 1024],
+            ['replay_delta', 'replay delta', 'absolute', 1, 1024]
         ]}
 }
 
@@ -237,6 +375,7 @@ class Service(SimpleService):
         self.data = dict()
         self.locks_zeroed = dict()
         self.databases = list()
+        self.secondaries = list()
         self.queries = QUERY_STATS.copy()
 
     def _connect(self):
@@ -270,6 +409,7 @@ class Service(SimpleService):
             cursor = self.connection.cursor()
             self.databases = discover_databases_(cursor, QUERIES['FIND_DATABASES'])
             is_superuser = check_if_superuser_(cursor, QUERIES['IF_SUPERUSER'])
+            self.secondaries = discover_secondaries_(cursor, QUERIES['FIND_STANDBY'])
             self.server_version = detect_server_version(cursor, QUERIES['DETECT_SERVER_VERSION'])
             cursor.close()
 
@@ -286,28 +426,43 @@ class Service(SimpleService):
             return False
 
     def add_additional_queries_(self, is_superuser):
+
+        if self.server_version >= 100000:
+            wal = 'wal'
+            lsn = 'lsn'
+        else:
+            wal = 'xlog'
+            lsn = 'location'
+
+        self.queries[QUERIES['BGWRITER']] = METRICS['BGWRITER']
+        self.queries[QUERIES['STANDBY_DELTA'].format(wal,lsn)] = METRICS['STANDBY_DELTA']
+
         if self.index_stats:
             self.queries[QUERIES['INDEX_STATS']] = METRICS['INDEX_STATS']
         if self.table_stats:
             self.queries[QUERIES['TABLE_STATS']] = METRICS['TABLE_STATS']
         if is_superuser:
-            self.queries[QUERIES['BGWRITER']] = METRICS['BGWRITER']
-            if self.server_version >= 100000:
-                wal_dir_name = 'pg_wal'
-            else:
-                wal_dir_name = 'pg_xlog'
-            self.queries[QUERIES['ARCHIVE'].format(wal_dir_name)] = METRICS['ARCHIVE']
+            self.queries[QUERIES['ARCHIVE'].format(wal)] = METRICS['ARCHIVE']
+            if self.server_version >= 90400:
+                self.queries[QUERIES['WAL'].format(wal,lsn)] = METRICS['WAL']
+        if self.server_version >= 90400:
+            self.queries[QUERIES['AUTOVACUUM']] = METRICS['AUTOVACUUM']
 
     def create_dynamic_charts_(self):
 
         for database_name in self.databases[::-1]:
             self.definitions['database_size']['lines'].append([database_name + '_size',
                                                                database_name, 'absolute', 1, 1024 * 1024])
-            for chart_name in [name for name in CHARTS if name.startswith('db_stat')]:
+            for chart_name in [name for name in self.order if name.startswith('db_stat')]:
                     add_database_stat_chart_(order=self.order, definitions=self.definitions,
                                              name=chart_name, database_name=database_name)
 
             add_database_lock_chart_(order=self.order, definitions=self.definitions, database_name=database_name)
+
+        for application_name in self.secondaries[::-1]:
+              add_replication_delta_chart_(order=self.order, definitions=self.definitions,
+                                       name='standby_delta', application_name=application_name)
+
 
     def _get_data(self):
         result, error = self._connect()
@@ -332,7 +487,12 @@ class Service(SimpleService):
         cursor.execute(query, dict(databases=tuple(self.databases)))
         for row in cursor:
             for metric in metrics:
-                dimension_id = '_'.join([row['database_name'], metric]) if 'database_name' in row else metric
+                if 'database_name' in row:
+                    dimension_id = '_'.join([row['database_name'], metric])
+                elif 'application_name' in row:
+                    dimension_id = '_'.join([row['application_name'], metric])
+                else:
+                    dimension_id = metric
                 if metric in row:
                     self.data[dimension_id] = int(row[metric])
                 elif 'locks_count' in row:
@@ -345,6 +505,14 @@ def discover_databases_(cursor, query):
     for db in [database[0] for database in cursor]:
         if db not in result:
             result.append(db)
+    return result
+
+def discover_secondaries_(cursor, query):
+    cursor.execute(query)
+    result = list()
+    for sc in [standby[0] for standby in cursor]:
+        if sc not in result:
+            result.append(sc)
     return result
 
 
@@ -398,3 +566,20 @@ def add_database_stat_chart_(order, definitions, name, database_name):
     definitions[chart_name] = {
                'options': [name, title + ': ' + database_name,  units, 'db ' + database_name, context,  chart_type],
                'lines': create_lines(database_name, chart_template['lines'])}
+
+def add_replication_delta_chart_(order, definitions, name, application_name):
+    def create_lines(standby, lines):
+        result = list()
+        for line in lines:
+            new_line = ['_'.join([standby, line[0]])] + line[1:]
+            result.append(new_line)
+        return result
+
+    chart_template = CHARTS[name]
+    chart_name = '_'.join([application_name, name])
+    position = order.index('database_size')
+    order.insert(position, chart_name)
+    name, title, units, family, context, chart_type = chart_template['options']
+    definitions[chart_name] = {
+               'options': [name, title + ': ' + application_name,  units, 'replication delta', context,  chart_type],
+               'lines': create_lines(application_name, chart_template['lines'])}

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -985,6 +985,59 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // POSTGRESQL
+
+
+    'postgres.db_stat_blks': {
+        info: 'Blocks reads from disk or cache.<ul>' +
+        '<li><strong>blks_read:</strong> number of disk blocks read in this database.</li>' +
+        '<li><strong>blks_hit:</strong> number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system&#39;s file system cache)</li>' +
+        '</ul>'
+    },
+    'postgres.db_stat_tuple_write': {
+        info: '<ul><li>Number of rows inserted/updated/deleted.</li>' +
+        '<li><strong>conflicts:</strong> number of queries canceled due to conflicts with recovery in this database. (Conflicts occur only on standby servers; see <a href="https://www.postgresql.org/docs/10/static/monitoring-stats.html#PG-STAT-DATABASE-CONFLICTS-VIEW" target="_blank">pg_stat_database_conflicts</a> for details.)</li>' +
+        '</ul>'
+    },
+    'postgres.db_stat_temp_bytes': {
+        info: 'Temporary files can be created on disk for sorts, hashes, and temporary query results.'
+    },
+    'postgres.db_stat_temp_files': {
+        info: '<ul>' +
+        '<li><strong>files:</strong> number of temporary files created by queries. All temporary files are counted, regardless of why the temporary file was created (e.g., sorting or hashing).</li>' +
+        '</ul>'
+    },
+    'postgres.archive_wal': {
+         info: 'WAL archiving.<ul>' +
+        '<li><strong>total:</strong> total files.</li>' +
+        '<li><strong>ready:</strong> WAL waiting to be archived.</li>' +
+        '<li><strong>done:</strong> WAL successfully archived' +
+        'Ready WAL can indicate archive_command is in error, see <a href="https://www.postgresql.org/docs/current/static/continuous-archiving.html" target="_blank">Continuous Archiving and Point-in-Time Recovery</a>.</li>' +
+        '</ul>'
+    },
+    'postgres.checkpointer': {
+        info: 'Number of checkpoints.<ul>' +
+        '<li><strong>scheduled:</strong> when checkpoint_timeout is reached.</li>' +
+        '<li><strong>requested:</strong> when max_wal_size is reached.</li>' +
+        '</ul>' +
+        'For more information see <a href="https://www.postgresql.org/docs/current/static/wal-configuration.html" target="_blank">WAL Configuration</a>.'
+    },
+    'postgres.autovacuum': {
+        info: 'PostgreSQL databases require periodic maintenance known as vacuuming. For many installations, it is sufficient to let vacuuming be performed by the autovacuum daemon.' +
+        'For more information see <a href="https://www.postgresql.org/docs/current/static/routine-vacuuming.html#AUTOVACUUM" target="_blank">The Autovacuum Daemon</a>.'
+    },
+    'postgres.standby_delta': {
+        info: 'Streaming replication delta.<ul>' +
+        '<li><strong>sent_delta:</strong> replication delta sent to standby.</li>' +
+        '<li><strong>write_delta:</strong> replication delta written to disk by this standby.</li>' +
+        '<li><strong>flush_delta:</strong> replication delta flushed to disk by this standby server.</li>' +
+        '<li><strong>replay_delta:</strong> replication delta replayed into the database on this standby server.</li>' +
+        '</ul>' +
+        'For more information see <a href="https://www.postgresql.org/docs/current/static/warm-standby.html#SYNCHRONOUS-REPLICATION" target="_blank">Synchronous Replication</a>.'
+    },
+
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {


### PR DESCRIPTION
Hello,

This PR add several charts for PostgreSQL: 

  * [x] : Rename chart BGWRITER to CHECKPOINTER because it is checkpointer process which triggers checkpoints (https://www.postgresql.org/docs/current/static/wal-configuration.html).
  * [x] : Rename "writer_scheduled" to "checkpoint_scheduled", same for writer_requested.
  * [x] : New BGWRITER chart according to https://www.postgresql.org/docs/10/static/monitoring-stats.html#PG-STAT-BGWRITER-VIEW
  * [x] :  New chart for autovacuum, it counts workers and their activity VACUUM, VACUUM ANALYZE, ANALYZE, VACUUM FREEZE
  * [x] : Replication delta. Maybe we should put chart below, I did not find how to change the position (python beginner inside)?
  * [x] : Wal chart renamed to archive wal
  * [x] : New chart wal files : number of WAL files, current number of written WAL, current number of recycled WAL
  * [x] : Add temps files stats per database

Heavily inspired by https://github.com/OPMDG/check_pgactivity

Here the result:
# BGWRITER

![selection_020](https://user-images.githubusercontent.com/6862220/35942991-eac1dbfc-0c57-11e8-8d76-8131a0520483.png)

# Autovacuum

![selection_021](https://user-images.githubusercontent.com/6862220/36060955-676a30f8-0e53-11e8-9770-c2295f45fba8.png)

# Replication delta

![selection_022](https://user-images.githubusercontent.com/6862220/36062522-a642c86a-0e6e-11e8-9cf9-2e6d5bb28abb.png)

# Wal

![selection_023](https://user-images.githubusercontent.com/6862220/36063597-407196e0-0e7f-11e8-817e-fe4465c94348.png)

# Temp files

![selection_024](https://user-images.githubusercontent.com/6862220/36064000-ce65815a-0e84-11e8-8c45-b9f7c060153a.png)


Regards,