### PR TITLE
Fix notification DoS introduced by PR 3490.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -62,6 +62,22 @@ curl=""
 nc=""
 
 #------------------------------------------------------------------------------
+# extra options for external commands
+#
+# In some cases, you may need to change what options get passed to an
+# external command.  Such cases are covered here.
+
+# Control TLS certificate validation for cURL.
+# If set to yes, disable certificatie validation.
+# Otherwise, cURL will validate TLS certificates normally.
+# ******************************WARNING****************************************
+# Disabling this validation by setting the below variable to 'yes'
+# makes it trivial for someone to block notification delivery through most
+# mechanisms other than email and IRC, and may additionally leak sensitive
+# information about the system state.
+curl_insecure="no"
+
+#------------------------------------------------------------------------------
 # NOTE ABOUT RECIPIENTS
 #
 # When you define recipients (all types):

--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -67,15 +67,13 @@ nc=""
 # In some cases, you may need to change what options get passed to an
 # external command.  Such cases are covered here.
 
-# Control TLS certificate validation for cURL.
-# If set to yes, disable certificatie validation.
-# Otherwise, cURL will validate TLS certificates normally.
-# ******************************WARNING****************************************
-# Disabling this validation by setting the below variable to 'yes'
-# makes it trivial for someone to block notification delivery through most
-# mechanisms other than email and IRC, and may additionally leak sensitive
-# information about the system state.
-curl_insecure="no"
+# Extra options to pass to curl.  In most cases, you shouldn't need to add anything
+# to this.  If you're having issues with HTTPS connections, you might try adding
+# '--insecure' here, but be warned that it will make it much easier for
+# third-parties to block notification delivery, and may allow disclosure
+# of potentially sensitive information.
+curl_options=""
+#curl_options="--insecure"
 
 #------------------------------------------------------------------------------
 # NOTE ABOUT RECIPIENTS

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -112,6 +112,13 @@ docurl() {
         return 1
     fi
 
+    if [ "${curl_insecure}" = "yes" ]
+        then
+        insecure='--insecure'
+    else
+        insecure=''
+    fi
+
     if [ "${debug}" = "1" ]
         then
         echo >&2 "--- BEGIN curl command ---"
@@ -120,7 +127,7 @@ docurl() {
         echo >&2 "--- END curl command ---"
 
         local out=$(mktemp /tmp/netdata-health-alarm-notify-XXXXXXXX)
-        local code=$(${curl} --insecure --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
+        local code=$(${curl} ${insecure} --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
         local ret=$?
         echo >&2 "--- BEGIN received response ---"
         cat >&2 "${out}"
@@ -132,7 +139,7 @@ docurl() {
         return ${ret}
     fi
 
-    ${curl} --insecure --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
+    ${curl} ${insecure} --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
     return $?
 }
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -112,13 +112,6 @@ docurl() {
         return 1
     fi
 
-    if [ "${curl_insecure}" = "yes" ]
-        then
-        insecure='--insecure'
-    else
-        insecure=''
-    fi
-
     if [ "${debug}" = "1" ]
         then
         echo >&2 "--- BEGIN curl command ---"
@@ -127,7 +120,7 @@ docurl() {
         echo >&2 "--- END curl command ---"
 
         local out=$(mktemp /tmp/netdata-health-alarm-notify-XXXXXXXX)
-        local code=$(${curl} ${insecure} --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
+        local code=$(${curl} ${curl_options} --write-out %{http_code} --output "${out}" --silent --show-error "${@}")
         local ret=$?
         echo >&2 "--- BEGIN received response ---"
         cat >&2 "${out}"
@@ -139,7 +132,7 @@ docurl() {
         return ${ret}
     fi
 
-    ${curl} ${insecure} --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
+    ${curl} ${curl_options} --write-out %{http_code} --output /dev/null --silent --show-error "${@}"
     return $?
 }
 


### PR DESCRIPTION
PR #3490 added the `--insecure` option to the cURL calls made by alarm-notify.sh to disable TLS certificate validation and make things work without user intervention if cURL can't find the local TLS certificate store.

However, disabling TLS certificate validation opens up a rather trivial to exploit mechanism to block notification delivery.  By hijacking the outbound HTTPS connections made by cURL for notification delivery and then scripting the responses that would be provided by the actual services cURL is trying to connect to, an attacker can persistently block the delivery of notifications through mechanisms other than e-mail and IRC.

It also allows trivial disclosure of potentially sensitive information about the state of the system including disclosing what software is running on the system and potentially certain aspects of it's configuration, which may aid an attacker.  At a minimum, this can provide more reliable feedback to an attacker that a DoS attack on one of the services provided by the system is working.

Here, we change the unconditional use of `--inescure` to be dependent on the value of a variable in `health_alarm_notify.conf`, and make that variable default to not enabling the option while putting a big warning right next to it about the security implications.  Most users should never need to disable TLS certificate validation, so this should be a reasonable default in terms of usability.

This has so far had only the bare minimum of testing, but it appears to work correctly.

In theory, the changes to `alarm-notify.sh` could be simplified because of the explicit use of bash as the shell (using `$(parameter:*word}` type expansion), but doing so would make the code less readable and would result in semantics of the option in `health_alarm_notify.conf` being a bit odd.

This PR does not currently have an associated issue in the bug tracker as I wanted to make sure I had a fix before posting about a potential security bug.