### PR TITLE
netdata web server protection against slowloris

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -19,6 +19,7 @@ char *netdata_configured_home_dir    = NULL;
 char *netdata_configured_host_prefix = NULL;
 char *netdata_configured_timezone    = NULL;
 
+struct rlimit rlimit_nofile = { .rlim_cur = 1024, .rlim_max = 1024 };
 int enable_ksm = 1;
 
 volatile sig_atomic_t netdata_exit = 0;

--- a/src/common.h
+++ b/src/common.h
@@ -323,6 +323,8 @@ extern int memory_file_save(const char *filename, void *mem, size_t size);
 
 extern int fd_is_valid(int fd);
 
+extern struct rlimit rlimit_nofile;
+
 extern int enable_ksm;
 
 extern int sleep_usec(usec_t usec);

--- a/src/main.c
+++ b/src/main.c
@@ -1005,6 +1005,11 @@ int main(int argc, char **argv) {
     }
 #endif /* NETDATA_INTERNAL_CHECKS */
 
+    // get the max file limit
+    if(getrlimit(RLIMIT_NOFILE, &rlimit_nofile) != 0)
+        error("getrlimit(RLIMIT_NOFILE) failed");
+    else
+        info("resources control: allowed file descriptors: soft = %zu, max = %zu", rlimit_nofile.rlim_cur, rlimit_nofile.rlim_max);
 
     // fork, switch user, create pid file, set process priority
     if(become_daemon(dont_fork, user) == -1)

--- a/src/socket.h
+++ b/src/socket.h
@@ -101,6 +101,8 @@ struct poll {
     size_t min;
     size_t max;
 
+    size_t limit;
+
     time_t complete_request_timeout;
     time_t idle_timeout;
     time_t checks_every;
@@ -154,6 +156,7 @@ extern void poll_events(LISTEN_SOCKETS *sockets
         , time_t tcp_idle_timeout_seconds
         , time_t timer_milliseconds
         , void *timer_data
+        , size_t max_tcp_sockets
 );
 
 #endif //NETDATA_SOCKET_H

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -159,6 +159,9 @@ void web_client_request_done(struct web_client *w) {
     w->response.sent = 0;
     w->response.code = 0;
 
+    w->header_parse_tries = 0;
+    w->header_parse_last_size = 0;
+
     web_client_enable_wait_receive(w);
     web_client_disable_wait_send(w);
 
@@ -809,7 +812,31 @@ typedef enum {
 } HTTP_VALIDATION;
 
 static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
-    char *s = w->response.data->buffer, *encoded_url = NULL;
+    char *s = (char *)buffer_tostring(w->response.data), *encoded_url = NULL;
+
+    size_t last_pos = w->header_parse_last_size;
+    if(last_pos > 4) last_pos -= 4; // allow searching for \r\n\r\n
+    else last_pos = 0;
+
+    w->header_parse_tries++;
+    w->header_parse_last_size = buffer_strlen(w->response.data);
+
+    if(w->header_parse_tries > 1) {
+        if(w->header_parse_last_size < last_pos)
+            last_pos = 0;
+
+        if(strstr(&s[last_pos], "\r\n\r\n") == NULL) {
+            if(w->header_parse_tries > 10) {
+                info("Disabling slow client after %zu attempts to read the request (%zu bytes received)", w->header_parse_tries, buffer_strlen(w->response.data));
+                w->header_parse_tries = 0;
+                w->header_parse_last_size = 0;
+                web_client_disable_wait_receive(w);
+                return HTTP_VALIDATION_NOT_SUPPORTED;
+            }
+
+            return HTTP_VALIDATION_INCOMPLETE;
+        }
+    }
 
     // is is a valid request?
     if(!strncmp(s, "GET ", 4)) {
@@ -825,6 +852,8 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
         w->mode = WEB_CLIENT_MODE_STREAM;
     }
     else {
+        w->header_parse_tries = 0;
+        w->header_parse_last_size = 0;
         web_client_disable_wait_receive(w);
         return HTTP_VALIDATION_NOT_SUPPORTED;
     }
@@ -872,6 +901,8 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // FIXME -- we should avoid it
                 strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
 
+                w->header_parse_tries = 0;
+                w->header_parse_last_size = 0;
                 web_client_disable_wait_receive(w);
                 return HTTP_VALIDATION_OK;
             }

--- a/src/web_client.h
+++ b/src/web_client.h
@@ -128,6 +128,9 @@ struct web_client {
     WEB_CLIENT_MODE mode;           // the operational mode of the client
     WEB_CLIENT_ACL acl;             // the access list of the client
 
+    size_t header_parse_tries;
+    size_t header_parse_last_size;
+
     int tcp_cork;                   // 1 = we have a cork on the socket
 
     int ifd;


### PR DESCRIPTION
This PR adds some additional web protection to netdata:

## slowloris

See [wikipedia](https://en.wikipedia.org/wiki/Slowloris_(computer_security)).

netdata already had a protection against slow http requests - it gives each socket 60 seconds to send a request.

But, we never tested what exactly happens when such an attack is made against it.

So, I used https://github.com/shekyan/slowhttptest to test netdata and I found out that netdata was entering an infinite loop when it run out of file descriptors.

This PR fixes it, and also adds a protection to prevent netdata from running out of file descriptors: each web server and statsd thread now has a maximum number of sockets it can work with. If this limit is reached, the worker thread stops accepting new TCP connections until a connected client disconnects. While this happens, netdata is just serving the existing clients, no CPU spikes, no dropped connections, no crashes.

Of course, if the attack continues, the listening sockets will overflow - netdata will detect this and send an alarm notification (like it does for all daemons running on a system).

By default netdata allocates file descriptors like this:

- 1/2 of them for web clients
- 1/4 of them for statsd TCP clients
- the rest 1/2 of them, for data collection, external plugins (pipes) and streaming out metrics

They are configurable at netdata.conf:

```
[web]
	web server max sockets = 512

[statsd]
	statsd server max TCP sockets = 256
```

netdata reads the file descriptors it is allowed to use, using `getrlimit()` and print this to error.log:

```
2018-03-27 01:35:06: netdata INFO  : MAIN : resources control: allowed file descriptors: soft = 1024, max = 4096
```

The solf limit is used for the default allocations.

---

netdata also applies a limit of 10 fragments for reading the entire HTTP request. So, clients that are sending the HTTP request in small steps (a few bytes per packet), will be allowed to send it in up to 10 packets. Once this limit is reached, the client is disconnected.

---

Finally, this PR fixes 2 rare conditions that could crash netdata, both caused by accessing a pointer in a structure that conditionally had been realloced.