### PR TITLE
monitor bcache;

### DIFF
--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -21,7 +21,6 @@ static struct disk {
     char *mount_point;
 
     // disk options caching
-    int configured;
     int do_io;
     int do_ops;
     int do_mops;
@@ -29,8 +28,20 @@ static struct disk {
     int do_qops;
     int do_util;
     int do_backlog;
+    int do_bcache;
 
     int updated;
+
+    int device_is_bcache;
+
+    char *bcache_filename_dirty_data;
+    char *bcache_filename_cache_available_percent;
+    char *bcache_filename_cache_hits;
+    char *bcache_filename_cache_misses;
+    char *bcache_filename_cache_miss_collisions;
+    char *bcache_filename_cache_bypass_hits;
+    char *bcache_filename_cache_bypass_misses;
+    char *bcache_filename_cache_readaheads;
 
     RRDSET *st_io;
     RRDDIM *rd_io_reads;
@@ -68,20 +79,83 @@ static struct disk {
     RRDSET *st_svctm;
     RRDDIM *rd_svctm_svctm;
 
+    RRDSET *st_bcache_size;
+    RRDDIM *rd_bcache_dirty_size;
+
+    RRDSET *st_bcache_usage;
+    RRDDIM *rd_bcache_available_percent;
+
+    RRDSET *st_bcache;
+    RRDDIM *rd_bcache_hits;
+    RRDDIM *rd_bcache_misses;
+    RRDDIM *rd_bcache_miss_collisions;
+
+    RRDSET *st_bcache_bypass;
+    RRDDIM *rd_bcache_bypass_hits;
+    RRDDIM *rd_bcache_bypass_misses;
+
+    RRDSET *st_bcache_readaheads;
+    RRDDIM *rd_bcache_readaheads;
+
     struct disk *next;
 } *disk_root = NULL;
 
 #define rrdset_obsolete_and_pointer_null(st) do { if(st) { rrdset_is_obsolete(st); (st) = NULL; } } while(st)
 
-static char *path_to_get_hw_sector_size = NULL;
-static char *path_to_get_hw_sector_size_partitions = NULL;
+// static char *path_to_get_hw_sector_size = NULL;
+// static char *path_to_get_hw_sector_size_partitions = NULL;
 static char *path_to_sys_dev_block_major_minor_string = NULL;
 static char *path_to_sys_block_device = NULL;
+static char *path_to_sys_block_device_bcache = NULL;
 static char *path_to_sys_devices_virtual_block_device = NULL;
 static char *path_to_device_mapper = NULL;
 static char *path_to_device_label = NULL;
 static char *path_to_device_id = NULL;
 static int name_disks_by_id = CONFIG_BOOLEAN_NO;
+
+static int  global_enable_new_disks_detected_at_runtime = CONFIG_BOOLEAN_YES,
+        global_enable_performance_for_physical_disks = CONFIG_BOOLEAN_AUTO,
+        global_enable_performance_for_virtual_disks = CONFIG_BOOLEAN_AUTO,
+        global_enable_performance_for_partitions = CONFIG_BOOLEAN_NO,
+        global_do_io = CONFIG_BOOLEAN_AUTO,
+        global_do_ops = CONFIG_BOOLEAN_AUTO,
+        global_do_mops = CONFIG_BOOLEAN_AUTO,
+        global_do_iotime = CONFIG_BOOLEAN_AUTO,
+        global_do_qops = CONFIG_BOOLEAN_AUTO,
+        global_do_util = CONFIG_BOOLEAN_AUTO,
+        global_do_backlog = CONFIG_BOOLEAN_AUTO,
+        global_do_bcache = CONFIG_BOOLEAN_AUTO,
+        globals_initialized = 0,
+        global_cleanup_removed_disks = 1;
+
+static SIMPLE_PATTERN *excluded_disks = NULL;
+
+static inline int is_major_enabled(int major) {
+    static int8_t *major_configs = NULL;
+    static size_t major_size = 0;
+
+    if(major < 0) return 1;
+
+    size_t wanted_size = (size_t)major + 1;
+
+    if(major_size < wanted_size) {
+        major_configs = reallocz(major_configs, wanted_size * sizeof(int8_t));
+
+        size_t i;
+        for(i = major_size; i < wanted_size ; i++)
+            major_configs[i] = -1;
+
+        major_size = wanted_size;
+    }
+
+    if(major_configs[major] == -1) {
+        char buffer[CONFIG_MAX_NAME + 1];
+        snprintfz(buffer, CONFIG_MAX_NAME, "performance metrics for disks with major %d", major);
+        major_configs[major] = (char)config_get_boolean(CONFIG_SECTION_DISKSTATS, buffer, 1);
+    }
+
+    return (int)major_configs[major];
+}
 
 static inline int get_disk_name_from_path(const char *path, char *result, size_t result_size, unsigned long major, unsigned long minor, char *disk) {
     char filename[FILENAME_MAX + 1];
@@ -160,6 +234,103 @@ static inline char *get_disk_name(unsigned long major, unsigned long minor, char
     return strdup(result);
 }
 
+static void get_disk_config(struct disk *d) {
+    int def_enable = global_enable_new_disks_detected_at_runtime;
+
+    if(def_enable != CONFIG_BOOLEAN_NO && (simple_pattern_matches(excluded_disks, d->device) || simple_pattern_matches(excluded_disks, d->disk)))
+        def_enable = CONFIG_BOOLEAN_NO;
+
+    char var_name[4096 + 1];
+    snprintfz(var_name, 4096, "plugin:proc:/proc/diskstats:%s", d->disk);
+
+    def_enable = config_get_boolean_ondemand(var_name, "enable", def_enable);
+    if(unlikely(def_enable == CONFIG_BOOLEAN_NO)) {
+        // the user does not want any metrics for this disk
+        d->do_io = CONFIG_BOOLEAN_NO;
+        d->do_ops = CONFIG_BOOLEAN_NO;
+        d->do_mops = CONFIG_BOOLEAN_NO;
+        d->do_iotime = CONFIG_BOOLEAN_NO;
+        d->do_qops = CONFIG_BOOLEAN_NO;
+        d->do_util = CONFIG_BOOLEAN_NO;
+        d->do_backlog = CONFIG_BOOLEAN_NO;
+        d->do_bcache = CONFIG_BOOLEAN_NO;
+    }
+    else {
+        // this disk is enabled
+        // check its direct settings
+
+        int def_performance = CONFIG_BOOLEAN_AUTO;
+
+        // since this is 'on demand' we can figure the performance settings
+        // based on the type of disk
+
+        if(!d->device_is_bcache) {
+            switch(d->type) {
+                default:
+                case DISK_TYPE_UNKNOWN:
+                    break;
+
+                case DISK_TYPE_PHYSICAL:
+                    def_performance = global_enable_performance_for_physical_disks;
+                    break;
+
+                case DISK_TYPE_PARTITION:
+                    def_performance = global_enable_performance_for_partitions;
+                    break;
+
+                case DISK_TYPE_VIRTUAL:
+                    def_performance = global_enable_performance_for_virtual_disks;
+                    break;
+            }
+        }
+
+        // check if we have to disable performance for this disk
+        if(def_performance)
+            def_performance = is_major_enabled((int)d->major);
+
+        // ------------------------------------------------------------
+        // now we have def_performance and def_space
+        // to work further
+
+        // def_performance
+        // check the user configuration (this will also show our 'on demand' decision)
+        def_performance = config_get_boolean_ondemand(var_name, "enable performance metrics", def_performance);
+
+        int ddo_io = CONFIG_BOOLEAN_NO,
+                ddo_ops = CONFIG_BOOLEAN_NO,
+                ddo_mops = CONFIG_BOOLEAN_NO,
+                ddo_iotime = CONFIG_BOOLEAN_NO,
+                ddo_qops = CONFIG_BOOLEAN_NO,
+                ddo_util = CONFIG_BOOLEAN_NO,
+                ddo_backlog = CONFIG_BOOLEAN_NO,
+                ddo_bcache = CONFIG_BOOLEAN_NO;
+
+        // we enable individual performance charts only when def_performance is not disabled
+        if(unlikely(def_performance != CONFIG_BOOLEAN_NO)) {
+            ddo_io = global_do_io,
+            ddo_ops = global_do_ops,
+            ddo_mops = global_do_mops,
+            ddo_iotime = global_do_iotime,
+            ddo_qops = global_do_qops,
+            ddo_util = global_do_util,
+            ddo_backlog = global_do_backlog,
+            ddo_bcache = global_do_bcache;
+        }
+
+        d->do_io      = config_get_boolean_ondemand(var_name, "bandwidth", ddo_io);
+        d->do_ops     = config_get_boolean_ondemand(var_name, "operations", ddo_ops);
+        d->do_mops    = config_get_boolean_ondemand(var_name, "merged operations", ddo_mops);
+        d->do_iotime  = config_get_boolean_ondemand(var_name, "i/o time", ddo_iotime);
+        d->do_qops    = config_get_boolean_ondemand(var_name, "queued operations", ddo_qops);
+        d->do_util    = config_get_boolean_ondemand(var_name, "utilization percentage", ddo_util);
+        d->do_backlog = config_get_boolean_ondemand(var_name, "backlog", ddo_backlog);
+
+        if(d->device_is_bcache)
+            d->do_bcache  = config_get_boolean_ondemand(var_name, "bcache", ddo_bcache);
+        else
+            d->do_bcache = 0;
+    }
+}
 
 static struct disk *get_disk(unsigned long major, unsigned long minor, char *disk) {
     static struct mountinfo *disk_mountinfo_root = NULL;
@@ -183,7 +354,6 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
     d->major = major;
     d->minor = minor;
     d->type = DISK_TYPE_UNKNOWN; // Default type. Changed later if not correct.
-    d->configured = 0;
     d->sector_size = 512; // the default, will be changed below
     d->next = NULL;
 
@@ -299,51 +469,72 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
     }
     */
 
+    // ------------------------------------------------------------------------
+    // check if the device is a bcache
+
+    struct stat bcache;
+    snprintfz(buffer, FILENAME_MAX, path_to_sys_block_device_bcache, disk);
+    if(unlikely(stat(buffer, &bcache) == 0 && (bcache.st_mode & S_IFMT) == S_IFDIR)) {
+        // we have the 'bcache' directory
+        d->device_is_bcache = 1;
+
+        char buffer2[FILENAME_MAX + 1];
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/dirty_data", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_dirty_data = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/cache/cache_available_percent", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_available_percent = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_hits", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_hits = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_misses", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_misses = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_bypass_hits", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_bypass_hits = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_bypass_misses", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_bypass_misses = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_miss_collisions", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_miss_collisions = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+
+        snprintfz(buffer2, FILENAME_MAX, "%s/stats_total/cache_readaheads", buffer);
+        if(access(buffer2, R_OK) == 0)
+            d->bcache_filename_cache_readaheads = strdupz(buffer2);
+        else
+            error("bcache file '%s' cannot be read.", buffer2);
+    }
+
+    get_disk_config(d);
     return d;
-}
-
-static inline int is_major_enabled(int major) {
-    static int8_t *major_configs = NULL;
-    static size_t major_size = 0;
-
-    if(major < 0) return 1;
-
-    size_t wanted_size = (size_t)major + 1;
-
-    if(major_size < wanted_size) {
-        major_configs = reallocz(major_configs, wanted_size * sizeof(int8_t));
-
-        size_t i;
-        for(i = major_size; i < wanted_size ; i++)
-            major_configs[i] = -1;
-
-        major_size = wanted_size;
-    }
-
-    if(major_configs[major] == -1) {
-        char buffer[CONFIG_MAX_NAME + 1];
-        snprintfz(buffer, CONFIG_MAX_NAME, "performance metrics for disks with major %d", major);
-        major_configs[major] = (char)config_get_boolean(CONFIG_SECTION_DISKSTATS, buffer, 1);
-    }
-
-    return (int)major_configs[major];
 }
 
 int do_proc_diskstats(int update_every, usec_t dt) {
     static procfile *ff = NULL;
-    static int  global_enable_new_disks_detected_at_runtime = CONFIG_BOOLEAN_YES,
-                global_enable_performance_for_physical_disks = CONFIG_BOOLEAN_AUTO,
-                global_enable_performance_for_virtual_disks = CONFIG_BOOLEAN_AUTO,
-                global_enable_performance_for_partitions = CONFIG_BOOLEAN_NO,
-                global_do_io = CONFIG_BOOLEAN_AUTO,
-                global_do_ops = CONFIG_BOOLEAN_AUTO,
-                global_do_mops = CONFIG_BOOLEAN_AUTO,
-                global_do_iotime = CONFIG_BOOLEAN_AUTO,
-                global_do_qops = CONFIG_BOOLEAN_AUTO,
-                global_do_util = CONFIG_BOOLEAN_AUTO,
-                global_do_backlog = CONFIG_BOOLEAN_AUTO,
-                globals_initialized = 0,
-                global_cleanup_removed_disks = 1;
 
     if(unlikely(!globals_initialized)) {
         globals_initialized = 1;
@@ -360,6 +551,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         global_do_qops    = config_get_boolean_ondemand(CONFIG_SECTION_DISKSTATS, "queued operations for all disks", global_do_qops);
         global_do_util    = config_get_boolean_ondemand(CONFIG_SECTION_DISKSTATS, "utilization percentage for all disks", global_do_util);
         global_do_backlog = config_get_boolean_ondemand(CONFIG_SECTION_DISKSTATS, "backlog for all disks", global_do_backlog);
+        global_do_bcache  = config_get_boolean_ondemand(CONFIG_SECTION_DISKSTATS, "bcache for all disks", global_do_bcache);
 
         global_cleanup_removed_disks = config_get_boolean(CONFIG_SECTION_DISKSTATS, "remove charts of removed disks" , global_cleanup_removed_disks);
         
@@ -368,17 +560,20 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/block/%s");
         path_to_sys_block_device = config_get(CONFIG_SECTION_DISKSTATS, "path to get block device", buffer);
 
+        snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/block/%s/bcache");
+        path_to_sys_block_device_bcache = config_get(CONFIG_SECTION_DISKSTATS, "path to get block device bcache", buffer);
+
         snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/virtual/block/%s");
         path_to_sys_devices_virtual_block_device = config_get(CONFIG_SECTION_DISKSTATS, "path to get virtual block device", buffer);
 
         snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/dev/block/%lu:%lu/%s");
         path_to_sys_dev_block_major_minor_string = config_get(CONFIG_SECTION_DISKSTATS, "path to get block device infos", buffer);
 
-        snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/block/%s/queue/hw_sector_size");
-        path_to_get_hw_sector_size = config_get(CONFIG_SECTION_DISKSTATS, "path to get h/w sector size", buffer);
+        //snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/block/%s/queue/hw_sector_size");
+        //path_to_get_hw_sector_size = config_get(CONFIG_SECTION_DISKSTATS, "path to get h/w sector size", buffer);
 
-        snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/dev/block/%lu:%lu/subsystem/%s/../queue/hw_sector_size");
-        path_to_get_hw_sector_size_partitions = config_get(CONFIG_SECTION_DISKSTATS, "path to get h/w sector size for partitions", buffer);
+        //snprintfz(buffer, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/dev/block/%lu:%lu/subsystem/%s/../queue/hw_sector_size");
+        //path_to_get_hw_sector_size_partitions = config_get(CONFIG_SECTION_DISKSTATS, "path to get h/w sector size for partitions", buffer);
 
         snprintfz(buffer, FILENAME_MAX, "%s/dev/mapper", netdata_configured_host_prefix);
         path_to_device_mapper = config_get(CONFIG_SECTION_DISKSTATS, "path to device mapper", buffer);
@@ -390,6 +585,12 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         path_to_device_id = config_get(CONFIG_SECTION_DISKSTATS, "path to /dev/disk/by-id", buffer);
 
         name_disks_by_id = config_get_boolean(CONFIG_SECTION_DISKSTATS, "name disks by id", name_disks_by_id);
+
+        excluded_disks = simple_pattern_create(
+                config_get(CONFIG_SECTION_DISKSTATS, "exclude disks", DEFAULT_EXCLUDED_DISKS)
+                , NULL
+                , SIMPLE_PATTERN_EXACT
+        );
     }
 
     // --------------------------------------------------------------------------
@@ -483,6 +684,9 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         struct disk *d = get_disk(major, minor, disk);
         d->updated = 1;
 
+        // --------------------------------------------------------------------------
+        // count the global system disk I/O of physical disks
+
         if(unlikely(d->type == DISK_TYPE_PHYSICAL)) {
             system_read_kb  += readsectors * d->sector_size / 1024;
             system_write_kb += writesectors * d->sector_size / 1024;
@@ -494,109 +698,6 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         char *family = d->mount_point;
         if(!family) family = d->disk;
 
-
-        // --------------------------------------------------------------------------
-        // Check the configuration for the device
-
-        if(unlikely(!d->configured)) {
-            d->configured = 1;
-
-            static SIMPLE_PATTERN *excluded_disks = NULL;
-
-            if(unlikely(!excluded_disks)) {
-                excluded_disks = simple_pattern_create(
-                        config_get(CONFIG_SECTION_DISKSTATS, "exclude disks", DEFAULT_EXCLUDED_DISKS)
-                        , NULL
-                        , SIMPLE_PATTERN_EXACT
-                );
-            }
-
-            int def_enable = global_enable_new_disks_detected_at_runtime;
-
-            if(def_enable != CONFIG_BOOLEAN_NO && (simple_pattern_matches(excluded_disks, d->device) || simple_pattern_matches(excluded_disks, d->disk)))
-                def_enable = CONFIG_BOOLEAN_NO;
-
-            char var_name[4096 + 1];
-            snprintfz(var_name, 4096, "plugin:proc:/proc/diskstats:%s", d->disk);
-
-            def_enable = config_get_boolean_ondemand(var_name, "enable", def_enable);
-            if(unlikely(def_enable == CONFIG_BOOLEAN_NO)) {
-                // the user does not want any metrics for this disk
-                d->do_io = CONFIG_BOOLEAN_NO;
-                d->do_ops = CONFIG_BOOLEAN_NO;
-                d->do_mops = CONFIG_BOOLEAN_NO;
-                d->do_iotime = CONFIG_BOOLEAN_NO;
-                d->do_qops = CONFIG_BOOLEAN_NO;
-                d->do_util = CONFIG_BOOLEAN_NO;
-                d->do_backlog = CONFIG_BOOLEAN_NO;
-            }
-            else {
-                // this disk is enabled
-                // check its direct settings
-
-                int def_performance = CONFIG_BOOLEAN_AUTO;
-
-                // since this is 'on demand' we can figure the performance settings
-                // based on the type of disk
-
-                switch(d->type) {
-                    default:
-                    case DISK_TYPE_UNKNOWN:
-                        break;
-
-                    case DISK_TYPE_PHYSICAL:
-                        def_performance = global_enable_performance_for_physical_disks;
-                        break;
-
-                    case DISK_TYPE_PARTITION:
-                        def_performance = global_enable_performance_for_partitions;
-                        break;
-
-                    case DISK_TYPE_VIRTUAL:
-                        def_performance = global_enable_performance_for_virtual_disks;
-                        break;
-                }
-
-                // check if we have to disable performance for this disk
-                if(def_performance)
-                    def_performance = is_major_enabled((int)major);
-
-                // ------------------------------------------------------------
-                // now we have def_performance and def_space
-                // to work further
-
-                // def_performance
-                // check the user configuration (this will also show our 'on demand' decision)
-                def_performance = config_get_boolean_ondemand(var_name, "enable performance metrics", def_performance);
-
-                int ddo_io = CONFIG_BOOLEAN_NO,
-                    ddo_ops = CONFIG_BOOLEAN_NO,
-                    ddo_mops = CONFIG_BOOLEAN_NO,
-                    ddo_iotime = CONFIG_BOOLEAN_NO,
-                    ddo_qops = CONFIG_BOOLEAN_NO,
-                    ddo_util = CONFIG_BOOLEAN_NO,
-                    ddo_backlog = CONFIG_BOOLEAN_NO;
-
-                // we enable individual performance charts only when def_performance is not disabled
-                if(unlikely(def_performance != CONFIG_BOOLEAN_NO)) {
-                    ddo_io = global_do_io,
-                    ddo_ops = global_do_ops,
-                    ddo_mops = global_do_mops,
-                    ddo_iotime = global_do_iotime,
-                    ddo_qops = global_do_qops,
-                    ddo_util = global_do_util,
-                    ddo_backlog = global_do_backlog;
-                }
-
-                d->do_io      = config_get_boolean_ondemand(var_name, "bandwidth", ddo_io);
-                d->do_ops     = config_get_boolean_ondemand(var_name, "operations", ddo_ops);
-                d->do_mops    = config_get_boolean_ondemand(var_name, "merged operations", ddo_mops);
-                d->do_iotime  = config_get_boolean_ondemand(var_name, "i/o time", ddo_iotime);
-                d->do_qops    = config_get_boolean_ondemand(var_name, "queued operations", ddo_qops);
-                d->do_util    = config_get_boolean_ondemand(var_name, "utilization percentage", ddo_util);
-                d->do_backlog = config_get_boolean_ondemand(var_name, "backlog", ddo_backlog);
-            }
-        }
 
         // --------------------------------------------------------------------------
         // Do performance metrics
@@ -918,6 +1019,211 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_svctm);
             }
         }
+
+        // --------------------------------------------------------------------------
+        // read bcache metrics and generate the bcache charts
+
+        if(d->device_is_bcache && d->do_bcache != CONFIG_BOOLEAN_NO) {
+            unsigned long long int
+                    cache_bypass_hits = 0,
+                    cache_bypass_misses = 0,
+                    cache_hits = 0,
+                    cache_miss_collisions = 0,
+                    cache_misses = 0,
+                    cache_readaheads = 0,
+                    dirty_size = 0,
+                    cache_available_percent = 0;
+
+            // read the bcache values
+
+            if(d->bcache_filename_dirty_data) {
+                char buffer[50 + 1];
+                if(read_file(d->bcache_filename_dirty_data, buffer, 50) == 0) {
+                    static int unknown_units_error = 10;
+
+                    char *end = NULL;
+                    long double value = str2ld(buffer, &end);
+                    if(end && *end) {
+                        if(*end == 'k' || *end == 'K')
+                            dirty_size = (unsigned long long int)(value * 1024.0);
+                        else if(*end == 'M')
+                            dirty_size = (unsigned long long int)(value * 1024.0 * 1024.0);
+                        else if(*end == 'G' || *end == 'g')
+                            dirty_size = (unsigned long long int)(value * 1024.0 * 1024.0 * 1024.0);
+                        else if(unknown_units_error > 0) {
+                            error("bcache provides value '%s' with unknown units '%s'", buffer, end);
+                            unknown_units_error--;
+                        }
+                    }
+                }
+            }
+
+            if(d->bcache_filename_cache_available_percent)
+                read_single_number_file(d->bcache_filename_cache_available_percent, &cache_available_percent);
+
+            if(d->bcache_filename_cache_hits)
+                read_single_number_file(d->bcache_filename_cache_hits, &cache_hits);
+
+            if(d->bcache_filename_cache_misses)
+                read_single_number_file(d->bcache_filename_cache_misses, &cache_misses);
+
+            if(d->bcache_filename_cache_miss_collisions)
+                read_single_number_file(d->bcache_filename_cache_miss_collisions, &cache_miss_collisions);
+
+            if(d->bcache_filename_cache_bypass_hits)
+                read_single_number_file(d->bcache_filename_cache_bypass_hits, &cache_bypass_hits);
+
+            if(d->bcache_filename_cache_bypass_misses)
+                read_single_number_file(d->bcache_filename_cache_bypass_misses, &cache_bypass_misses);
+
+            if(d->bcache_filename_cache_readaheads)
+                read_single_number_file(d->bcache_filename_cache_readaheads, &cache_readaheads);
+
+
+            // update the charts
+
+            {
+                if(unlikely(!d->st_bcache_size)) {
+                    d->st_bcache_size = rrdset_create_localhost(
+                            "disk_bcache_size"
+                            , d->device
+                            , d->disk
+                            , family
+                            , "disk.bcache_size"
+                            , "Block Cache Sizes"
+                            , "MB"
+                            , "proc"
+                            , "diskstats"
+                            , 2120
+                            , update_every
+                            , RRDSET_TYPE_AREA
+                    );
+
+                    d->rd_bcache_dirty_size = rrddim_add(d->st_bcache_size, "dirty", NULL,  1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                }
+                else rrdset_next(d->st_bcache_size);
+
+                rrddim_set_by_pointer(d->st_bcache_size, d->rd_bcache_dirty_size, dirty_size);
+                rrdset_done(d->st_bcache_size);
+            }
+
+            {
+                if(unlikely(!d->st_bcache_usage)) {
+                    d->st_bcache_usage = rrdset_create_localhost(
+                            "disk_bcache_usage"
+                            , d->device
+                            , d->disk
+                            , family
+                            , "disk.bcache_usage"
+                            , "Block Cache Usage"
+                            , "percent"
+                            , "proc"
+                            , "diskstats"
+                            , 2121
+                            , update_every
+                            , RRDSET_TYPE_AREA
+                    );
+
+                    d->rd_bcache_available_percent = rrddim_add(d->st_bcache_usage, "avail", NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
+                }
+                else rrdset_next(d->st_bcache_usage);
+
+                rrddim_set_by_pointer(d->st_bcache_usage, d->rd_bcache_available_percent, cache_available_percent);
+                rrdset_done(d->st_bcache_usage);
+            }
+
+            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO && (cache_hits != 0 || cache_misses != 0 || cache_miss_collisions != 0))) {
+
+                cache_misses -= cache_miss_collisions;
+
+                if(unlikely(!d->st_bcache)) {
+                    d->st_bcache = rrdset_create_localhost(
+                            "disk_bcache"
+                            , d->device
+                            , d->disk
+                            , family
+                            , "disk.bcache"
+                            , "Block Cache I/O"
+                            , "operations/s"
+                            , "proc"
+                            , "diskstats"
+                            , 2122
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+
+                    rrdset_flag_set(d->st_bcache, RRDSET_FLAG_DETAIL);
+
+                    d->rd_bcache_hits            = rrddim_add(d->st_bcache, "hits",       NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
+                    d->rd_bcache_misses          = rrddim_add(d->st_bcache, "misses",     NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+                    d->rd_bcache_miss_collisions = rrddim_add(d->st_bcache, "collisions", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
+                }
+                else rrdset_next(d->st_bcache);
+
+                rrddim_set_by_pointer(d->st_bcache, d->rd_bcache_hits, cache_hits);
+                rrddim_set_by_pointer(d->st_bcache, d->rd_bcache_misses, cache_misses);
+                rrddim_set_by_pointer(d->st_bcache, d->rd_bcache_miss_collisions, cache_miss_collisions);
+                rrdset_done(d->st_bcache);
+            }
+
+            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO && (cache_bypass_hits != 0 || cache_bypass_misses != 0))) {
+
+                if(unlikely(!d->st_bcache_bypass)) {
+                    d->st_bcache_bypass = rrdset_create_localhost(
+                            "disk_bcache_bypass"
+                            , d->device
+                            , d->disk
+                            , family
+                            , "disk.bcache_bypass"
+                            , "Block Cache Bypass I/O"
+                            , "operations/s"
+                            , "proc"
+                            , "diskstats"
+                            , 2123
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+
+                    rrdset_flag_set(d->st_bcache_bypass, RRDSET_FLAG_DETAIL);
+
+                    d->rd_bcache_bypass_hits   = rrddim_add(d->st_bcache_bypass, "hits",   NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
+                    d->rd_bcache_bypass_misses = rrddim_add(d->st_bcache_bypass, "misses", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+                }
+                else rrdset_next(d->st_bcache_bypass);
+
+                rrddim_set_by_pointer(d->st_bcache_bypass, d->rd_bcache_bypass_hits, cache_bypass_hits);
+                rrddim_set_by_pointer(d->st_bcache_bypass, d->rd_bcache_bypass_misses, cache_bypass_misses);
+                rrdset_done(d->st_bcache_bypass);
+            }
+
+            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO && cache_readaheads != 0)) {
+
+                if(unlikely(!d->st_bcache_readaheads)) {
+                    d->st_bcache_readaheads = rrdset_create_localhost(
+                            "disk_bcache_readahead"
+                            , d->device
+                            , d->disk
+                            , family
+                            , "disk.bcache_readahead"
+                            , "Block Cache Readaheads"
+                            , "events/s"
+                            , "proc"
+                            , "diskstats"
+                            , 2124
+                            , update_every
+                            , RRDSET_TYPE_LINE
+                    );
+
+                    rrdset_flag_set(d->st_bcache_readaheads, RRDSET_FLAG_DETAIL);
+
+                    d->rd_bcache_readaheads = rrddim_add(d->st_bcache_readaheads, "readaheads", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
+                }
+                else rrdset_next(d->st_bcache_readaheads);
+
+                rrddim_set_by_pointer(d->st_bcache_readaheads, d->rd_bcache_readaheads, cache_readaheads);
+                rrdset_done(d->st_bcache_readaheads);
+            }
+        }
     }
 
 
@@ -973,6 +1279,11 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_obsolete_and_pointer_null(d->st_qops);
             rrdset_obsolete_and_pointer_null(d->st_svctm);
             rrdset_obsolete_and_pointer_null(d->st_util);
+            rrdset_obsolete_and_pointer_null(d->st_bcache);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_bypass);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_readaheads);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_size);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_usage);
 
             if(d == disk_root) {
                 disk_root = d = d->next;
@@ -981,6 +1292,15 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             else if(last) {
                 last->next = d = d->next;
             }
+
+            freez(t->bcache_filename_dirty_data);
+            freez(t->bcache_filename_cache_available_percent);
+            freez(t->bcache_filename_cache_hits);
+            freez(t->bcache_filename_cache_misses);
+            freez(t->bcache_filename_cache_miss_collisions);
+            freez(t->bcache_filename_cache_bypass_hits);
+            freez(t->bcache_filename_cache_bypass_misses);
+            freez(t->bcache_filename_cache_readaheads);
 
             freez(t->disk);
             freez(t->device);

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -1172,7 +1172,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache_hit_ratio"
-                            , "Block Cache I/O Hit Ratio"
+                            , "BCache Cache Hit Ratio"
                             , "percentage"
                             , "proc"
                             , "diskstats"
@@ -1204,7 +1204,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache_rates"
-                            , "Block Cache I/O Rates"
+                            , "BCache Rates"
                             , "KB/s"
                             , "proc"
                             , "diskstats"
@@ -1231,7 +1231,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache_size"
-                            , "Block Cache Sizes"
+                            , "BCache Cache Sizes"
                             , "MB"
                             , "proc"
                             , "diskstats"
@@ -1256,7 +1256,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache_usage"
-                            , "Block Cache Usage"
+                            , "BCache Cache Usage"
                             , "percent"
                             , "proc"
                             , "diskstats"
@@ -1282,7 +1282,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache"
-                            , "Block Cache I/O"
+                            , "BCache Cache I/O Operations"
                             , "operations/s"
                             , "proc"
                             , "diskstats"
@@ -1295,8 +1295,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
                     d->rd_bcache_hits            = rrddim_add(d->st_bcache, "hits",       NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                     d->rd_bcache_misses          = rrddim_add(d->st_bcache, "misses",     NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
-                    d->rd_bcache_readaheads      = rrddim_add(d->st_bcache, "readaheads", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                     d->rd_bcache_miss_collisions = rrddim_add(d->st_bcache, "collisions", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+                    d->rd_bcache_readaheads      = rrddim_add(d->st_bcache, "readaheads", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                 }
                 else rrdset_next(d->st_bcache);
 
@@ -1316,7 +1316,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                             , d->disk
                             , family
                             , "disk.bcache_bypass"
-                            , "Block Cache Bypass I/O"
+                            , "BCache Cache Bypass I/O Operations"
                             , "operations/s"
                             , "proc"
                             , "diskstats"

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -34,7 +34,7 @@ static struct disk {
 
     int device_is_bcache;
 
-    char *bcache_filename_congested;
+    char *bcache_filename_cache_congested;
     char *bcache_filename_readahead;
     char *bcache_filename_dirty_data;
     char *bcache_filename_writeback_rate;
@@ -511,9 +511,9 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
 
         char buffer2[FILENAME_MAX + 1];
 
-        snprintfz(buffer2, FILENAME_MAX, "%s/congested", buffer);
+        snprintfz(buffer2, FILENAME_MAX, "%s/cache/congested", buffer);
         if(access(buffer2, R_OK) == 0)
-            d->bcache_filename_congested = strdupz(buffer2);
+            d->bcache_filename_cache_congested = strdupz(buffer2);
         else
             error("bcache file '%s' cannot be read.", buffer2);
 
@@ -1081,8 +1081,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
             // read the bcache values
 
-            if(d->bcache_filename_congested)
-                congested = bcache_read_number_with_units(d->bcache_filename_congested);
+            if(d->bcache_filename_cache_congested)
+                congested = bcache_read_number_with_units(d->bcache_filename_cache_congested);
 
             if(d->bcache_filename_readahead)
                 readahead = bcache_read_number_with_units(d->bcache_filename_readahead);
@@ -1327,7 +1327,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 last->next = d = d->next;
             }
 
-            freez(t->bcache_filename_congested);
+            freez(t->bcache_filename_cache_congested);
             freez(t->bcache_filename_readahead);
             freez(t->bcache_filename_dirty_data);
             freez(t->bcache_filename_writeback_rate);


### PR DESCRIPTION
 fixes #3482

This PR adds a few charts to a disk that is found to be a `bcache`.

1. `disk.bcache_hit_ratio` (with `5min`, `1hour`, `1day`, `ever`)
  read from `/sys/block/<DEVICE>/bcache/stats_total/cache_hit_ratio`, `/sys/block/bcache0/<DEVICE>/stats_hour/cache_hit_ratio`, `/sys/block/bcache0/<DEVICE>/stats_day/cache_hit_ratio`, `/sys/block/bcache0/<DEVICE>/stats_five_minute/cache_hit_ratio`.

  ![screenshot from 2018-03-05 19-28-00](https://user-images.githubusercontent.com/2662304/36989846-99e76504-20ab-11e8-927b-590c7478a98e.png)


2. `disk.bcache_rates` (currently with `writeback`, `congested`)
  read from `/sys/block/<DEVICE>/bcache/writeback_rate` and `/sys/block/<DEVICE>/bcache/cache/congested`.

  ![screenshot from 2018-03-05 19-28-29](https://user-images.githubusercontent.com/2662304/36989869-a3b47a18-20ab-11e8-968f-9dfac8aa941c.png)


3. `disk.bcache_sizes` (currently it accounts only `dirty`)
  read from `/sys/block/<DEVICE>/bcache/dirty_data`

  ![screenshot from 2018-03-05 19-28-45](https://user-images.githubusercontent.com/2662304/36989882-aca86846-20ab-11e8-8136-0500b5b29e26.png)


4. `disk.bcache_usage` (currently it accounts only `avail`)
  read from `/sys/block/<DEVICE>/bcache/cache/cache_available_percent`

  ![screenshot from 2018-03-05 19-29-00](https://user-images.githubusercontent.com/2662304/36989892-b35ee426-20ab-11e8-9dc9-2e539f463360.png)


5. `disk.bcache` (tracking `hits`, `misses`, `collisions`, `readaheads`)
  read from `/sys/block/<DEVICE>/bcache//stats_total/`, files `cache_hits`, `cache_misses`, `cache_miss_collisions`, `cache_readaheads`

  ![screenshot from 2018-03-05 19-29-14](https://user-images.githubusercontent.com/2662304/36989901-b8263cd4-20ab-11e8-9406-fabf79bdd430.png)


6. `disk.bcache_bypass` (tracking `hits` and `misses`)
  read from `/sys/block/<DEVICE>/bcache//stats_total/`, files `cache_bypass_hits`, `cache_bypass_misses`

  ![screenshot from 2018-03-05 19-29-30](https://user-images.githubusercontent.com/2662304/36989908-bd611156-20ab-11e8-9b6f-47ed5ee26891.png)


---

Unfortunately, the developers of bcache tried to provide human readable statistics through `sysfs`. This strategy introduced significant detail losses, and in many cases it made it impossible to properly monitor bcache at the rate netdata supports (per second).

Example detail loss:

It would be perfect to see the cache size in a stacked chart, with the information presented at `cat /sys/block/bcache0/bcache/cache/cache0/priority_stats`:

```
Unused:		33%
Clean:		58%
Dirty:		4%
Metadata:	0%
```

But the sum is not 100% (it is 95%). something is missing here... and it is not just rounding (4 numbers lost 5%, so it is above 1% per number).

If the above was ok, we could get cache size by multiplying `/sys/block/bcache0/bcache/cache/cache0/nbuckets` with `/sys/block/bcache0/bcache/cache/cache0/bucket_size` to get the size of the underlying cache disk and then use the percentages to find out what the cache does (e.g. `dirty` increases, `unused` decreases, etc) and of course sum the above for all cache disks attached.  However the detail loss is significant.

---

I resisted reading `/sys/block/bcache?/bcache/writeback_rate_debug` due to this bug: https://lists.debian.org/debian-kernel/2016/01/msg00494.html. I see the fix appears in 4.4.89 (https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.4.89), so I understand all kernels prior to that may crash when this file is read. Therefore, netdata does not read it.

---

bcache documentation: https://www.kernel.org/doc/Documentation/bcache.txt
