### PR TITLE
configuration option to prevent multiple streaming connections for a host

### DIFF
--- a/conf.d/stream.conf
+++ b/conf.d/stream.conf
@@ -112,6 +112,13 @@
     # postpone alarms for a short period after the sender is connected
     default postpone alarms on connect seconds = 60
 
+    # allow or deny multiple connections for the same host?
+    # If you are sure all your netdata have their own machine GUID,
+    # set this to 'allow', since it allows faster reconnects.
+    # When set to 'deny', new connections for a host will not be
+    # accepted until an existing connection is cleared.
+    multiple connections = allow
+
     # need to route metrics differently? set these.
     # the defaults are the ones at the [stream] section
     #default proxy enabled = yes | no
@@ -158,6 +165,13 @@
 
     # postpone alarms when the sender connects
     postpone alarms on connect seconds = 60
+
+    # allow or deny multiple connections for the same host?
+    # If you are sure all your netdata have their own machine GUID,
+    # set this to 'allow', since it allows faster reconnects.
+    # When set to 'deny', new connections for a host will not be
+    # accepted until an existing connection is cleared.
+    multiple connections = allow
 
     # need to route metrics differently?
     #proxy enabled = yes | no

--- a/configs.signatures
+++ b/configs.signatures
@@ -209,6 +209,7 @@ declare -A configs_signatures=(
   ['54614490a14e1a4b7b3d9fecb6b4cfa5']='python.d/exim.conf'
   ['547779cdc460a926980de1590294b96b']='health.d/softnet.conf'
   ['54c3934a03453453b8d7d0e8b84a7cd8']='health_alarm_notify.conf'
+  ['5523c092be7d667b228c70aeda6f44eb']='stream.conf'
   ['55608bdd908a3806df1468f6ee318b2b']='health.d/qos.conf'
   ['5598b83e915e31f68027afe324a427cd']='apps_groups.conf'
   ['55cc7e3fe365a77f8e92d01d7a428276']='health.d/ram.conf'


### PR DESCRIPTION
#3505

When multiple slaves are streaming metrics for the same host, the behavior of netdata is undefined.
This PR adds a new stream API key and MACHINE option to prevent it from happening.

```
  multiple connections = accept | deny
```

The default is `accept`.
