### PR TITLE
Postgres : replslot and wal writes charts

### DIFF
--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -1068,6 +1068,13 @@ netdataDashboard.context = {
         '</ul>' +
         'For more information see <a href="https://www.postgresql.org/docs/current/static/warm-standby.html#SYNCHRONOUS-REPLICATION" target="_blank">Synchronous Replication</a>.'
     },
+    'postgres.replication_slot': {
+        info: 'Replication slot files.<ul>' +
+        '<li><strong>wal_keeped:</strong> WAL files retained by each replication slots.</li>' +
+        '<li><strong>pg_replslot_files:</strong> files present in pg_replslot.</li>' +
+        '</ul>' +
+        'For more information see <a href="https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS" target="_blank">Replication Slots</a>.'
+    },
 
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
Hello,
New charts to monitor wal files keeped for replication_slot, replslots files used for logical replication and  a chart to measure wal_writes.

![selection_031](https://user-images.githubusercontent.com/6862220/37253490-a21f66b4-2532-11e8-8e65-8d076f93d506.png)
![selection_030](https://user-images.githubusercontent.com/6862220/37253491-a25e7ca0-2532-11e8-9038-25ea15f89308.png)


I also find an error in unit for stat_bgwriter* metrics.

I you are ok, I will add help in dashboard_info.js

TODO : 

* [x] : complete dashboard_info.js


Regards,

