### PR TITLE
procfile optimizations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ AC_ARG_ENABLE(
 AX_GCC_FUNC_ATTRIBUTE([returns_nonnull])
 AX_GCC_FUNC_ATTRIBUTE([malloc])
 AX_GCC_FUNC_ATTRIBUTE([noreturn])
+AX_GCC_FUNC_ATTRIBUTE([noinline])
 AX_GCC_FUNC_ATTRIBUTE([format])
 AX_GCC_FUNC_ATTRIBUTE([warn_unused_result])
 

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -3588,7 +3588,7 @@ int main(int argc, char **argv) {
 #warning "compiling for profiling"
         static int profiling_count=0;
         profiling_count++;
-        if(unlikely(profiling_count > 1000)) exit(0);
+        if(unlikely(profiling_count > 2000)) exit(0);
         usec_t dt = update_every * USEC_PER_SEC;
 #else
         usec_t dt = heartbeat_next(&hb, step);

--- a/src/common.h
+++ b/src/common.h
@@ -159,6 +159,12 @@
 #define NEVERNULL
 #endif
 
+#ifdef HAVE_FUNC_ATTRIBUTE_NOINLINE
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+
 #ifdef HAVE_FUNC_ATTRIBUTE_MALLOC
 #define MALLOCLIKE __attribute__((malloc))
 #else

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -139,22 +139,10 @@ void procfile_close(procfile *ff) {
     freez(ff);
 }
 
-__attribute__((noinline))
 static void _procfile_parser_add_word(procfile *ff, size_t line, char *begin, char *end) {
     *end = '\0';
     ff->words = pfwords_add(ff->words, begin);
     ff->lines->lines[line].words++;
-}
-
-__attribute__((noinline))
-static char *_procfile_parser_skip_word(char *begin, char *end, PF_CHAR_TYPE *ct, PF_CHAR_TYPE *separators) {
-    PF_CHAR_TYPE c = PF_CHAR_IS_NEWLINE;
-
-    while(begin < end && (c = separators[(unsigned char)(*begin)]) == PF_CHAR_IS_WORD)
-        begin++;
-
-    *ct = c;
-    return begin;
 }
 
 static void procfile_parser(procfile *ff) {
@@ -174,12 +162,10 @@ static void procfile_parser(procfile *ff) {
         , w = 0                         // counts the number of words we added
         , opened = 0;                   // counts the number of open parenthesis
 
-    PF_CHAR_TYPE ct;
-
     ff->lines = pflines_add(ff->lines, w);
 
-    while((s = _procfile_parser_skip_word(s, e, &ct, separators)) < e) {
-        // we are not at the end
+    while(s < e) {
+        PF_CHAR_TYPE ct = separators[(unsigned char)(*s)];
 
         // this is faster than a switch()
         if(likely(ct == PF_CHAR_IS_WORD)) {

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -160,6 +160,7 @@ static void procfile_parser(procfile *ff) {
         PF_CHAR_TYPE ct = separators[(unsigned char)(*s)];
 
         // this is faster than a switch()
+        // read more here: http://lazarenko.me/switch/
         if(likely(ct == PF_CHAR_IS_WORD)) {
             s++;
         }

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -39,8 +39,7 @@ char *procfile_filename(procfile *ff) {
 // ----------------------------------------------------------------------------
 // An array of words
 
-NOINLINE
-static void pfwords_add(procfile *ff, char *str) {
+static inline void pfwords_add(procfile *ff, char *str) {
     // debug(D_PROCFILE, PF_PREFIX ":   adding word No %d: '%s'", fw->len, str);
 
     pfwords *fw = ff->words;
@@ -55,7 +54,7 @@ static void pfwords_add(procfile *ff, char *str) {
 }
 
 NEVERNULL
-static pfwords *pfwords_new(void) {
+static inline pfwords *pfwords_new(void) {
     // debug(D_PROCFILE, PF_PREFIX ":   initializing words");
 
     size_t size = (procfile_adaptive_initial_allocation) ? procfile_max_words : PFWORDS_INCREASE_STEP;
@@ -81,8 +80,8 @@ static inline void pfwords_free(pfwords *fw) {
 // ----------------------------------------------------------------------------
 // An array of lines
 
-NEVERNULL NOINLINE
-static size_t *pflines_add(procfile *ff) {
+NEVERNULL
+static inline size_t *pflines_add(procfile *ff) {
     // debug(D_PROCFILE, PF_PREFIX ":   adding line %d at word %d", fl->len, first_word);
 
     pflines *fl = ff->lines;
@@ -101,7 +100,7 @@ static size_t *pflines_add(procfile *ff) {
 }
 
 NEVERNULL
-static pflines *pflines_new(void) {
+static inline pflines *pflines_new(void) {
     // debug(D_PROCFILE, PF_PREFIX ":   initializing lines");
 
     size_t size = (unlikely(procfile_adaptive_initial_allocation)) ? procfile_max_words : PFLINES_INCREASE_STEP;


### PR DESCRIPTION
This is as good as it can get.

I believe proc file parsing cannot be made faster without per-file specific heuristics (which I strongly believe we should avoid).

So, this PR eliminates a few function calls, a few function call parameters, a few memory lookups and a few local variables, while parsing proc files.

The procfile routines significantly influence apps.plugin - more than half of its execution time is inside `procfile_parser()`. The addition of `/proc/PID/status` significantly affected its cpu usage, however I think we can't do anything more to help it. This is the fastest it can get (without heuristics).