### PR TITLE
Add syslog support to alarm-notify.sh.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -15,6 +15,7 @@
 # - sms messages to your cell phone or any sms enabled device (messagebird.com)
 # - notifications to users on pagerduty.com
 # - messages to your irc channel on your selected network
+# - messages to a local or remote syslog daemon
 #
 # The 'to' line given at netdata alarms defines a *role*, so that many
 # people can be notified for each role.
@@ -61,6 +62,11 @@ curl=""
 # If not found, irc notifications will be silently disabled.
 nc=""
 
+# The full path of the logger command.
+# If empty, the system $PATH will be searched for it.
+# If not found, syslog notifications will be silently disabled.
+logger=""
+
 #------------------------------------------------------------------------------
 # extra options for external commands
 #
@@ -73,6 +79,13 @@ nc=""
 # third-parties to block notification delivery, and may allow disclosure
 # of potentially sensitive information.
 #curl_options="--insecure"
+
+# Extra options to pass to logger.  If you just want to send to your
+# local system logs, you can leave this empty and everything should work.
+# If you want to send to a remote syslog server, you need to specify the
+# remote server here with the `--host` option, and may need additional
+# options to select the protocol.  See `man logger` for more information.
+#logger_options=""
 
 #------------------------------------------------------------------------------
 # NOTE ABOUT RECIPIENTS
@@ -438,6 +451,59 @@ IRC_NICKNAME=""
 # The irc realname which is required in order to make the connection and is an
 # extra identifier.
 IRC_REALNAME=""
+
+
+#------------------------------------------------------------------------------
+# syslog notifications
+#
+# syslog notifications only need you to have a working logger command, which
+# should be the case on pretty much any Linux system.
+
+# enable/disable sending syslog notifications
+# NOTE: make sure you have everything else configured the way you want
+# it _before_ turning this on.
+SEND_SYSLOG="NO"
+
+# A note on log levels and facilities:
+#
+# The traditional UNIX syslog mechanism has the concept of both log
+# levels and facilities.  A log level indicates the relaitve severity of
+# the message, while a facility specifies a generic source for the message
+# (for example, the `mail` facility is where sendmail and postfix log
+# their messages).  All major syslog daemons have the ability to filter
+# messages based on both log level and facility, and can often also make
+# routing decisions for messages based on both factors.
+#
+# On Linux, the eight log levels in decreasing order of severity are:
+# emerg, alert, crit, err, warning, notice, info, debug
+#
+# By default, netdata alerts will be logged at the warning level
+# for warnings and clear notifications, and the err level for critical
+# notifications.
+#
+# And the 19 facilities you can log to are:
+# auth, authpriv, cron, daemon, ftp, lpr, mail, news, syslog, user,
+# uucp, local0, local1, local2, local3, local4, local5, local6, and local7
+#
+# By default, netdata alerts will be logged to the local6 facility.
+#
+# Depending on your distribution, this means that either all your
+# netdata alerts will by default end up in the main system log (usually
+# /var/log/messages), or they won't be logged to a file at all.
+# Neither of these are likely to be what you actually want, but any
+# configuration to change that needs to happen in the syslog daemon
+# configuration, not here.
+
+# This specifies the log level that warnings and clear notifications
+# will be sent at.  If unset, it defaults to 'warning'.
+SYSLOG_LEVEL=''
+
+# This specifies the log level that critical alerts will be sent at.
+# If unset, it defaults to 'err'
+SYSLOG_CRITICAL_LEVEL=''
+
+# This controls which facility is used for logging.  Defaults to local6.
+SYSLOG_FACILITY=''
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This uses the `logger` command (found on all modern Linux and BSD systems)
to allow `alarm-notify.sh` to send netdata alarm messages to a local
or remote syslog server.  By default, logging is done to the local6
facility at a warning log level, with critical alarms being logged at
the err level.

This provides a mechanism of easily generating a running log of all
netdata alarm events on most standard UNIX systems, and when used with
full-featured logging daemons like rsyslog or syslong-ng can be used to
archive such messages in a wide variety of alternative formats.

There are a few limitations currently:

 * It can only log to one location.  This can be easily worked around in
 most syslog daemon's configurations, as almost all of them support some
 form of output multiplexing.
 * The default settings will usually not get the results most people
 would want, but because of the sometimes very significant differences
 in default syslog configurations from distribution to distribution,
 there's not really any way to make the defaults any saner.
 * While it is possible to log directly to a remote syslog server, there
 is no quick and easy wet up for this, it requires the user to manually
 compose the extra options that need to be passed to `logger`.

Syslog messages generated by this will look something like this:

    Apr  3 09:00:30 localhost netdata: Netdata notification on wild-karde at Tue Apr 3 09:00:00 EDT 2018: WARNING, out of disk space time = 5h

Lightly tested on Linux, no testing on BSD yet but based on FreeBSD documentation it should work there as-is.

As mentioned in the limitations above, the default settings are almost certainly not what most people will want (depending on the distribution, you'll either get all the notifications in the main syslog log file (`/var/log/syslog` or `/var/log/messages` in most cases), or you won't get any at all), so it won't send messages unless explicitly enabled (which is extra important as the necessary command is present in the default install of all major Linux distributions, as well as FreeBSD and it's derivatives).

I've been using a custom notification mechanism similar to this for a while now on my VPS nodes so that I have an easy way to correlate netdata alarms with other log entries (for example, making it easier to correlate data collection alarms for my web servers with specific sets of requests).   I've found this to be extremely useful on a couple of occasions, and would much rather not need to go through custom alert notifiers for it, and I expect other people may find it useful too.