### PR TITLE
Add alarms for stiebeleltron and fronius plugin

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -86,6 +86,7 @@ dist_healthconfig_DATA = \
     health.d/elasticsearch.conf \
     health.d/entropy.conf \
     health.d/fping.conf \
+    health.d/fronius.conf \
     health.d/haproxy.conf \
     health.d/ipc.conf \
     health.d/ipfs.conf \
@@ -109,6 +110,7 @@ dist_healthconfig_DATA = \
     health.d/retroshare.conf \
     health.d/softnet.conf \
     health.d/squid.conf \
+    health.d/stiebeleltron.conf \
     health.d/swap.conf \
     health.d/tcp_conn.conf \
     health.d/tcp_listen.conf \

--- a/conf.d/health.d/fronius.conf
+++ b/conf.d/health.d/fronius.conf
@@ -1,0 +1,11 @@
+template: fronius_last_collected_secs
+families: *
+      on: fronius.power
+    calc: $now - $last_collected_t
+   every: 10s
+   units: seconds ago
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: sitemgr

--- a/conf.d/health.d/stiebeleltron.conf
+++ b/conf.d/health.d/stiebeleltron.conf
@@ -1,0 +1,11 @@
+template: stiebeleltron_last_collected_secs
+families: *
+      on: stiebeleltron.system.heating
+    calc: $now - $last_collected_t
+   every: 10s
+   units: seconds ago
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: sitemgr

--- a/conf.d/health.d/stiebeleltron.conf
+++ b/conf.d/health.d/stiebeleltron.conf
@@ -1,6 +1,6 @@
 template: stiebeleltron_last_collected_secs
 families: *
-      on: stiebeleltron.system.heating
+      on: stiebeleltron.heating.hc1
     calc: $now - $last_collected_t
    every: 10s
    units: seconds ago

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -615,3 +615,36 @@ role_recipients_kavenegar[proxyadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"
 
 role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
+
+# -----------------------------------------------------------------------------
+# peripheral devices
+# UPS, photovoltaics, etc
+
+role_recipients_email[sitemgr]="${DEFAULT_RECIPIENT_EMAIL}"
+
+role_recipients_pushover[sitemgr]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+role_recipients_pushbullet[sitemgr]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+
+role_recipients_telegram[sitemgr]="${DEFAULT_RECIPIENT_TELEGRAM}"
+
+role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+
+role_recipients_alerta[sitemgr]="${DEFAULT_RECIPIENT_ALERTA}"
+
+role_recipients_flock[sitemgr]="${DEFAULT_RECIPIENT_FLOCK}"
+
+role_recipients_discord[sitemgr]="${DEFAULT_RECIPIENT_DISCORD}"
+
+role_recipients_hipchat[sitemgr]="${DEFAULT_RECIPIENT_HIPCHAT}"
+
+role_recipients_twilio[sitemgr]="${DEFAULT_RECIPIENT_TWILIO}"
+
+role_recipients_messagebird[sitemgr]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+
+role_recipients_kavenegar[sitemgr]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+
+role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_custom[sitemgr]="${DEFAULT_RECIPIENT_CUSTOM}"
+

--- a/node.d/stiebeleltron.node.js
+++ b/node.d/stiebeleltron.node.js
@@ -116,7 +116,7 @@ var stiebeleltron = {
             title: chartDefinition.title,
             units: chartDefinition.unit,
             family: context.category.name,
-            context: 'stiebeleltron.' + context.page.id + "." + context.category.id,
+            context: 'stiebeleltron.' + context.category.id + '.' + chartId,
             type: chartDefinition.type,
             priority: stiebeleltron.base_priority + chartDefinition.prio,// the priority relative to others in the same family
             update_every: service.update_every,             // the expected update frequency of the chart

--- a/node.d/stiebeleltron.node.js
+++ b/node.d/stiebeleltron.node.js
@@ -116,7 +116,7 @@ var stiebeleltron = {
             title: chartDefinition.title,
             units: chartDefinition.unit,
             family: context.category.name,
-            context: 'stiebeleltron.' + context.category.id + '.' + chartId,
+            context: 'stiebeleltron.' + context.category.id + '.' + chartDefinition.id,
             type: chartDefinition.type,
             priority: stiebeleltron.base_priority + chartDefinition.prio,// the priority relative to others in the same family
             update_every: service.update_every,             // the expected update frequency of the chart


### PR DESCRIPTION
* I propose a new role "sitemgr" for peripheral devices, such as photovoltaics, UPS, heating/cooling, etc.
* Alarms ensure that we get notified when plugins stop collecting data, for role "sitemgr"

tested & working for both plugins