### PR TITLE
[updater] only restart when previously running

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1234,7 +1234,14 @@ cd "${REINSTALL_PWD}" || exit 1
 # signal netdata to start saving its database
 # this is handy if your database is big
 pids=\$(pidof netdata)
-[ ! -z "\${pids}" ] && kill -USR1 \${pids}
+do_not_start=
+if [ ! -z "\${pids}" ]
+    then
+    kill -USR1 \${pids}
+else
+    # netdata is currently not running, so do not start it after updating
+    do_not_start="--dont-start-it"
+fi
 
 tmp=
 if [ -t 2 ]
@@ -1305,7 +1312,7 @@ update() {
 
     emptyline
     info "Re-installing netdata..."
-    ${REINSTALL_COMMAND} --dont-wait >&3 2>&3 || failed "FAILED TO COMPILE/INSTALL NETDATA"
+    ${REINSTALL_COMMAND} --dont-wait \${do_not_start} >&3 2>&3 || failed "FAILED TO COMPILE/INSTALL NETDATA"
 
     [ ! -z "\${tmp}" ] && rm "\${tmp}" && tmp=
     return 0


### PR DESCRIPTION
Updating netdata (e.g. headless via cron) should not start netdata in case it was not running before.