### PR TITLE
allow show-X-at for before, after, duration, update-every and selection

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5719,6 +5719,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20180210-4"></script>
+    <script type="text/javascript" src="dashboard.js?v20180326-2"></script>
 </body>
 </html>


### PR DESCRIPTION
fixes #3571

This PR allows custom dashboards to set on any chart:

```html
<div
    ...
    show-after-at="DOM_ELEMENT_ID"
    show-before-at="DOM_ELEMENT_ID"
    show-duration-at="DOM_ELEMENT_ID"
    show-update-every-at="DOM_ELEMENT_ID"
    show-selection-at="DOM_ELEMENT_ID"
    ></div>
```

For example, this HTML fragment:

```html
<body>
Data from <b><span id="after"></span></b> to <b><span id="before"></span></b>, duration <b><span id="duration"></span></b>, update every <b><span id="update-every"></span></b>.<br/>
Selection <b><span id="selection"></span></b>.
<br/>
<div style="width: 100%; text-align: center;">
	<div
		data-netdata="system.net"
        data-width="100%"
        data-height="200px"
        data-after="-600"
        data-points="600"
	 	data-show-before-at="before"
	 	data-show-after-at="after"
	 	data-show-duration-at="duration"
	 	data-show-update-every-at="update-every"
	 	data-show-selection-at="selection"
    	></div>
</div>
<script type="text/javascript" src="dashboard.js"></script>
</body>
```


will produce this:

![image](https://user-images.githubusercontent.com/2662304/37904051-0819076e-3103-11e8-91a6-e0165813f738.png)
