### PR TITLE
various installer improvements

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -817,6 +817,15 @@ add_netdata_user_and_group() {
         portable_add_user_to_group proxy    netdata && NETDATA_ADDED_TO_PROXY=1
         portable_add_user_to_group squid    netdata && NETDATA_ADDED_TO_SQUID=1
         portable_add_user_to_group ceph     netdata && NETDATA_ADDED_TO_CEPH=1
+
+        [ ~netdata = / ] && cat <<USERMOD
+
+The netdata user has its home directory set to /
+You may want to change it, using this command:
+
+# usermod -d "${homedir}" netdata
+
+USERMOD
         return 0
     fi
 

--- a/makeself/install-or-update.sh
+++ b/makeself/install-or-update.sh
@@ -85,13 +85,40 @@ progress "Add user netdata to required user groups"
 
 NETDATA_USER="root"
 NETDATA_GROUP="root"
-add_netdata_user_and_group
+add_netdata_user_and_group "/opt/netdata"
 if [ $? -eq 0 ]
     then
     NETDATA_USER="netdata"
     NETDATA_GROUP="netdata"
 else
     run_failed "Failed to add netdata user and group"
+fi
+
+[ ~netdata = / ] && cat <<USERMOD
+
+The netdata user has its home directory set to /
+You may want to change it, using this command:
+
+# usermod -m -d /opt/netdata netdata
+
+USERMOD
+
+
+# -----------------------------------------------------------------------------
+progress "Check SSL certificates paths"
+
+if [ ! -f "/etc/ssl/certs/ca-certificates.crt" ]
+then
+    if [ ! -f /opt/netdata/.curlrc ]
+    then
+        # CentOS
+        if [ -f "/etc/ssl/certs/ca-bundle.crt" ]
+        then
+            echo >/opt/netdata/.curlrc "cacert=/etc/ssl/certs/ca-bundle.crt"
+        else
+            run_failed "Failed to find /etc/ssl/certs/ca-certificates.crt"
+        fi
+    fi
 fi
 
 

--- a/makeself/install-or-update.sh
+++ b/makeself/install-or-update.sh
@@ -94,15 +94,6 @@ else
     run_failed "Failed to add netdata user and group"
 fi
 
-[ ~netdata = / ] && cat <<USERMOD
-
-The netdata user has its home directory set to /
-You may want to change it, using this command:
-
-# usermod -m -d /opt/netdata netdata
-
-USERMOD
-
 
 # -----------------------------------------------------------------------------
 progress "Check SSL certificates paths"
@@ -111,10 +102,15 @@ if [ ! -f "/etc/ssl/certs/ca-certificates.crt" ]
 then
     if [ ! -f /opt/netdata/.curlrc ]
     then
+        cacert=
+
         # CentOS
-        if [ -f "/etc/ssl/certs/ca-bundle.crt" ]
+        [ -f "/etc/ssl/certs/ca-bundle.crt" ] && cacert="/etc/ssl/certs/ca-bundle.crt"
+
+        if [ ! -z "${cacert}" ]
         then
-            echo >/opt/netdata/.curlrc "cacert=/etc/ssl/certs/ca-bundle.crt"
+            echo "Creating /opt/netdata/.curlrc with cacert=${cacert}"
+            echo >/opt/netdata/.curlrc "cacert=${cacert}"
         else
             run_failed "Failed to find /etc/ssl/certs/ca-certificates.crt"
         fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -642,7 +642,7 @@ run find ./system/ -type f -a \! -name \*.in -a \! -name Makefile\* -a \! -name 
 # -----------------------------------------------------------------------------
 progress "Add user netdata to required user groups"
 
-homedir="${NETDATA_LIB_DIR}"
+homedir="${NETDATA_PREFIX}/var/lib/netdata"
 [ ! -z "${NETDATA_PREFIX}" ] && homedir="${NETDATA_PREFIX}"
 add_netdata_user_and_group "${homedir}" || run_failed "The installer does not run as root."
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -642,7 +642,9 @@ run find ./system/ -type f -a \! -name \*.in -a \! -name Makefile\* -a \! -name 
 # -----------------------------------------------------------------------------
 progress "Add user netdata to required user groups"
 
-add_netdata_user_and_group || run_failed "The installer does not run as root."
+homedir="${NETDATA_LIB_DIR}"
+[ ! -z "${NETDATA_PREFIX}" ] && homedir="${NETDATA_PREFIX}"
+add_netdata_user_and_group "${homedir}" || run_failed "The installer does not run as root."
 
 
 # -----------------------------------------------------------------------------

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -120,7 +120,7 @@ docurl() {
         echo >&2 "--- END curl command ---"
 
         local out=$(mktemp /tmp/netdata-health-alarm-notify-XXXXXXXX)
-        local code=$(${curl} --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
+        local code=$(${curl} --insecure --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
         local ret=$?
         echo >&2 "--- BEGIN received response ---"
         cat >&2 "${out}"
@@ -132,7 +132,7 @@ docurl() {
         return ${ret}
     fi
 
-    ${curl} --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
+    ${curl} --insecure --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
     return $?
 }
 


### PR DESCRIPTION
1. set `netdata` user home directory
  - for installation in `/`, the netdata user home directory is set to `/var/lib/netdata`
  - for installation in other paths, the netdata user home directory is to the prefix (i.e. `/opt/netdata`)

2. If the installer finds the home directory of user netdata to be `/` it prints instructions to set it.

3. do not validate SSL certifications when sending alarms - I think this is better than not sending the alarms at all. The notification sent is not that sensitive and it is better to do whatever necessary to dispatch the notification.

3. the static `curl` command shipped with netdata static builds, expects to find SSL CA certificates at `/etc/ssl/certs/ca-certificates.crt`, however CentOS has them at `/etc/ssl/certs/ca-bundle.crt`. Now the static installer adds the file `~netdata/.curlrc` with a `cacert=` line to the correct path.

fixes #3489
