### PR TITLE
pass host tags to json backends;

### DIFF
--- a/conf.d/health.d/backend.conf
+++ b/conf.d/health.d/backend.conf
@@ -27,7 +27,7 @@
    units: metrics
     calc: abs($lost)
    every: 10s
-    crit: $this != 0
+    crit: ($this != 0) || ($status == $CRITICAL && abs($sent) == 0)
    delay: down 5m multiplier 1.5 max 1h
     info: number of metrics lost due to repeating failures to contact the backend server
       to: dba

--- a/configs.signatures
+++ b/configs.signatures
@@ -498,6 +498,7 @@ declare -A configs_signatures=(
   ['b7d769ce86a7aebba01315da5c0799e6']='health.d/ram.conf'
   ['b81b8f331161b0d48e03f6fbf6b6d062']='health.d/memcached.conf'
   ['b846ca1f99fa6a65303b58186f47d7a4']='python.d/squid.conf'
+  ['b854fcb711ee4d052741de5fc888682e']='health.d/backend.conf'
   ['b8969be5b3ceb4a99477937119bd4323']='python.d.conf'
   ['b8aff60806fb6829a4e72a824e655375']='health.d/beanstalkd.conf'
   ['b8b87574fd496a66ede884c5336493bd']='python.d/phpfpm.conf'

--- a/src/backends.c
+++ b/src/backends.c
@@ -347,9 +347,24 @@ static inline int format_dimension_collected_json_plaintext(
     (void)before;
     (void)options;
 
+    const char *tags_pre = "", *tags_post = "", *tags = host->tags;
+    if(!tags) tags = "";
+
+    if(*tags) {
+        if(*tags == '{' || *tags == '[' || *tags == '"') {
+            tags_pre = "\"host_tags\":";
+            tags_post = ",";
+        }
+        else {
+            tags_pre = "\"host_tags\":\"";
+            tags_post = "\",";
+        }
+    }
+
     buffer_sprintf(b, "{"
         "\"prefix\":\"%s\","
         "\"hostname\":\"%s\","
+        "%s%s%s"
 
         "\"chart_id\":\"%s\","
         "\"chart_name\":\"%s\","
@@ -362,9 +377,10 @@ static inline int format_dimension_collected_json_plaintext(
         "\"name\":\"%s\","
         "\"value\":" COLLECTED_NUMBER_FORMAT ","
 
-        "\"timestamp\": %u}\n", 
+        "\"timestamp\": %u}\n",
             prefix,
             hostname,
+            tags_pre, tags, tags_post,
 
             st->id,
             st->name,
@@ -400,9 +416,24 @@ static inline int format_dimension_stored_json_plaintext(
     calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options, &first_t, &last_t);
 
     if(!isnan(value)) {
+        const char *tags_pre = "", *tags_post = "", *tags = host->tags;
+        if(!tags) tags = "";
+
+        if(*tags) {
+            if(*tags == '{' || *tags == '[' || *tags == '"') {
+                tags_pre = "\"host_tags\":";
+                tags_post = ",";
+            }
+            else {
+                tags_pre = "\"host_tags\":\"";
+                tags_post = "\",";
+            }
+        }
+
         buffer_sprintf(b, "{"
             "\"prefix\":\"%s\","
             "\"hostname\":\"%s\","
+            "%s%s%s"
 
             "\"chart_id\":\"%s\","
             "\"chart_name\":\"%s\","
@@ -418,7 +449,8 @@ static inline int format_dimension_stored_json_plaintext(
             "\"timestamp\": %u}\n", 
                 prefix,
                 hostname,
-                
+                tags_pre, tags, tags_post,
+
                 st->id,
                 st->name,
                 st->family,


### PR DESCRIPTION
fixes #3479 

host tags have to be formatted in a json friendly way.
netdata will not surround host tags with quotes, if they start with ` { `, or ` [ `, or ` " `. Otherwise, netdata will add ` " ` before and after them.