### PR TITLE
propagate netdata version with streaming

### DIFF
--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -110,12 +110,15 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER 
 
     char labels[PROMETHEUS_LABELS_MAX + 1] = "";
     if(allhosts) {
+        buffer_sprintf(wb, "netdata_info{instance=\"%s\",application=\"%s\",version=\"%s\"}\n", hostname, host->program_name, host->program_version);
         if(host->tags && *(host->tags))
             buffer_sprintf(wb, "netdata_host_tags{instance=\"%s\",%s} 1 %llu\n", hostname, host->tags, now_realtime_usec() / USEC_PER_MS);
 
         snprintfz(labels, PROMETHEUS_LABELS_MAX, ",instance=\"%s\"", hostname);
     }
     else {
+        buffer_sprintf(wb, "netdata_info{application=\"%s\",version=\"%s\"}\n", host->program_name, host->program_version);
+
         if(host->tags && *(host->tags))
             buffer_sprintf(wb, "netdata_host_tags{%s} 1 %llu\n", host->tags, now_realtime_usec() / USEC_PER_MS);
     }

--- a/src/health.c
+++ b/src/health.c
@@ -348,7 +348,6 @@ static void health_main_cleanup(void *ptr) {
 }
 
 void *health_main(void *ptr) {
-    BUFFER *wb = buffer_create(100);
     netdata_thread_cleanup_push(health_main_cleanup, ptr);
 
     int min_run_every = (int)config_get_number(CONFIG_SECTION_HEALTH, "run at least every seconds", 10);
@@ -421,7 +420,7 @@ void *health_main(void *ptr) {
                     int value_is_null = 0;
 
                     int ret = rrdset2value_api_v1(rc->rrdset
-                                                  , wb
+                                                  , NULL
                                                   , &rc->value
                                                   , rc->dimensions
                                                   , 1
@@ -732,8 +731,6 @@ void *health_main(void *ptr) {
             debug(D_HEALTH, "Health monitoring iteration no %u done. Next iteration now", loop);
 
     } // forever
-
-    buffer_free(wb);
 
     netdata_thread_cleanup_pop(1);
     return NULL;

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -432,6 +432,8 @@ struct rrdhost {
     char *cache_dir;                                // the directory to save RRD cache files
     char *varlib_dir;                               // the directory to save health log
 
+    char *program_name;                             // the program name that collects metrics for this host
+    char *program_version;                          // the program version that collects metrics for this host
 
     // ------------------------------------------------------------------------
     // streaming of data to remote hosts - rrdpush
@@ -557,6 +559,8 @@ extern RRDHOST *rrdhost_find_or_create(
         , const char *os
         , const char *timezone
         , const char *tags
+        , const char *program_name
+        , const char *program_version
         , int update_every
         , long history
         , RRD_MEMORY_MODE mode

--- a/src/rrd2json.c
+++ b/src/rrd2json.c
@@ -128,7 +128,7 @@ void rrd_stats_api_v1_charts(RRDHOST *host, BUFFER *wb) {
         ",\n\t\"custom_info\": \"%s\""
         ",\n\t\"charts\": {"
         , host->hostname
-        , program_version
+        , host->program_version
         , host->os
         , host->timezone
         , host->rrd_update_every
@@ -1849,10 +1849,12 @@ int rrdset2value_api_v1(
         return 400;
     }
 
-    if(r->result_options & RRDR_RESULT_OPTION_RELATIVE)
-        buffer_no_cacheable(wb);
-    else if(r->result_options & RRDR_RESULT_OPTION_ABSOLUTE)
-        buffer_cacheable(wb);
+    if(wb) {
+        if (r->result_options & RRDR_RESULT_OPTION_RELATIVE)
+            buffer_no_cacheable(wb);
+        else if (r->result_options & RRDR_RESULT_OPTION_ABSOLUTE)
+            buffer_cacheable(wb);
+    }
 
     options = rrdr_check_options(r, options, dimensions);
 

--- a/src/rrdhost.c
+++ b/src/rrdhost.c
@@ -111,6 +111,8 @@ RRDHOST *rrdhost_create(const char *hostname,
                         const char *os,
                         const char *timezone,
                         const char *tags,
+                        const char *program_name,
+                        const char *program_version,
                         int update_every,
                         long entries,
                         RRD_MEMORY_MODE memory_mode,
@@ -146,6 +148,9 @@ RRDHOST *rrdhost_create(const char *hostname,
     rrdhost_init_os(host, os);
     rrdhost_init_timezone(host, timezone);
     rrdhost_init_tags(host, tags);
+
+    host->program_name = strdupz((program_name && *program_name)?program_name:"unknown");
+    host->program_version = strdupz((program_version && *program_version)?program_version:"unknown");
     host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
 
     avl_init_lock(&(host->rrdset_root_index),      rrdset_compare);
@@ -265,6 +270,8 @@ RRDHOST *rrdhost_create(const char *hostname,
                      ", os '%s'"
                      ", timezone '%s'"
                      ", tags '%s'"
+                     ", program_name '%s'"
+                     ", program_version '%s'"
                      ", update every %d"
                      ", memory mode %s"
                      ", history entries %ld"
@@ -282,6 +289,8 @@ RRDHOST *rrdhost_create(const char *hostname,
              , host->os
              , host->timezone
              , (host->tags)?host->tags:""
+             , host->program_name
+             , host->program_version
              , host->rrd_update_every
              , rrd_memory_mode_name(host->rrd_memory_mode)
              , host->rrd_history_entries
@@ -309,6 +318,8 @@ RRDHOST *rrdhost_find_or_create(
         , const char *os
         , const char *timezone
         , const char *tags
+        , const char *program_name
+        , const char *program_version
         , int update_every
         , long history
         , RRD_MEMORY_MODE mode
@@ -329,6 +340,8 @@ RRDHOST *rrdhost_find_or_create(
                 , os
                 , timezone
                 , tags
+                , program_name
+                , program_version
                 , update_every
                 , history
                 , mode
@@ -343,9 +356,24 @@ RRDHOST *rrdhost_find_or_create(
         host->health_enabled = health_enabled;
 
         if(strcmp(host->hostname, hostname) != 0) {
+            info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);
             char *t = host->hostname;
             host->hostname = strdupz(hostname);
             host->hash_hostname = simple_hash(host->hostname);
+            freez(t);
+        }
+
+        if(strcmp(host->program_name, program_name) != 0) {
+            info("Host '%s' switched program name from '%s' to '%s'", host->hostname, host->program_name, program_name);
+            char *t = host->program_name;
+            host->program_name = strdupz(program_name);
+            freez(t);
+        }
+
+        if(strcmp(host->program_version, program_version) != 0) {
+            info("Host '%s' switched program version from '%s' to '%s'", host->hostname, host->program_version, program_version);
+            char *t = host->program_version;
+            host->program_version = strdupz(program_version);
             freez(t);
         }
 
@@ -424,6 +452,8 @@ void rrd_init(char *hostname) {
             , os_type
             , netdata_configured_timezone
             , config_get(CONFIG_SECTION_BACKEND, "host tags", "")
+            , program_name
+            , program_version
             , default_rrd_update_every
             , default_rrd_history_entries
             , default_rrd_memory_mode
@@ -533,6 +563,8 @@ void rrdhost_free(RRDHOST *host) {
     freez((void *)host->tags);
     freez((void *)host->os);
     freez((void *)host->timezone);
+    freez(host->program_version);
+    freez(host->program_name);
     freez(host->cache_dir);
     freez(host->varlib_dir);
     freez(host->rrdpush_send_api_key);

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -144,6 +144,7 @@ struct web_client {
     char cookie1[NETDATA_WEB_REQUEST_COOKIE_SIZE+1];
     char cookie2[NETDATA_WEB_REQUEST_COOKIE_SIZE+1];
     char origin[NETDATA_WEB_REQUEST_ORIGIN_HEADER_SIZE+1];
+    char *user_agent;
 
     struct response response;
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -106,6 +106,8 @@ static void web_client_zero(struct web_client *w) {
     buffer_flush(b2);
     buffer_flush(b3);
 
+    freez(w->user_agent);
+
     // zero everything
     memset(w, 0, sizeof(struct web_client));
 
@@ -119,6 +121,7 @@ static void web_client_free(struct web_client *w) {
     buffer_free(w->response.header_output);
     buffer_free(w->response.header);
     buffer_free(w->response.data);
+    freez(w->user_agent);
     freez(w);
 }
 
@@ -342,6 +345,9 @@ static void web_client_initialize_connection(struct web_client *w) {
     web_client_update_acl_matches(w);
 
     w->origin[0] = '*'; w->origin[1] = '\0';
+    w->cookie1[0] = '\0'; w->cookie2[0] = '\0';
+    freez(w->user_agent); w->user_agent = NULL;
+
     web_client_enable_wait_receive(w);
 
     log_connection(w, "CONNECTED");


### PR DESCRIPTION
netdata now exposes to the dashboard, the version of the netdata collecting the metrics (i.e. it also passes-through netdata proxies).

The netdata version is also sent to prometheus - fixes #3519
