### PR TITLE
Add disk inode usage rate health alarms (like disk fill rate)

### DIFF
--- a/conf.d/health.d/disks.conf
+++ b/conf.d/health.d/disks.conf
@@ -81,6 +81,47 @@ families: *
 
 
 # -----------------------------------------------------------------------------
+# disk inode fill rate
+
+# calculate the rate the disk inodes are allocated
+# use as base, the available inodes change
+# during the last hour
+
+# this is just a calculation - it has no alarm
+# we will use it in the next template to find
+# the hours remaining
+
+template: disk_inode_rate
+      on: disk.inodes
+      os: linux freebsd
+   hosts: *
+families: *
+  lookup: min -10m at -50m unaligned of avail
+    calc: ($this - $avail) / (($now - $after) / 3600)
+   every: 1m
+   units: inodes/hour
+    info: average rate at which disk inodes are allocated (positive), or freed (negative), for the last hour
+
+# calculate the hours remaining
+# if the disk inodes are allocated
+# in this rate
+
+template: out_of_disk_inodes_time
+      on: disk.inodes
+      os: linux freebsd
+   hosts: *
+families: *
+    calc: ($disk_inode_rate > 0) ? ($avail / $disk_inode_rate) : (inf)
+   units: hours
+   every: 10s
+    warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
+    crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
+   delay: down 15m multiplier 1.2 max 1h
+    info: estimated time the disk will run out of inodes, if the system continues to allocate inodes with the rate of the last hour
+      to: sysadmin
+
+
+# -----------------------------------------------------------------------------
 # disk congestion
 
 # raise an alarm if the disk is congested


### PR DESCRIPTION
I noticed that health alarms for inode usage rate were missing, so I added them (that's copy'n'paste from the disk fill rate block with some changes).