### PR TITLE
New charts for Elasticsearch

### DIFF
--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -34,12 +34,33 @@ NODE_STATS = [
     'indices.refresh.total_time_in_millis',
     'indices.flush.total',
     'indices.flush.total_time_in_millis',
+    'indices.translog.operations',
+    'indices.translog.size_in_bytes',
+    'indices.translog.uncommitted_operations',
+    'indices.translog.uncommitted_size_in_bytes',
+    'indices.segments.count',
+    'indices.segments.memory_in_bytes',
+    'indices.segments.terms_memory_in_bytes',
+    'indices.segments.stored_fields_memory_in_bytes',
+    'indices.segments.term_vectors_memory_in_bytes',
+    'indices.segments.norms_memory_in_bytes',
+    'indices.segments.points_memory_in_bytes',
+    'indices.segments.doc_values_memory_in_bytes',
+    'indices.segments.index_writer_memory_in_bytes',
+    'indices.segments.version_map_memory_in_bytes',
+    'indices.segments.fixed_bit_set_memory_in_bytes',
     'jvm.gc.collectors.young.collection_count',
     'jvm.gc.collectors.old.collection_count',
     'jvm.gc.collectors.young.collection_time_in_millis',
     'jvm.gc.collectors.old.collection_time_in_millis',
     'jvm.mem.heap_used_percent',
     'jvm.mem.heap_committed_in_bytes',
+    'jvm.buffer_pools.direct.count',
+    'jvm.buffer_pools.direct.used_in_bytes',
+    'jvm.buffer_pools.direct.total_capacity_in_bytes',
+    'jvm.buffer_pools.mapped.count',
+    'jvm.buffer_pools.mapped.used_in_bytes',
+    'jvm.buffer_pools.mapped.total_capacity_in_bytes',
     'thread_pool.bulk.queue',
     'thread_pool.bulk.rejected',
     'thread_pool.index.queue',
@@ -103,7 +124,9 @@ LATENCY = {
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_performance_total', 'search_performance_current', 'search_performance_time',
          'search_latency', 'index_performance_total', 'index_performance_current', 'index_performance_time',
-         'index_latency', 'jvm_mem_heap', 'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
+         'index_latency', 'index_segments_count', 'index_segments_memory', 'jvm_mem_heap',
+         'jvm_buffer_pool_count', 'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory',
+         'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
          'host_metrics_http', 'host_metrics_transport', 'thread_pool_queued', 'thread_pool_rejected',
          'fielddata_cache', 'fielddata_evictions_tripped', 'cluster_health_status', 'cluster_health_nodes',
          'cluster_health_shards', 'cluster_stats_nodes', 'cluster_stats_query_cache', 'cluster_stats_docs',
@@ -166,12 +189,54 @@ CHARTS = {
             ['indexing_latency', 'indexing', 'absolute', 1, 1000],
             ['flushing_latency', 'flushing', 'absolute', 1, 1000]
         ]},
+    'index_segments_count': {
+        'options': [None, 'Total Number Of Indices Segments', 'count', 'indices segments',
+                    'elastic.index_segments_count', 'line'],
+        'lines': [
+            ['indices_segments_count', 'segments', 'absolute']
+        ]},
+    'index_segments_memory': {
+        'options': [None, 'Indices Segments Memory Usage', 'MB', 'indices segments',
+                    'elastic.index_segments_memory', 'area'],
+        'lines': [
+            ['indices_segments_memory_in_bytes', 'total', 'absolute', 1, 1048567],
+            ['indices_segments_terms_memory_in_bytes', 'terms', 'absolute', 1, 1048567],
+            ['indices_segments_stored_fields_memory_in_bytes', 'stored_fields', 'absolute', 1, 1048567],
+            ['indices_segments_term_vectors_memory_in_bytes', 'term_vectors', 'absolute', 1, 1048567],
+            ['indices_segments_norms_memory_in_bytes', 'norms', 'absolute', 1, 1048567],
+            ['indices_segments_points_memory_in_bytes', 'points', 'absolute', 1, 1048567],
+            ['indices_segments_doc_values_memory_in_bytes', 'doc_values', 'absolute', 1, 1048567],
+            ['indices_segments_index_writer_memory_in_bytes', 'index_writer', 'absolute', 1, 1048567],
+            ['indices_segments_version_map_memory_in_bytes', 'version_map', 'absolute', 1, 1048567],
+            ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed_bit_set', 'absolute', 1, 1048567]
+        ]},
     'jvm_mem_heap': {
         'options': [None, 'JVM Heap Currently in Use/Committed', 'percent/MB', 'memory usage and gc',
                     'elastic.jvm_heap', 'area'],
         'lines': [
             ['jvm_mem_heap_used_percent', 'inuse', 'absolute'],
             ['jvm_mem_heap_committed_in_bytes', 'commit', 'absolute', -1, 1048576]
+        ]},
+    'jvm_buffer_pool_count': {
+        'options': [None, 'JVM Buffers', 'count', 'memory usage and gc',
+                    'elastic.jvm_buffer_pool_count', 'line'],
+        'lines': [
+            ['jvm_buffer_pools_direct_count', 'direct', 'absolute'],
+            ['jvm_buffer_pools_mapped_count', 'mapped', 'absolute']
+        ]},
+    'jvm_direct_buffers_memory': {
+        'options': [None, 'JVM Direct Buffers Memory', 'MB', 'memory usage and gc',
+                    'elastic.jvm_direct_buffers_memory', 'area'],
+        'lines': [
+            ['jvm_buffer_pools_direct_used_in_bytes', 'used', 'absolute', 1, 1048567],
+            ['jvm_buffer_pools_direct_total_capacity_in_bytes', 'total capacity', 'absolute', 1, 1048567]
+        ]},
+    'jvm_mapped_buffers_memory': {
+        'options': [None, 'JVM Mapped Buffers Memory', 'MB', 'memory usage and gc',
+                    'elastic.jvm_mapped_buffers_memory', 'area'],
+        'lines': [
+            ['jvm_buffer_pools_mapped_used_in_bytes', 'used', 'absolute', 1, 1048567],
+            ['jvm_buffer_pools_mapped_total_capacity_in_bytes', 'total capacity', 'absolute', 1, 1048567]
         ]},
     'jvm_gc_count': {
         'options': [None, 'Garbage Collections', 'counts', 'memory usage and gc', 'elastic.gc_count', 'stacked'],

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -124,7 +124,7 @@ LATENCY = {
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_performance_total', 'search_performance_current', 'search_performance_time',
          'search_latency', 'index_performance_total', 'index_performance_current', 'index_performance_time',
-         'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory_writer', 
+         'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory_writer',
          'index_segments_memory', 'jvm_mem_heap', 'jvm_mem_heap_bytes', 'jvm_buffer_pool_count',
          'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory', 'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
          'host_metrics_http', 'host_metrics_transport', 'thread_pool_queued', 'thread_pool_rejected',

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -215,14 +215,14 @@ CHARTS = {
         'lines': [
             ['indices_segments_memory_in_bytes', 'total', 'absolute', 1, 1048567],
             ['indices_segments_terms_memory_in_bytes', 'terms', 'absolute', 1, 1048567],
-            ['indices_segments_stored_fields_memory_in_bytes', 'stored_fields', 'absolute', 1, 1048567],
-            ['indices_segments_term_vectors_memory_in_bytes', 'term_vectors', 'absolute', 1, 1048567],
+            ['indices_segments_stored_fields_memory_in_bytes', 'stored fields', 'absolute', 1, 1048567],
+            ['indices_segments_term_vectors_memory_in_bytes', 'term vectors', 'absolute', 1, 1048567],
             ['indices_segments_norms_memory_in_bytes', 'norms', 'absolute', 1, 1048567],
             ['indices_segments_points_memory_in_bytes', 'points', 'absolute', 1, 1048567],
-            ['indices_segments_doc_values_memory_in_bytes', 'doc_values', 'absolute', 1, 1048567],
-            ['indices_segments_index_writer_memory_in_bytes', 'index_writer', 'absolute', 1, 1048567],
-            ['indices_segments_version_map_memory_in_bytes', 'version_map', 'absolute', 1, 1048567],
-            ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed_bit_set', 'absolute', 1, 1048567]
+            ['indices_segments_doc_values_memory_in_bytes', 'doc values', 'absolute', 1, 1048567],
+            ['indices_segments_index_writer_memory_in_bytes', 'index writer', 'absolute', 1, 1048567],
+            ['indices_segments_version_map_memory_in_bytes', 'version map', 'absolute', 1, 1048567],
+            ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed bit set', 'absolute', 1, 1048567]
         ]},
     'jvm_mem_heap': {
         'options': [None, 'JVM Heap Currently in Use/Committed', 'percent/MB', 'memory usage and gc',

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -54,6 +54,7 @@ NODE_STATS = [
     'jvm.gc.collectors.young.collection_time_in_millis',
     'jvm.gc.collectors.old.collection_time_in_millis',
     'jvm.mem.heap_used_percent',
+    'jvm.mem.heap_used_in_bytes',
     'jvm.mem.heap_committed_in_bytes',
     'jvm.buffer_pools.direct.count',
     'jvm.buffer_pools.direct.used_in_bytes',
@@ -125,7 +126,7 @@ LATENCY = {
 ORDER = ['search_performance_total', 'search_performance_current', 'search_performance_time',
          'search_latency', 'index_performance_total', 'index_performance_current', 'index_performance_time',
          'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory', 'jvm_mem_heap',
-         'jvm_buffer_pool_count', 'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory',
+         'jvm_mem_heap_bytes', 'jvm_buffer_pool_count', 'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory',
          'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
          'host_metrics_http', 'host_metrics_transport', 'thread_pool_queued', 'thread_pool_rejected',
          'fielddata_cache', 'fielddata_evictions_tripped', 'cluster_health_status', 'cluster_health_nodes',
@@ -225,11 +226,17 @@ CHARTS = {
             ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed bit set', 'absolute', 1, 1048567]
         ]},
     'jvm_mem_heap': {
-        'options': [None, 'JVM Heap Currently in Use/Committed', 'percent/MB', 'memory usage and gc',
+        'options': [None, 'JVM Heap Percentage Currently in Use', 'percent', 'memory usage and gc',
                     'elastic.jvm_heap', 'area'],
         'lines': [
-            ['jvm_mem_heap_used_percent', 'inuse', 'absolute'],
-            ['jvm_mem_heap_committed_in_bytes', 'commit', 'absolute', -1, 1048576]
+            ['jvm_mem_heap_used_percent', 'inuse', 'absolute']
+        ]},
+    'jvm_mem_heap_bytes': {
+        'options': [None, 'JVM Heap Commit And Usage', 'MB', 'memory usage and gc',
+                    'elastic.jvm_heap_bytes', 'area'],
+        'lines': [
+            ['jvm_mem_heap_committed_in_bytes', 'commited', 'absolute', 1, 1048576],
+            ['jvm_mem_heap_used_in_bytes', 'used', 'absolute', 1, 1048576]
         ]},
     'jvm_buffer_pool_count': {
         'options': [None, 'JVM Buffers', 'count', 'memory usage and gc',

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -124,7 +124,7 @@ LATENCY = {
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_performance_total', 'search_performance_current', 'search_performance_time',
          'search_latency', 'index_performance_total', 'index_performance_current', 'index_performance_time',
-         'index_latency', 'index_segments_count', 'index_segments_memory', 'jvm_mem_heap',
+         'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory', 'jvm_mem_heap',
          'jvm_buffer_pool_count', 'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory',
          'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
          'host_metrics_http', 'host_metrics_transport', 'thread_pool_queued', 'thread_pool_rejected',
@@ -188,6 +188,20 @@ CHARTS = {
         'lines': [
             ['indexing_latency', 'indexing', 'absolute', 1, 1000],
             ['flushing_latency', 'flushing', 'absolute', 1, 1000]
+        ]},
+    'index_translog_operations': {
+        'options': [None, 'Translog Operations', 'count', 'translog',
+                    'elastic.index_translog_operations', 'area'],
+        'lines': [
+            ['indices_translog_operations', 'total', 'absolute'],
+            ['indices_translog_uncommitted_operations', 'uncommited', 'absolute']
+        ]},
+    'index_translog_size': {
+        'options': [None, 'Translog Size', 'MB', 'translog',
+                    'elastic.index_translog_size', 'area'],
+        'lines': [
+            ['indices_translog_size_in_bytes', 'total', 'absolute', 1, 1048567],
+            ['indices_translog_uncommitted_size_in_bytes', 'uncommited', 'absolute', 1, 1048567]
         ]},
     'index_segments_count': {
         'options': [None, 'Total Number Of Indices Segments', 'count', 'indices segments',

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -39,7 +39,6 @@ NODE_STATS = [
     'indices.translog.uncommitted_operations',
     'indices.translog.uncommitted_size_in_bytes',
     'indices.segments.count',
-    'indices.segments.memory_in_bytes',
     'indices.segments.terms_memory_in_bytes',
     'indices.segments.stored_fields_memory_in_bytes',
     'indices.segments.term_vectors_memory_in_bytes',
@@ -125,9 +124,9 @@ LATENCY = {
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = ['search_performance_total', 'search_performance_current', 'search_performance_time',
          'search_latency', 'index_performance_total', 'index_performance_current', 'index_performance_time',
-         'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory', 'jvm_mem_heap',
-         'jvm_mem_heap_bytes', 'jvm_buffer_pool_count', 'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory',
-         'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
+         'index_latency', 'index_translog_operations', 'index_translog_size', 'index_segments_count', 'index_segments_memory_writer', 
+         'index_segments_memory', 'jvm_mem_heap', 'jvm_mem_heap_bytes', 'jvm_buffer_pool_count',
+         'jvm_direct_buffers_memory', 'jvm_mapped_buffers_memory', 'jvm_gc_count', 'jvm_gc_time', 'host_metrics_file_descriptors',
          'host_metrics_http', 'host_metrics_transport', 'thread_pool_queued', 'thread_pool_rejected',
          'fielddata_cache', 'fielddata_evictions_tripped', 'cluster_health_status', 'cluster_health_nodes',
          'cluster_health_shards', 'cluster_stats_nodes', 'cluster_stats_query_cache', 'cluster_stats_docs',
@@ -210,18 +209,22 @@ CHARTS = {
         'lines': [
             ['indices_segments_count', 'segments', 'absolute']
         ]},
+    'index_segments_memory_writer': {
+        'options': [None, 'Index Writer Memory Usage', 'MB', 'indices segments',
+                    'elastic.index_segments_memory_writer', 'area'],
+        'lines': [
+            ['indices_segments_index_writer_memory_in_bytes', 'total', 'absolute', 1, 1048567]
+        ]},
     'index_segments_memory': {
         'options': [None, 'Indices Segments Memory Usage', 'MB', 'indices segments',
-                    'elastic.index_segments_memory', 'area'],
+                    'elastic.index_segments_memory', 'stacked'],
         'lines': [
-            ['indices_segments_memory_in_bytes', 'total', 'absolute', 1, 1048567],
             ['indices_segments_terms_memory_in_bytes', 'terms', 'absolute', 1, 1048567],
             ['indices_segments_stored_fields_memory_in_bytes', 'stored fields', 'absolute', 1, 1048567],
             ['indices_segments_term_vectors_memory_in_bytes', 'term vectors', 'absolute', 1, 1048567],
             ['indices_segments_norms_memory_in_bytes', 'norms', 'absolute', 1, 1048567],
             ['indices_segments_points_memory_in_bytes', 'points', 'absolute', 1, 1048567],
             ['indices_segments_doc_values_memory_in_bytes', 'doc values', 'absolute', 1, 1048567],
-            ['indices_segments_index_writer_memory_in_bytes', 'index writer', 'absolute', 1, 1048567],
             ['indices_segments_version_map_memory_in_bytes', 'version map', 'absolute', 1, 1048567],
             ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed bit set', 'absolute', 1, 1048567]
         ]},


### PR DESCRIPTION
This pull request adds several charts for Elasticsearch translog/indices segments statistics and JVM buffer pools utilization.
These metrics are often very helpful when evaluating an Elasticsearch node health.