### PR TITLE
redis.chart.py: fix mem usage dimension

### DIFF
--- a/python.d/redis.chart.py
+++ b/python.d/redis.chart.py
@@ -36,8 +36,8 @@ CHARTS = {
     'memory': {
         'options': [None, 'Redis Memory utilization', 'kilobytes', 'memory', 'redis.memory', 'line'],
         'lines': [
-            ['used_memory', 'total', 'absolute', 1, 1024],
-            ['used_memory_lua', 'lua', 'absolute', 1, 1024]
+            ['used_memory', 'total', 'absolute', 1/1024, 1024],
+            ['used_memory_lua', 'lua', 'absolute', 1/1024, 1024]
         ]},
     'net': {
         'options': [None, 'Redis Bandwidth', 'kilobits/s', 'network', 'redis.net', 'area'],


### PR DESCRIPTION
Redis reports memory usage in bytes, not kilobytes:
```
# Memory
used_memory:266838672
used_memory_human:254.48M
```
A scale down factor of 1024 is required.