### PR TITLE
minor fixes

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -679,22 +679,23 @@ config_option() {
 if [ "${UID}" = "0" ]
     then
     NETDATA_USER="$( config_option "global" "run as user" "netdata" )"
-    NETDATA_GROUP="${NETDATA_USER}"
     ROOT_USER="root"
 else
     NETDATA_USER="${USER}"
-    NETDATA_GROUP="$(id -g -n ${NETDATA_USER})"
     ROOT_USER="${NETDATA_USER}"
 fi
+NETDATA_GROUP="$(id -g -n ${NETDATA_USER})"
+[ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_USER}"
 
 # the owners of the web files
 NETDATA_WEB_USER="$(  config_option "web" "web files owner" "${NETDATA_USER}" )"
+NETDATA_WEB_GROUP="${NETDATA_GROUP}"
 if [ "${UID}" = "0" -a "${NETDATA_USER}" != "${NETDATA_WEB_USER}" ]
 then
-    NETDATA_GROUP="$(id -g -n ${NETDATA_WEB_USER})"
-    [ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_WEB_USER}"
+    NETDATA_WEB_GROUP="$(id -g -n ${NETDATA_WEB_USER})"
+    [ -z "${NETDATA_WEB_GROUP}" ] && NETDATA_WEB_GROUP="${NETDATA_WEB_USER}"
 fi
-NETDATA_WEB_GROUP="$( config_option "web" "web files group" "${NETDATA_GROUP}" )"
+NETDATA_WEB_GROUP="$( config_option "web" "web files group" "${NETDATA_WEB_GROUP}" )"
 
 # port
 defport=19999

--- a/src/sys_fs_cgroup.c
+++ b/src/sys_fs_cgroup.c
@@ -2332,7 +2332,7 @@ void update_cgroup_charts(int update_every) {
                 rrdset_next(cg->st_mem);
 
             rrddim_set(cg->st_mem, "cache", cg->memory.cache);
-            rrddim_set(cg->st_mem, "rss", cg->memory.rss);
+            rrddim_set(cg->st_mem, "rss", (cg->memory.rss > cg->memory.rss_huge)?(cg->memory.rss - cg->memory.rss_huge):0);
 
             if(cg->memory.detailed_has_swap)
                 rrddim_set(cg->st_mem, "swap", cg->memory.swap);


### PR DESCRIPTION
1. The installer was applying wrong filesystem permissions for key netdata directories when the user has edited `web files group`.

2. in cgroups, `rss` memory includes `rss_huge`. Now netdata substracts `rss_huge` from `rss` to provide a valid stacked chart.
