### PR TITLE
allow statsd private charts to be hidden from the dashboard

### DIFF
--- a/src/plugins_d.c
+++ b/src/plugins_d.c
@@ -331,6 +331,11 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
                 else
                     rrdset_flag_clear(st, RRDSET_FLAG_DETAIL);
 
+                if(strstr(options, "hidden"))
+                    rrdset_flag_set(st, RRDSET_FLAG_HIDDEN);
+                else
+                    rrdset_flag_clear(st, RRDSET_FLAG_HIDDEN);
+
                 if(strstr(options, "store_first"))
                     rrdset_flag_set(st, RRDSET_FLAG_STORE_FIRST);
                 else

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -232,7 +232,8 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_EXPOSED_UPSTREAM = 1 << 6, // if set, we have sent this chart to netdata master (streaming)
     RRDSET_FLAG_STORE_FIRST      = 1 << 7, // if set, do not eliminate the first collection during interpolation
     RRDSET_FLAG_HETEROGENEOUS    = 1 << 8, // if set, the chart is not homogeneous (dimensions in it have multiple algorithms, multipliers or dividers)
-    RRDSET_FLAG_HOMEGENEOUS_CHECK= 1 << 9  // if set, the chart should be checked to determine if the dimensions as homogeneous
+    RRDSET_FLAG_HOMEGENEOUS_CHECK= 1 << 9, // if set, the chart should be checked to determine if the dimensions as homogeneous
+    RRDSET_FLAG_HIDDEN           = 1 << 10, // if set, do not show this chart on the dashboard, but use it for backends
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -648,7 +649,7 @@ extern void rrdset_is_obsolete(RRDSET *st);
 extern void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
-#define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
+#define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
 #define rrdset_is_available_for_backends(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions)
 
 // get the total duration in seconds of the round robin database

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -86,7 +86,7 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
     // send the chart
     buffer_sprintf(
             host->rrdpush_sender_buffer
-            , "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d \"%s %s %s\" \"%s\" \"%s\"\n"
+            , "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d \"%s %s %s %s\" \"%s\" \"%s\"\n"
             , st->id
             , st->name
             , st->title
@@ -99,6 +99,7 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
             , rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)?"obsolete":""
             , rrdset_flag_check(st, RRDSET_FLAG_DETAIL)?"detail":""
             , rrdset_flag_check(st, RRDSET_FLAG_STORE_FIRST)?"store_first":""
+            , rrdset_flag_check(st, RRDSET_FLAG_HIDDEN)?"hidden":""
             , (st->plugin_name)?st->plugin_name:""
             , (st->module_name)?st->module_name:""
     );

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -259,6 +259,7 @@ static struct statsd {
     size_t max_private_charts_hard;
     RRD_MEMORY_MODE private_charts_memory_mode;
     long private_charts_rrd_history_entries;
+    int private_charts_hidden;
 
     STATSD_APP *apps;
     size_t recvmmsg_size;
@@ -274,6 +275,7 @@ static struct statsd {
         .enabled = 1,
         .max_private_charts = 200,
         .max_private_charts_hard = 1000,
+        .private_charts_hidden = 0,
         .recvmmsg_size = 10,
         .decimal_detail = STATSD_DECIMAL_DETAIL,
 
@@ -1449,6 +1451,10 @@ static inline RRDSET *statsd_private_rrdset_create(
             , history         // history
     );
     rrdset_flag_set(st, RRDSET_FLAG_STORE_FIRST);
+
+    if(statsd.private_charts_hidden)
+        rrdset_flag_set(st, RRDSET_FLAG_HIDDEN);
+
     // rrdset_flag_set(st, RRDSET_FLAG_DEBUG);
     return st;
 }
@@ -2099,6 +2105,7 @@ void *statsd_main(void *ptr) {
     statsd.private_charts_rrd_history_entries = (int)config_get_number(CONFIG_SECTION_STATSD, "private charts history", default_rrd_history_entries);
     statsd.decimal_detail = (size_t)config_get_number(CONFIG_SECTION_STATSD, "decimal detail", (long long int)statsd.decimal_detail);
     statsd.tcp_idle_timeout = (size_t) config_get_number(CONFIG_SECTION_STATSD, "disconnect idle tcp clients after seconds", (long long int)statsd.tcp_idle_timeout);
+    statsd.private_charts_hidden = (int)config_get_boolean(CONFIG_SECTION_STATSD, "private charts hidden", statsd.private_charts_hidden);
 
     statsd.histogram_percentile = (double)config_get_float(CONFIG_SECTION_STATSD, "histograms and timers percentile (percentThreshold)", statsd.histogram_percentile);
     if(isless(statsd.histogram_percentile, 0) || isgreater(statsd.histogram_percentile, 100)) {


### PR DESCRIPTION
add option

```
[statsd]
  private charts hidden = yes/no
```

to allow using statsd private charts only for backends

fixes #3229