### PR TITLE
Pagerduty enhancement to avoid incident duplication.

### DIFF
--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1008,7 +1008,7 @@ send_pd() {
             ${pd_send} -k ${PD_SERVICE_KEY} \
                        -t ${t} \
                        -d "${d}" \
-                       -i ${alarm_id} \
+                       -i ${host}:${chart}:${name} \
                        -f 'info'="${info}" \
                        -f 'value_w_units'="${value_string}" \
                        -f 'when'="${when}" \


### PR DESCRIPTION
We have 2 netdata masters (for high availability) sending alarms through pagerduty. With this enhancement we can avoid alarm duplication.

Feedback is appreciated!