### PR TITLE
do not send clear notifications for web_slow

### DIFF
--- a/conf.d/health.d/web_log.conf
+++ b/conf.d/health.d/web_log.conf
@@ -116,6 +116,7 @@ families: *
     crit: ($1m_requests > 120) ? ($this > $red   && $this > ($10m_response_time * 4) ) : ( 0 )
    delay: down 15m multiplier 1.5 max 1h
     info: the average time to respond to HTTP requests, over the last 1 minute
+ options: no-clear-notification
       to: webmaster
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
since we compare 2 periods, when the problem dominates over both periods, the alarm will be cleared, but it will be misleading - so, don't send clear notifications for this kind of alarms.
