### PR TITLE
 Alpine docker image improvements and hardening

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,17 +13,14 @@ WORKDIR /opt/netdata.git
 # Install source
 RUN chmod +x ./netdata-installer.sh && \
     sync && sleep 1 && \
-    ./netdata-installer.sh --dont-wait --dont-start-it && \
-    sync && sleep 1 && \
-# Compile fping
-    /usr/libexec/netdata/plugins.d/fping.plugin install
+    ./netdata-installer.sh --dont-wait --dont-start-it
 
 ################################################################################
 FROM alpine:edge
 
 # Reinstall some prerequisites
 RUN apk --no-cache add lm_sensors nodejs libuuid python py-mysqldb \
-                       py-psycopg2 py-yaml netcat-openbsd jq curl
+                       py-psycopg2 py-yaml netcat-openbsd jq curl fping
 
 # Copy files over
 COPY --from=builder /usr/share/netdata   /usr/share/netdata
@@ -32,12 +29,14 @@ COPY --from=builder /var/cache/netdata   /var/cache/netdata
 COPY --from=builder /var/lib/netdata     /var/lib/netdata
 COPY --from=builder /usr/sbin/netdata    /usr/sbin/netdata
 COPY --from=builder /etc/netdata         /etc/netdata
-COPY --from=builder /usr/local/bin/fping /usr/local/bin/fping
 
 ARG NETDATA_UID=101
 ARG NETDATA_GID=101
 
 RUN \
+    # fping from alpine apk is on a different location. Moving it.
+    mv /usr/sbin/fping /usr/local/bin/fping && \
+    chmod 4755 /usr/local/bin/fping && \
     mkdir -p /var/log/netdata && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S netdata && \
@@ -48,7 +47,6 @@ RUN \
     chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /usr/share/netdata && \
     chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin /usr/libexec/netdata/plugins.d/cgroup-network && \
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin && \
-    chmod 4755 /usr/local/bin/fping && \
     chmod 0750 /var/lib/netdata /var/cache/netdata && \
     # Link log files to stdout
     ln -sf /dev/stdout /var/log/netdata/access.log && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -44,9 +44,8 @@ RUN \
     adduser -S -H -s /bin/sh -u ${NETDATA_GID} -h /etc/netdata -G netdata netdata && \
     # Apply the permissions as described in
     # https://github.com/firehol/netdata/wiki/netdata-security#netdata-directories
-    find /usr/share/netdata -type f -exec chmod 0644 -- {} + && \
-    chown -R root:netdata /usr/share/netdata /etc/netdata && \
-    chown -R netdata:netdata /var/cache/netdata /var/lib/netdata && \
+    chown -R root:netdata /etc/netdata && \
+    chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /usr/share/netdata && \
     chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin /usr/libexec/netdata/plugins.d/cgroup-network && \
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin /usr/local/bin/fping && \
     chmod 0750 /var/lib/netdata /var/cache/netdata && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,14 +13,17 @@ WORKDIR /opt/netdata.git
 # Install source
 RUN chmod +x ./netdata-installer.sh && \
     sync && sleep 1 && \
-    ./netdata-installer.sh --dont-wait --dont-start-it
+    ./netdata-installer.sh --dont-wait --dont-start-it && \
+    sync && sleep 1 && \
+# Compile fping
+    /usr/libexec/netdata/plugins.d/fping.plugin install
 
 ################################################################################
 FROM alpine:edge
 
 # Reinstall some prerequisites
 RUN apk --no-cache add lm_sensors nodejs libuuid python py-mysqldb \
-                       py-psycopg2 py-yaml netcat-openbsd jq
+                       py-psycopg2 py-yaml netcat-openbsd jq curl
 
 # Copy files over
 COPY --from=builder /usr/share/netdata   /usr/share/netdata
@@ -29,9 +32,25 @@ COPY --from=builder /var/cache/netdata   /var/cache/netdata
 COPY --from=builder /var/lib/netdata     /var/lib/netdata
 COPY --from=builder /usr/sbin/netdata    /usr/sbin/netdata
 COPY --from=builder /etc/netdata         /etc/netdata
+COPY --from=builder /usr/local/bin/fping /usr/local/bin/fping
 
-# Link log files to stdout
-RUN mkdir -p /var/log/netdata && \
+ARG NETDATA_UID=101
+ARG NETDATA_GID=101
+
+RUN \
+    mkdir -p /var/log/netdata && \
+    # Add netdata user
+    addgroup -g ${NETDATA_GID} -S netdata && \
+    adduser -S -H -s /bin/sh -u ${NETDATA_GID} -h /etc/netdata -G netdata netdata && \
+    # Apply the permissions as described in
+    # https://github.com/firehol/netdata/wiki/netdata-security#netdata-directories
+    find /usr/share/netdata -type f -exec chmod 0644 -- {} + && \
+    chown -R root:netdata /usr/share/netdata /etc/netdata && \
+    chown -R netdata:netdata /var/cache/netdata /var/lib/netdata && \
+    chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin /usr/libexec/netdata/plugins.d/cgroup-network && \
+    chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin /usr/local/bin/fping && \
+    chmod 0750 /var/lib/netdata /var/cache/netdata && \
+    # Link log files to stdout
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log
@@ -39,3 +58,5 @@ RUN mkdir -p /var/log/netdata && \
 EXPOSE 19999
 
 CMD [ "/usr/sbin/netdata" , "-D", "-s", "/host", "-p", "19999"]
+
+USER netdata:netdata

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -47,7 +47,8 @@ RUN \
     chown -R root:netdata /etc/netdata && \
     chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /usr/share/netdata && \
     chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin /usr/libexec/netdata/plugins.d/cgroup-network && \
-    chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin /usr/local/bin/fping && \
+    chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin && \
+    chmod 4755 /usr/local/bin/fping && \
     chmod 0750 /var/lib/netdata /var/cache/netdata && \
     # Link log files to stdout
     ln -sf /dev/stdout /var/log/netdata/access.log && \
@@ -57,5 +58,3 @@ RUN \
 EXPOSE 19999
 
 CMD [ "/usr/sbin/netdata" , "-D", "-s", "/host", "-p", "19999"]
-
-USER netdata:netdata


### PR DESCRIPTION
* Now comes with fping and curl installed (there were some errors about missing curl command), fping just adds 130 kb to the image
* Installs user `uid=101(netdata) gid=101(netdata)`
* chmod/chown of files and folders

I'm not sure if switching to non-root user will cause problems in containers. It seems to be working in my case. I'm running with
```
docker run -d --cap-add SYS_PTRACE -v /proc:/host/proc:ro -v /sys:/host/sys:ro -p 19999:19999 -u netdata:netdata firehol/netdata:alpine
```

~~I'm also not sure about the USER directive in the docker file. People that derive from this image may not be able to install additional packages without root (I think the USER directive also applies to child images). But at least it's "netdata user"-ready. On the other hand, the alpine image is quite young, not many people will be using it by now.~~

I realized there is a `[global].run as user = netdata` config. I'm assuming that netdata will switch to this user if it exists, even if commented out?