### PR TITLE
Fixed IDE warning that tracked files are ignored in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ web/index_new.html
 web/version.txt
 
 # related to karma/javascript/node
-node_modules/
-coverage/
+/node_modules/
+/coverage/
 
 system/netdata-lsb
 system/netdata-openrc


### PR DESCRIPTION
I was just about to get started in developing a new plugin, when I got this warning.

The previous .gitignore entries were ignoring both `/node_modules` and `/node.d/node_modules`, however `/node.d/node_modules` contains netdata specific modules that shouldn't get ignored (I think). The fix now only ignores `/node_modules`.