### PR TITLE
Add Http check plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -87,6 +87,7 @@ dist_healthconfig_DATA = \
     health.d/entropy.conf \
     health.d/fping.conf \
     health.d/haproxy.conf \
+    health.d/httpcheck.conf \
     health.d/ipc.conf \
     health.d/ipfs.conf \
     health.d/ipmi.conf \

--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -44,6 +44,7 @@ dist_pythonconfig_DATA = \
     python.d/go_expvar.conf \
     python.d/haproxy.conf \
     python.d/hddtemp.conf \
+    python.d/httpcheck.conf \
     python.d/ipfs.conf \
     python.d/isc_dhcpd.conf \
     python.d/mdstat.conf \

--- a/conf.d/health.d/httpcheck.conf
+++ b/conf.d/health.d/httpcheck.conf
@@ -1,0 +1,84 @@
+template: httpcheck_last_collected_secs
+families: *
+      on: httpcheck.error
+    calc: $now - $last_collected_t
+   every: 10s
+   units: seconds ago
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: sysadmin
+
+# This is a fast-reacting no-notification alarm ideal for custom dashboards or badges
+template: web_service_reachable
+families: *
+      on: httpcheck.error
+  lookup: average -1m unaligned percentage of success
+    calc: ($this < 75) ? (0) : ($this)
+   every: 5s
+   units: up/down
+    info: at least 75% verified responses during last 60 seconds, ideal for badges
+      to: silent
+
+template: web_service_unexpected_contents
+families: *
+      on: httpcheck.error
+  lookup: average -5m unaligned percentage of unexpected_content
+   every: 10s
+   units: %
+    warn: $this >= 10 AND $this < 40
+    crit: $this >= 40
+   delay: down 5m multiplier 1.5 max 1h
+    info: average of unexpected http response content during the last 5 minutes
+      to: webmaster
+
+template: web_service_unexpected_status
+families: *
+      on: httpcheck.error
+  lookup: average -5m unaligned percentage of unexpected_status
+   every: 10s
+   units: %
+    warn: $this >= 10 AND $this < 40
+    crit: $this >= 40
+   delay: down 5m multiplier 1.5 max 1h
+    info: average of unexpected http status during the last 5 minutes
+      to: webmaster
+
+template: web_service_timeouts
+families: *
+      on: httpcheck.error
+  lookup: average -5m unaligned percentage of timeout
+   every: 10s
+   units: %
+    warn: $this >= 10 AND $this < 40
+    crit: $this >= 40
+   delay: down 5m multiplier 1.5 max 1h
+    info: average of timeouts during the last 5 minutes
+      to: webmaster
+
+template: web_service_fails
+families: *
+      on: httpcheck.error
+  lookup: average -5m unaligned percentage of failed
+   every: 10s
+   units: %
+    warn: $this >= 10 AND $this < 40
+    crit: $this >= 40
+   delay: down 5m multiplier 1.5 max 1h
+    info: average of failed requests during the last 5 minutes
+      to: webmaster
+
+# need help...
+
+#template: web_service_latency
+#families: *
+#      on: httpcheck.responsetime
+#  lookup: average -2m unaligned of response_time
+#   every: 5s
+#   units: %
+#    warn: $this >= 5 AND $this < 40
+#    crit: $this >= 40
+#   delay: down 5m multiplier 1.5 max 1h
+#    info:
+#      to: sysadmin

--- a/conf.d/health.d/httpcheck.conf
+++ b/conf.d/health.d/httpcheck.conf
@@ -1,6 +1,6 @@
 template: httpcheck_last_collected_secs
 families: *
-      on: httpcheck.error
+      on: httpcheck.status
     calc: $now - $last_collected_t
    every: 10s
    units: seconds ago
@@ -8,12 +8,13 @@ families: *
     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
    delay: down 5m multiplier 1.5 max 1h
     info: number of seconds since the last successful data collection
+ options: no-clear-notification
       to: sysadmin
 
 # This is a fast-reacting no-notification alarm ideal for custom dashboards or badges
 template: web_service_reachable
 families: *
-      on: httpcheck.error
+      on: httpcheck.status
   lookup: average -1m unaligned percentage of success
     calc: ($this < 75) ? (0) : ($this)
    every: 5s
@@ -21,33 +22,35 @@ families: *
     info: at least 75% verified responses during last 60 seconds, ideal for badges
       to: silent
 
-template: web_service_unexpected_contents
+template: web_service_bad_content_received
 families: *
-      on: httpcheck.error
-  lookup: average -5m unaligned percentage of unexpected_content
+      on: httpcheck.status
+  lookup: average -5m unaligned percentage of bad_content
    every: 10s
    units: %
     warn: $this >= 10 AND $this < 40
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
     info: average of unexpected http response content during the last 5 minutes
+ options: no-clear-notification
       to: webmaster
 
-template: web_service_unexpected_status
+template: web_service_bad_status
 families: *
-      on: httpcheck.error
-  lookup: average -5m unaligned percentage of unexpected_status
+      on: httpcheck.status
+  lookup: average -5m unaligned percentage of bad_status
    every: 10s
    units: %
     warn: $this >= 10 AND $this < 40
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
-    info: average of unexpected http status during the last 5 minutes
+    info: average of bad http status during the last 5 minutes
+ options: no-clear-notification
       to: webmaster
 
 template: web_service_timeouts
 families: *
-      on: httpcheck.error
+      on: httpcheck.status
   lookup: average -5m unaligned percentage of timeout
    every: 10s
    units: %
@@ -55,21 +58,21 @@ families: *
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
     info: average of timeouts during the last 5 minutes
+ options: no-clear-notification
       to: webmaster
 
 template: web_service_fails
 families: *
-      on: httpcheck.error
-  lookup: average -5m unaligned percentage of failed
+      on: httpcheck.status
+  lookup: average -5m unaligned percentage of no_connection
    every: 10s
    units: %
     warn: $this >= 10 AND $this < 40
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
     info: average of failed requests during the last 5 minutes
+ options: no-clear-notification
       to: webmaster
-
-# need help...
 
 #template: web_service_latency
 #families: *

--- a/conf.d/health.d/httpcheck.conf
+++ b/conf.d/health.d/httpcheck.conf
@@ -8,11 +8,10 @@ families: *
     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
    delay: down 5m multiplier 1.5 max 1h
     info: number of seconds since the last successful data collection
- options: no-clear-notification
       to: sysadmin
 
 # This is a fast-reacting no-notification alarm ideal for custom dashboards or badges
-template: web_service_reachable
+template: web_service_up
 families: *
       on: httpcheck.status
   lookup: average -1m unaligned percentage of success
@@ -22,7 +21,7 @@ families: *
     info: at least 75% verified responses during last 60 seconds, ideal for badges
       to: silent
 
-template: web_service_bad_content_received
+template: web_service_bad_content
 families: *
       on: httpcheck.status
   lookup: average -5m unaligned percentage of bad_content
@@ -44,7 +43,7 @@ families: *
     warn: $this >= 10 AND $this < 40
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
-    info: average of bad http status during the last 5 minutes
+    info: average of unexpected http status during the last 5 minutes
  options: no-clear-notification
       to: webmaster
 
@@ -54,34 +53,47 @@ families: *
   lookup: average -5m unaligned percentage of timeout
    every: 10s
    units: %
-    warn: $this >= 10 AND $this < 40
-    crit: $this >= 40
-   delay: down 5m multiplier 1.5 max 1h
     info: average of timeouts during the last 5 minutes
- options: no-clear-notification
-      to: webmaster
 
-template: web_service_fails
+template: no_web_service_connections
 families: *
       on: httpcheck.status
   lookup: average -5m unaligned percentage of no_connection
    every: 10s
    units: %
-    warn: $this >= 10 AND $this < 40
-    crit: $this >= 40
-   delay: down 5m multiplier 1.5 max 1h
     info: average of failed requests during the last 5 minutes
+
+# combined timeout & no connection alarm
+template: web_service_unreachable
+families: *
+      on: httpcheck.status
+    calc: ($no_web_service_connections >= $web_service_timeouts) ? ($no_web_service_connections) : ($web_service_timeouts)
+   units: %
+   every: 10s
+    warn: ($no_web_service_connections >= 10 OR $web_service_timeouts >= 10) AND ($no_web_service_connections < 40 OR $web_service_timeouts < 40)
+    crit: $no_web_service_connections >= 40 OR $web_service_timeouts >= 40
+   delay: down 5m multiplier 1.5 max 1h
+    info: average of failed requests either due to timeouts or no connection during the last 5 minutes
  options: no-clear-notification
       to: webmaster
 
-#template: web_service_latency
-#families: *
-#      on: httpcheck.responsetime
-#  lookup: average -2m unaligned of response_time
-#   every: 5s
-#   units: %
-#    warn: $this >= 5 AND $this < 40
-#    crit: $this >= 40
-#   delay: down 5m multiplier 1.5 max 1h
-#    info:
-#      to: sysadmin
+template: 1h_web_service_response_time
+families: *
+      on: httpcheck.responsetime
+  lookup: average -1h unaligned of time
+   every: 30s
+   units: ms
+    info: average response time over the last hour
+
+template: web_service_slow
+families: *
+      on: httpcheck.responsetime
+  lookup: average -3m unaligned of time
+   units: ms
+   every: 10s
+    warn: ($this > ($1h_web_service_response_time * 2) )
+    crit: ($this > ($1h_web_service_response_time * 3) )
+    info: average response time over the last 3 minutes, compared to the average over the last hour
+   delay: down 5m multiplier 1.5 max 1h
+ options: no-clear-notification
+      to: webmaster

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -19,7 +19,7 @@
 # may define its own, overriding the defaults.
 
 # update_every sets the default data collection frequency.
-# If unset, the python.d.plugin default is used.
+# If unset, the httpcheck default is used, which is at 3 seconds.
 # update_every: 1
 
 # priority controls the order of charts at the netdata dashboard.

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -1,0 +1,71 @@
+# netdata python.d.plugin configuration for httpcheck
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# Autodetection and retries do not work for this plugin
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# -------------------------------
+# ATTENTION: Any valid configuration will be accepted, even if initial connection fails!
+# -------------------------------
+#
+# There is intentionally no default config, e.g. for 'localhost'
+
+# job_name:
+#     name: myname            # [optional] the JOB's name as it will appear at the
+#                             #   dashboard (by default is the job_name)
+#                             #   JOBs sharing a name are mutually exclusive
+#     update_every: 1         # [optional] the JOB's data collection frequency
+#     priority: 60000         # [optional] the JOB's order on the dashboard
+#     retries: 60             # [optional] the JOB's number of restoration attempts
+#     request_timeout: 1      # [optional] the timeout when connecting
+#     url: 'http[s]://host-ip-or-dns[:port][path]'
+#                             # [required] the remote host url to connect to. If [:port] is missing, it defaults to 80
+#                             #   for HTTP and 443 for HTTPS. [path] is optional too, defaults to /
+#     redirect: yes           # [optional] If the remote host returns 30x status codes, the redirection url will be
+#                             #   followed.
+#     status_accepted:        # [optional] By default, 200 is accepted. Anything else will result in 'error = 1' in the
+#                             #   chart, however: The response time will still be > 0, since the host responded with something.
+#                             #   If redirect is enabled, the accepted status will be checked against the redirected page.
+#       - 200                 # Multiple status codes are possible. If you specify 'status_accepted', you would still
+#                             #   need to add '200'. E.g. 'status_accepted: [301]' will result in 'error = 2' if code is 200.
+#                             #   Do specify numerical entries such as 200, not 'OK'.
+#     regex: '.*'             # If the status code is accepted, the content of the response will be searched for this
+#                             #   regex. Be aware that you may need to escape the regex string. If redirect is enabled,
+#                             #   the regex will be matched to the redirected page, not the initial 30x response.
+
+# This plugin is intended for simple cases. For monitoring large networks, consider a real service monitoring tool.

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -79,5 +79,21 @@ chart_cleanup: 0
 #                             #   regex (if defined). Be aware that you may need to escape the regex string. If redirect is enabled,
 #                             #   the regex will be matched to the redirected page, not the initial 3xx response.
 
+# Simple example:
+#
+# jira:
+#   url: 'https://jira.localdomain/'
+
+
+# Complex example:
+#
+# cool_website:
+#   url: 'http://cool.website:8080/home'
+#   status_accepted:
+#     - 200
+#     - 204
+#   regex: <title>My cool website!<\/title>
+#   timeout: 2
+
 # This plugin is intended for simple cases. Currently, the accuracy of the response time is low and should be used as reference only.
 

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -59,7 +59,7 @@ chart_cleanup: 0
 #     name: myname            # [optional] the JOB's name as it will appear at the
 #                             #   dashboard (by default is the job_name)
 #                             #   JOBs sharing a name are mutually exclusive
-#     update_every: 1         # [optional] the JOB's data collection frequency
+#     update_every: 3         # [optional] the JOB's data collection frequency
 #     priority: 60000         # [optional] the JOB's order on the dashboard
 #     retries: 60             # [optional] the JOB's number of restoration attempts
 #     timeout: 1              # [optional] the timeout when connecting, supports decimals (e.g. 0.5s)
@@ -75,8 +75,8 @@ chart_cleanup: 0
 #       - 200                 # Multiple status codes are possible. If you specify 'status_accepted', you would still
 #                             #   need to add '200'. E.g. 'status_accepted: [301]' will trigger an error in 'bad status'
 #                             #   if code is 200. Do specify numerical entries such as 200, not 'OK'.
-#     regex: '.*'             # If the status code is accepted, the content of the response will be searched for this
-#                             #   regex. Be aware that you may need to escape the regex string. If redirect is enabled,
+#     regex: None             # [optional] If the status code is accepted, the content of the response will be searched for this
+#                             #   regex (if defined). Be aware that you may need to escape the regex string. If redirect is enabled,
 #                             #   the regex will be matched to the redirected page, not the initial 3xx response.
 
 # This plugin is intended for simple cases. Currently, the accuracy of the response time is low and should be used as reference only.

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -67,13 +67,13 @@ chart_cleanup: 0
 #                             # [required] the remote host url to connect to. If [:port] is missing, it defaults to 80
 #                             #   for HTTP and 443 for HTTPS. [path] is optional too, defaults to /
 #     redirect: yes           # [optional] If the remote host returns 3xx status codes, the redirection url will be
-#                             #   followed.
-#     status_accepted:        # [optional] By default, 200 is accepted. Anything else will result in 'error = 1' in the
-#                             #   'unexpected status' dimension, however: The response time will still be > 0, since the
+#                             #   followed (default).
+#     status_accepted:        # [optional] By default, 200 is accepted. Anything else will result in 'bad status' in the
+#                             #   status chart, however: The response time will still be > 0, since the
 #                             #   host responded with something.
 #                             #   If redirect is enabled, the accepted status will be checked against the redirected page.
 #       - 200                 # Multiple status codes are possible. If you specify 'status_accepted', you would still
-#                             #   need to add '200'. E.g. 'status_accepted: [301]' will trigger an error in 'unexpected status'
+#                             #   need to add '200'. E.g. 'status_accepted: [301]' will trigger an error in 'bad status'
 #                             #   if code is 200. Do specify numerical entries such as 200, not 'OK'.
 #     regex: '.*'             # If the status code is accepted, the content of the response will be searched for this
 #                             #   regex. Be aware that you may need to escape the regex string. If redirect is enabled,

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -27,6 +27,16 @@
 # If unset, the default for python.d.plugin is used.
 # priority: 60000
 
+# chart_cleanup sets the default chart cleanup interval in iterations.
+# A chart is marked as obsolete if it has not been updated
+# 'chart_cleanup' iterations in a row.
+# They will be hidden immediately (not offered to dashboard viewer,
+# streamed upstream and archived to backends) and deleted one hour
+# later (configurable from netdata.conf).
+# -- For this plugin, cleanup MUST be disabled, otherwise we lose response
+#    time charts
+chart_cleanup: 0
+
 # Autodetection and retries do not work for this plugin
 
 # ----------------------------------------------------------------------

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -52,7 +52,7 @@
 #     update_every: 1         # [optional] the JOB's data collection frequency
 #     priority: 60000         # [optional] the JOB's order on the dashboard
 #     retries: 60             # [optional] the JOB's number of restoration attempts
-#     request_timeout: 1      # [optional] the timeout when connecting
+#     timeout: 1              # [optional] the timeout when connecting, supports decimals (e.g. 0.5s)
 #     url: 'http[s]://host-ip-or-dns[:port][path]'
 #                             # [required] the remote host url to connect to. If [:port] is missing, it defaults to 80
 #                             #   for HTTP and 443 for HTTPS. [path] is optional too, defaults to /

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -56,17 +56,18 @@
 #     url: 'http[s]://host-ip-or-dns[:port][path]'
 #                             # [required] the remote host url to connect to. If [:port] is missing, it defaults to 80
 #                             #   for HTTP and 443 for HTTPS. [path] is optional too, defaults to /
-#     redirect: yes           # [optional] If the remote host returns 30x status codes, the redirection url will be
+#     redirect: yes           # [optional] If the remote host returns 3xx status codes, the redirection url will be
 #                             #   followed.
 #     status_accepted:        # [optional] By default, 200 is accepted. Anything else will result in 'error = 1' in the
-#                             #   chart, however: The response time will still be > 0, since the host responded with something.
+#                             #   'unexpected status' dimension, however: The response time will still be > 0, since the
+#                             #   host responded with something.
 #                             #   If redirect is enabled, the accepted status will be checked against the redirected page.
 #       - 200                 # Multiple status codes are possible. If you specify 'status_accepted', you would still
-#                             #   need to add '200'. E.g. 'status_accepted: [301]' will result in 'error = 2' if code is 200.
-#                             #   Do specify numerical entries such as 200, not 'OK'.
+#                             #   need to add '200'. E.g. 'status_accepted: [301]' will trigger an error in 'unexpected status'
+#                             #   if code is 200. Do specify numerical entries such as 200, not 'OK'.
 #     regex: '.*'             # If the status code is accepted, the content of the response will be searched for this
 #                             #   regex. Be aware that you may need to escape the regex string. If redirect is enabled,
-#                             #   the regex will be matched to the redirected page, not the initial 30x response.
+#                             #   the regex will be matched to the redirected page, not the initial 3xx response.
 
-# This plugin is intended for simple cases. For monitoring large networks, consider a real service monitoring tool.
+# This plugin is intended for simple cases. Currently, the accuracy of the response time is low and should be used as reference only.
 

--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -69,3 +69,4 @@
 #                             #   the regex will be matched to the redirected page, not the initial 30x response.
 
 # This plugin is intended for simple cases. For monitoring large networks, consider a real service monitoring tool.
+

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -32,6 +32,7 @@ dist_python_DATA = \
     go_expvar.chart.py \
     haproxy.chart.py \
     hddtemp.chart.py \
+    httpcheck.chart.py \
     ipfs.chart.py \
     isc_dhcpd.chart.py \
     mdstat.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -864,7 +864,7 @@ Following charts are drawn per job:
    it will be at least 0.1 ms, even if the measured time is lower than 0.1 ms.
    If the connection failed, the value is missing.
 
-2. **Error** boolean
+2. **Status** boolean
  * Connection successful
  * Unexpected content: No Regex match found in the response
  * Unexpected status code: Do we get 500 errors?

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -880,7 +880,7 @@ server:
   status_accepted:              # optional
     - 200
   timeout: 1                    # optional, supports decimals (e.g. 0.2)
-  update_every: 1               # optional
+  update_every: 3               # optional
   regex: '.*'                   # optional
   redirect: yes                 # optional
 ```

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -881,7 +881,7 @@ server:
     - 200
   timeout: 1                    # optional, supports decimals (e.g. 0.2)
   update_every: 3               # optional
-  regex: '.*'                   # optional
+  regex: 'REGULAR_EXPRESSION'   # optional, see https://docs.python.org/3/howto/regex.html
   redirect: yes                 # optional
 ```
 

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -853,6 +853,50 @@ If no configuration is given, module will attempt to connect to hddtemp daemon o
 
 ---
 
+# httpcheck
+
+Module monitors remote http server for availability and response time.
+
+Following charts are drawn per job:
+
+1. **Response time** ms
+ * Time in 0.1 ms resolution in which the server responds. When connection is successful,
+   it will be at least 0.1 ms, even if the measured time is lower than 0.1 ms.
+   If it is 0.0 ms, the connection failed with error code >=3 (useful for API)
+
+2. **Error code** int
+ * One of:
+   - 0: Connection successful
+   - 1: Content does not satisfy regex pattern.
+   - 2: HTTP status code not accepted
+   - 3: Connection failed (port not listening or blocked)
+   - 4: Connection timed out (host unreachable?)
+
+### configuration
+
+Sample configuration and their default values.
+
+```yaml
+server:
+  url: 'http://host:port/path'  # required
+  status_accepted:              # optional
+    - 200
+  request_timeout: 1            # optional
+  update_every: 1               # optional
+  regex: '.*'                   # optional
+  redirect: yes                 # optional
+```
+
+### notes
+
+ * The error code chart is intended for health check or for access via API.
+ * A system/service/firewall might block netdata's access if a portscan or
+   similar is detected.
+ * This plugin is meant for simple use cases. For monitoring large networks
+   consider a real service monitoring tool.
+
+---
+
 # IPFS
 
 Module monitors [IPFS](https://ipfs.io) basic information.

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -881,7 +881,7 @@ server:
   url: 'http://host:port/path'  # required
   status_accepted:              # optional
     - 200
-  request_timeout: 1            # optional
+  timeout: 1                    # optional, supports decimals (e.g. 0.2)
   update_every: 1               # optional
   regex: '.*'                   # optional
   redirect: yes                 # optional

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -862,15 +862,14 @@ Following charts are drawn per job:
 1. **Response time** ms
  * Time in 0.1 ms resolution in which the server responds. When connection is successful,
    it will be at least 0.1 ms, even if the measured time is lower than 0.1 ms.
-   If it is 0.0 ms, the connection failed with error code >=3 (useful for API)
+   If the connection failed, the value is missing.
 
-2. **Error code** int
- * One of:
-   - 0: Connection successful
-   - 1: Content does not satisfy regex pattern.
-   - 2: HTTP status code not accepted
-   - 3: Connection failed (port not listening or blocked)
-   - 4: Connection timed out (host unreachable?)
+2. **Error** int
+ * Connection successful: value = 1 otherwise 0
+ * Unexpected content: No Regex match found in the response (value = 1, otherwise 0) 
+ * Unexpected status code: Do we get 500 errors? (value = 1, otherwise 0)
+ * Connection failed: port not listening or blocked (value = 1, otherwise 0)
+ * Connection timed out: host or port unreachable (value = 1, otherwise 0)
 
 ### configuration
 
@@ -892,8 +891,8 @@ server:
  * The error code chart is intended for health check or for access via API.
  * A system/service/firewall might block netdata's access if a portscan or
    similar is detected.
- * This plugin is meant for simple use cases. For monitoring large networks
-   consider a real service monitoring tool.
+ * This plugin is meant for simple use cases. Currently, the accuracy of the
+   response time is low and should be used as reference only.
 
 ---
 

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -864,12 +864,12 @@ Following charts are drawn per job:
    it will be at least 0.1 ms, even if the measured time is lower than 0.1 ms.
    If the connection failed, the value is missing.
 
-2. **Error** int
- * Connection successful: value = 1 otherwise 0
- * Unexpected content: No Regex match found in the response (value = 1, otherwise 0) 
- * Unexpected status code: Do we get 500 errors? (value = 1, otherwise 0)
- * Connection failed: port not listening or blocked (value = 1, otherwise 0)
- * Connection timed out: host or port unreachable (value = 1, otherwise 0)
+2. **Error** boolean
+ * Connection successful
+ * Unexpected content: No Regex match found in the response
+ * Unexpected status code: Do we get 500 errors?
+ * Connection failed: port not listening or blocked
+ * Connection timed out: host or port unreachable
 
 ### configuration
 
@@ -888,7 +888,7 @@ server:
 
 ### notes
 
- * The error code chart is intended for health check or for access via API.
+ * The status chart is primarily intended for alarms, badges or for access via API.
  * A system/service/firewall might block netdata's access if a portscan or
    similar is detected.
  * This plugin is meant for simple use cases. Currently, the accuracy of the

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -860,8 +860,7 @@ Module monitors remote http server for availability and response time.
 Following charts are drawn per job:
 
 1. **Response time** ms
- * Time in 0.1 ms resolution in which the server responds. When connection is successful,
-   it will be at least 0.1 ms, even if the measured time is lower than 0.1 ms.
+ * Time in 0.1 ms resolution in which the server responds.
    If the connection failed, the value is missing.
 
 2. **Status** boolean

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -3,18 +3,17 @@
 # Original Author: ccremer (github.com/ccremer)
 
 import urllib3
-import time
 import re
+
+try:
+    from time import monotonic as time
+except ImportError:
+    from time import time
 
 from bases.FrameworkServices.UrlService import UrlService
 
-try:
-    urllib3.disable_warnings()
-except AttributeError:
-    pass
-
 # default module values (can be overridden per job in `config`)
-# update_every = 2
+update_every = 3
 priority = 60000
 retries = 60
 
@@ -57,32 +56,15 @@ CHARTS = {
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
-        self.url = self.configuration.get('url', None)
-        self.regex = re.compile(self.configuration.get('regex', '.*'))
+        self.regex = self._compile(self.configuration.get('regex'))
         self.status_codes_accepted = self.configuration.get('status_accepted', [200])
         self.follow_redirect = self.configuration.get('redirect', True)
         self.order = ORDER
         self.definitions = CHARTS
-        self._manager = None
 
-    def check(self):
-        """
-        Format configuration data and try to connect to server
-        :return: boolean
-        """
-        if not (self.url and isinstance(self.url, str)):
-            self.error('URL is not defined or type is not <str>')
-            return False
-
-        self._manager = self._build_manager()
-        if not self._manager:
-            return False
-
-        self.info('Enabled {url} with (redirect={redirect}, status={accepted}, interval={update}, timeout={timeout}, '
-                  'regex={regex})'
-                  .format(url=self.url, redirect=self.follow_redirect, accepted=self.status_codes_accepted,
-                          update=self.update_every, timeout=self.request_timeout, regex=self.regex.pattern))
-        return True
+    @staticmethod
+    def _compile(pattern=None):
+        return None if pattern is None else re.compile(pattern)
 
     def _get_data(self):
         """
@@ -97,28 +79,15 @@ class Service(UrlService):
         data[HTTP_NO_CONNECTION] = 0
         url = self.url
         try:
-            retr = 1 if self.follow_redirect else False
-            start = time.time()
-            response = self._manager.request(
-                method='GET', url=url, timeout=self.request_timeout, retries=retr, headers=self._manager.headers,
-                redirect=self.follow_redirect
-            )
-            content = response.data
-            diff = time.time() - start
+            start = time()
+            status, content = self._get_raw_data_with_status(retries=1 if self.follow_redirect else False,
+                                                             redirect=self.follow_redirect)
+            diff = time() - start
             data[HTTP_RESPONSE_TIME] = max(round(diff * 10000), 0)
-            data[HTTP_RESPONSE_LENGTH] = len(content)
             self.debug('Url: {url}. Host responded with status code {code} in {diff} s'.format(
-                url=url, code=response.status, diff=diff
+                url=url, code=status, diff=diff
             ))
-            self.debug('Content: \n\n{content}\n'.format(content=content))
-            if response.status in self.status_codes_accepted:
-                if self.regex.search(content) is None:
-                    self.debug('No match for regex \'{regex}\' found'.format(regex=self.regex.pattern))
-                    data[HTTP_BAD_CONTENT] = 1
-                else:
-                    data[HTTP_SUCCESS] = 1
-            else:
-                data[HTTP_BAD_STATUS] = 1
+            self.process_response(content, data, status)
 
         except urllib3.exceptions.NewConnectionError as error:
             self.debug("Connection failed: {url}. Error: {error}".format(url=url, error=error))
@@ -137,3 +106,15 @@ class Service(UrlService):
             return None
 
         return data
+
+    def process_response(self, content, data, status):
+        data[HTTP_RESPONSE_LENGTH] = len(content)
+        self.debug('Content: \n\n{content}\n'.format(content=content))
+        if status in self.status_codes_accepted:
+            if self.regex is not None and self.regex.search(content) is None:
+                self.debug("No match for regex '{regex}' found".format(regex=self.regex.pattern))
+                data[HTTP_BAD_CONTENT] = 1
+            else:
+                data[HTTP_SUCCESS] = 1
+        else:
+            data[HTTP_BAD_STATUS] = 1

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -56,15 +56,12 @@ CHARTS = {
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
-        self.regex = self._compile(self.configuration.get('regex'))
+        pattern = self.configuration.get('regex')
+        self.regex = re.compile(pattern) if pattern else None
         self.status_codes_accepted = self.configuration.get('status_accepted', [200])
         self.follow_redirect = self.configuration.get('redirect', True)
         self.order = ORDER
         self.definitions = CHARTS
-
-    @staticmethod
-    def _compile(pattern=None):
-        return None if pattern is None else re.compile(pattern)
 
     def _get_data(self):
         """
@@ -111,7 +108,7 @@ class Service(UrlService):
         data[HTTP_RESPONSE_LENGTH] = len(content)
         self.debug('Content: \n\n{content}\n'.format(content=content))
         if status in self.status_codes_accepted:
-            if self.regex is not None and self.regex.search(content) is None:
+            if self.regex and self.regex.search(content) is None:
                 self.debug("No match for regex '{regex}' found".format(regex=self.regex.pattern))
                 data[HTTP_BAD_CONTENT] = 1
             else:

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -91,13 +91,14 @@ class Service(UrlService):
             )
             diff = time.time() - start
             data[HTTP_RESPONSE_TIME] = max(round(diff * 10000), 1)
+            self.debug('Url: {url}. Host responded with status code {code} in {diff} ms'.format(
+                url=url, code=response.status, diff=diff
+            ))
 
-            self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=response.status))
             if response.status in self.status_codes_accepted:
                 content = response.data
                 self.debug('Content: \n\n{content}\n'.format(content=content))
-                match = self.regex.search(content)
-                if match is None:
+                if self.regex.search(content) is None:
                     self.debug('No match for regex \'{regex}\' found'.format(regex=self.regex.pattern))
                     data[HTTP_ERROR] = CONTENT_MISMATCH
             else:

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -84,7 +84,6 @@ class Service(UrlService):
         :return: dict
         """
         data = dict()
-        data[HTTP_RESPONSE_TIME] = 0
         data[HTTP_SUCCESS] = 0
         data[HTTP_UNEXPECTED_CONTENT] = 0
         data[HTTP_UNEXPECTED_STATUS] = 0

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -37,7 +37,7 @@ CHARTS = {
             [HTTP_RESPONSE_TIME, 'response time', 'absolute', 100, 1000]
         ]},
     'error': {
-        'options': [None, 'HTTP check error code', 'code', 'error', 'httpcheck.error', 'line'],
+        'options': [None, 'HTTP check error code', 'yes/no', 'error', 'httpcheck.error', 'line'],
         'lines': [
             [HTTP_SUCCESS, 'success', 'absolute'],
             [HTTP_UNEXPECTED_CONTENT, 'unexpected content', 'absolute'],
@@ -84,6 +84,7 @@ class Service(UrlService):
         :return: dict
         """
         data = dict()
+        data[HTTP_RESPONSE_TIME] = 0
         data[HTTP_SUCCESS] = 0
         data[HTTP_UNEXPECTED_CONTENT] = 0
         data[HTTP_UNEXPECTED_STATUS] = 0

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -90,7 +90,7 @@ class Service(UrlService):
             )
             diff = time.time() - start
             data[HTTP_RESPONSE_TIME] = max(round(diff * 10000), 1)
-            self.debug('Url: {url}. Host responded with status code {code} in {diff} ms'.format(
+            self.debug('Url: {url}. Host responded with status code {code} in {diff} s'.format(
                 url=url, code=response.status, diff=diff
             ))
 

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -27,7 +27,7 @@ CHARTS = {
     'responsetime': {
         'options': [None, 'HTTP response time', 'ms', 'response time', 'httpcheck.responsetime', 'line'],
         'lines': [
-            [HTTP_RESPONSE_TIME, 'response_time', 'absolute', 100, 1000]
+            [HTTP_RESPONSE_TIME, 'response time', 'absolute', 100, 1000]
         ]},
     'error': {
         'options': [None, 'HTTP check error code', 'code', 'error', 'httpcheck.error', 'line'],
@@ -66,12 +66,10 @@ class Service(UrlService):
         if not self._manager:
             return False
 
-        self.info('Enabled {url} with (redirect={redirect}, status_accepted={accepted}, update_every={update}, '
-                  'timeout={timeout})'
-            .format(
-            url=self.url, redirect=self.follow_redirect, accepted=self.status_codes_accepted,
-            update=self.update_every, timeout=self.request_timeout
-        ))
+        self.info('Enabled {url} with (redirect={redirect}, status={accepted}, interval={update}, timeout={timeout}, '
+                  'regex={regex})'
+                  .format(url=self.url, redirect=self.follow_redirect, accepted=self.status_codes_accepted,
+                          update=self.update_every, timeout=self.request_timeout, regex=self.regex.pattern))
         return True
 
     def _get_data(self):

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -36,10 +36,14 @@ CHARTS = {
         ]}
 }
 
-CONTENT_MISMATCH = 1
-STATUS_NOT_ACCEPTED = 2
-CONNECTION_TIMED_OUT = 3
-CONNECTION_FAILED = 4
+# The higher the error code, the "more severe" it is. E.g. an unreachable host is probably much worse than a regex
+# mismatch (maybe the web service just has a new design that doesn't match the regex anymore).
+# We use steps of 5, which allows future fine-grained error codes, should we need it (fill the blanks where
+# appropriate).
+CONTENT_MISMATCH = 3
+STATUS_NOT_ACCEPTED = 5
+CONNECTION_TIMED_OUT = 10
+CONNECTION_FAILED = 15
 
 
 class Service(UrlService):

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Description: http check netdata python.d module
+# Original Author: ccremer (github.com/ccremer)
+
+import urllib3
+import time
+import re
+
+from bases.FrameworkServices.UrlService import UrlService
+
+try:
+    urllib3.disable_warnings()
+except AttributeError:
+    pass
+
+# default module values (can be overridden per job in `config`)
+# update_every = 2
+priority = 60000
+retries = 60
+
+HTTP_RESPONSE_TIME = 'http_responsetime'
+HTTP_ERROR = 'http_error'
+
+ORDER = ['responsetime', 'error']
+
+CHARTS = {
+    'responsetime': {
+        'options': [None, 'HTTP response time', 'ms', 'response time', 'httpcheck.responsetime', 'line'],
+        'lines': [
+            [HTTP_RESPONSE_TIME, 'response_time', 'absolute', 100, 1000]
+        ]},
+    'error': {
+        'options': [None, 'HTTP check error code', 'code', 'error', 'httpcheck.error', 'line'],
+        'lines': [
+            [HTTP_ERROR, 'error', 'absolute']
+        ]}
+}
+
+CONTENT_MISMATCH = 1
+STATUS_NOT_ACCEPTED = 2
+CONNECTION_TIMED_OUT = 3
+CONNECTION_FAILED = 4
+
+
+class Service(UrlService):
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.url = self.configuration.get('url', None)
+        self.regex = re.compile(self.configuration.get('regex', '.*'))
+        self.status_codes_accepted = self.configuration.get('status_accepted', [200])
+        self.follow_redirect = self.configuration.get('redirect', False)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self._manager = None
+
+    def check(self):
+        """
+        Format configuration data and try to connect to server
+        :return: boolean
+        """
+        if not (self.url and isinstance(self.url, str)):
+            self.error('URL is not defined or type is not <str>')
+            return False
+
+        self._manager = self._build_manager()
+        if not self._manager:
+            return False
+
+        self.info('Enabled {url} with (redirect={redirect}, status_accepted={accepted}, update_every={update}, '
+                  'timeout={timeout})'
+            .format(
+            url=self.url, redirect=self.follow_redirect, accepted=self.status_codes_accepted,
+            update=self.update_every, timeout=self.request_timeout
+        ))
+        return True
+
+    def _get_data(self):
+        """
+        Format data received from http request
+        :return: dict
+        """
+        data = dict()
+        data[HTTP_RESPONSE_TIME] = 0
+        data[HTTP_ERROR] = 0
+        url = self.url
+        try:
+            start = time.time()
+            response = self._manager.request(
+                method='GET', url=url, timeout=self.request_timeout, retries=1, headers=self._manager.headers,
+                redirect=self.follow_redirect
+            )
+            diff = time.time() - start
+            data[HTTP_RESPONSE_TIME] = max(round(diff * 10000), 1)
+
+            self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=response.status))
+            if response.status in self.status_codes_accepted:
+                content = response.data
+                self.debug('Content: \n\n{content}\n'.format(content=content))
+                match = self.regex.search(content)
+                if match is None:
+                    self.debug('No match for regex \'{regex}\' found'.format(regex=self.regex.pattern))
+                    data[HTTP_ERROR] = CONTENT_MISMATCH
+            else:
+                data[HTTP_ERROR] = STATUS_NOT_ACCEPTED
+
+        except urllib3.exceptions.TimeoutError:
+            self.debug("Connection timed out: {url}".format(url=url))
+            data[HTTP_ERROR] = CONNECTION_TIMED_OUT
+
+        except urllib3.exceptions.HTTPError:
+            self.debug("Connection timed out: {url}".format(url=url))
+            data[HTTP_ERROR] = CONNECTION_FAILED
+
+        except (TypeError, AttributeError) as error:
+            self.error('Url: {url}. Error: {error}'.format(url=url, error=error))
+            return None
+
+        return data

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -43,7 +43,7 @@ CHARTS = {
             [HTTP_RESPONSE_LENGTH, 'length', 'absolute']
         ]},
     'status': {
-        'options': [None, 'HTTP status', 'flag', 'status', 'httpcheck.status', 'line'],
+        'options': [None, 'HTTP status', 'boolean', 'status', 'httpcheck.status', 'line'],
         'lines': [
             [HTTP_SUCCESS, 'success', 'absolute'],
             [HTTP_BAD_CONTENT, 'bad content', 'absolute'],

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -60,7 +60,7 @@ class Service(UrlService):
         self.url = self.configuration.get('url', None)
         self.regex = re.compile(self.configuration.get('regex', '.*'))
         self.status_codes_accepted = self.configuration.get('status_accepted', [200])
-        self.follow_redirect = self.configuration.get('redirect', False)
+        self.follow_redirect = self.configuration.get('redirect', True)
         self.order = ORDER
         self.definitions = CHARTS
         self._manager = None

--- a/python.d/python_modules/bases/FrameworkServices/UrlService.py
+++ b/python.d/python_modules/bases/FrameworkServices/UrlService.py
@@ -75,20 +75,30 @@ class UrlService(SimpleService):
         :return: str
         """
         try:
-            url = url or self.url
-            manager = manager or self._manager
-            response = manager.request(method='GET',
-                                       url=url,
-                                       timeout=self.request_timeout,
-                                       retries=1,
-                                       headers=manager.headers)
+            status, data = self._get_raw_data_with_status(url, manager)
+            if status == 200:
+                return data
+            else:
+                self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=status))
+                return None
         except (urllib3.exceptions.HTTPError, TypeError, AttributeError) as error:
             self.error('Url: {url}. Error: {error}'.format(url=url, error=error))
             return None
-        if response.status == 200:
-            return response.data.decode()
-        self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=response.status))
-        return None
+
+    def _get_raw_data_with_status(self, url=None, manager=None, retries=1, redirect=True):
+        """
+        Get status and response body content from http request. Does not catch exceptions
+        :return: int, str
+        """
+        url = url or self.url
+        manager = manager or self._manager
+        response = manager.request(method='GET',
+                                   url=url,
+                                   timeout=self.request_timeout,
+                                   retries=retries,
+                                   headers=manager.headers,
+                                   redirect=redirect)
+        return response.status, response.data.decode()
 
     def check(self):
         """

--- a/python.d/python_modules/bases/FrameworkServices/UrlService.py
+++ b/python.d/python_modules/bases/FrameworkServices/UrlService.py
@@ -76,13 +76,14 @@ class UrlService(SimpleService):
         """
         try:
             status, data = self._get_raw_data_with_status(url, manager)
-            if status == 200:
-                return data
-            else:
-                self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=status))
-                return None
         except (urllib3.exceptions.HTTPError, TypeError, AttributeError) as error:
             self.error('Url: {url}. Error: {error}'.format(url=url, error=error))
+            return None
+
+        if status == 200:
+            return data
+        else:
+            self.debug('Url: {url}. Http response status code: {code}'.format(url=url, code=status))
             return None
 
     def _get_raw_data_with_status(self, url=None, manager=None, retries=1, redirect=True):

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1136,15 +1136,15 @@ netdataDashboard.context = {
     // ------------------------------------------------------------------------
     // HTTP check
 
-    'httpcheck.latency': {
-        info: 'The <code>Latency</code> describes the time passed between request and response. ' +
-        'A response time of <code>0.0 ms</code> indicates a connection error.'
+    'httpcheck.responsetime': {
+        info: 'The <code>response time</code> describes the time passed between request and response. ' +
+        'Currently, the accuracy of the response time is low and should be used as reference only.'
     },
 
     'httpcheck.error': {
         valueRange: "[0, 1]",
         info: 'The <code>error</code> codes are returned by the plugin when it could verify the availability of the webserver. ' +
-        'Each error dimension will have a value of <code>1</code> if triggered. Dimension <code>success</code> is always <code>1</code> on successful requests.' +
+        'Each error dimension will have a value of <code>1</code> if triggered. Dimension <code>success</code> is <code>1</code> if all constraints are satisfied.' +
         'This chart is most useful for alarms or third-party apps.'
     },
 

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1144,9 +1144,9 @@ netdataDashboard.context = {
     'httpcheck.error': {
         valueRange: "[0, 3]",
         info: 'The <code>Error</code> is returned by the plugin when it could not connect to the webserver. It is one of: ' +
-        '<code>0</code> (connection successful), <code>1</code> (unexpected response content), <code>2</code> (unexpected status code), ' +
-        '<code>3</code> (port unreachable), <code>4</code> (host unreachable). ' +
-        'The error code is most useful for 3rd-party apps and alarms.'
+        '<code>0</code> (connection successful), <code>3</code> (unexpected response content), <code>5</code> (unexpected status code), ' +
+        '<code>10</code> (port unreachable), <code>15</code> (host unreachable). ' +
+        'The higher the error code, the "more severe" it is. The error code is most useful for 3rd-party apps and alarms.'
     },
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1142,11 +1142,10 @@ netdataDashboard.context = {
     },
 
     'httpcheck.error': {
-        valueRange: "[0, 3]",
-        info: 'The <code>Error</code> is returned by the plugin when it could not connect to the webserver. It is one of: ' +
-        '<code>0</code> (connection successful), <code>3</code> (unexpected response content), <code>5</code> (unexpected status code), ' +
-        '<code>10</code> (port unreachable), <code>15</code> (host unreachable). ' +
-        'The higher the error code, the "more severe" it is. The error code is most useful for 3rd-party apps and alarms.'
+        valueRange: "[0, 1]",
+        info: 'The <code>error</code> codes are returned by the plugin when it could verify the availability of the webserver. ' +
+        'Each error dimension will have a value of <code>1</code> if triggered. Dimension <code>success</code> is always <code>1</code> on successful requests.' +
+        'This chart is most useful for alarms or third-party apps.'
     },
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1138,6 +1138,7 @@ netdataDashboard.context = {
 
     'httpcheck.responsetime': {
         info: 'The <code>response time</code> describes the time passed between request and response. ' +
+        'The minimum is <code>0.1 ms</code> except on errors, where it will be <code>0.0 ms</code> ' +
         'Currently, the accuracy of the response time is low and should be used as reference only.'
     },
 

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -177,6 +177,12 @@ netdataDashboard.menu = {
         info: 'Network latency statistics, via <b>fping</b>. <b>fping</b> is a program to send ICMP echo probes to network hosts, similar to <code>ping</code>, but much better performing when pinging multiple hosts. fping versions after 3.15 can be directly used as netdata plugins.'
     },
 
+    'httpcheck': {
+        title: 'Http Check',
+        icon: '<i class="fas fa-heartbeat"></i>',
+        info: 'Web Service availability and latency monitoring using HTTP checks. This plugin is a specialized version of the port check plugin.'
+    },
+
     'memcached': {
         title: 'memcached',
         icon: '<i class="fas fa-database"></i>',
@@ -1125,6 +1131,22 @@ netdataDashboard.context = {
         mainheads: [
             netdataDashboard.gaugeChart('Requests', '12%', '', NETDATA.colors[0])
         ]
+    },
+
+    // ------------------------------------------------------------------------
+    // HTTP check
+
+    'httpcheck.latency': {
+        info: 'The <code>Latency</code> describes the time passed between request and response. ' +
+        'A response time of <code>0.0 ms</code> indicates a connection error.'
+    },
+
+    'httpcheck.error': {
+        valueRange: "[0, 3]",
+        info: 'The <code>Error</code> is returned by the plugin when it could not connect to the webserver. It is one of: ' +
+        '<code>0</code> (connection successful), <code>1</code> (unexpected response content), <code>2</code> (unexpected status code), ' +
+        '<code>3</code> (port unreachable), <code>4</code> (host unreachable). ' +
+        'The error code is most useful for 3rd-party apps and alarms.'
     },
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1138,7 +1138,7 @@ netdataDashboard.context = {
 
     'httpcheck.responsetime': {
         info: 'The <code>response time</code> describes the time passed between request and response. ' +
-        'The minimum is <code>0.1 ms</code> except on errors, where it will be <code>0.0 ms</code> ' +
+        'The minimum is <code>0.1 ms</code> except on errors, where it will be <code>0.0 ms</code>. ' +
         'Currently, the accuracy of the response time is low and should be used as reference only.'
     },
 

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1138,14 +1138,17 @@ netdataDashboard.context = {
 
     'httpcheck.responsetime': {
         info: 'The <code>response time</code> describes the time passed between request and response. ' +
-        'The minimum is <code>0.1 ms</code> except on errors, where it will be <code>0.0 ms</code>. ' +
         'Currently, the accuracy of the response time is low and should be used as reference only.'
     },
 
-    'httpcheck.error': {
+    'httpcheck.responselength': {
+        info: 'The <code>response length</code> counts the number of characters in the response body. For static pages, this should be mostly constant.'
+    },
+
+    'httpcheck.status': {
         valueRange: "[0, 1]",
-        info: 'The <code>error</code> codes are returned by the plugin when it could verify the availability of the webserver. ' +
-        'Each error dimension will have a value of <code>1</code> if triggered. Dimension <code>success</code> is <code>1</code> if all constraints are satisfied.' +
+        info: 'This chart verifies the response of the webserver. Each status dimension will have a value of <code>1</code> if triggered. ' +
+        'Dimension <code>success</code> is <code>1</code> only if all constraints are satisfied.' +
         'This chart is most useful for alarms or third-party apps.'
     },
 


### PR DESCRIPTION
More specialized version of the port check plugin. This plugin measures the response of web servers and checks if the content is expected.
* Is it efficient?
  You judge ;)
* Why?
  1. For simple use cases where nagios etc. would introduce another unnecessary tool and maintenance
  2. API access for custom dashboards
  3. When using a minimal netdata installation in docker-compose file as slave for health checking a docker image (I'm working on it).

I would like to add alarm templates, but I don't know how (expression) and what a sensible default would be. Any quick ideas? E.g. warning when error code > 0 for last 20 sec, critical over last 1 min and error code >2. To catch service flapping maybe take averages (e.g. average err code of >2.2) ?

![httpcheck](https://user-images.githubusercontent.com/12159026/36447709-77c2f400-1685-11e8-941a-07ac7c7f10d8.png)