### PR TITLE
statsd improvements

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -101,7 +101,7 @@ typedef enum statsd_metric_type {
 
 
 typedef struct statsd_metric {
-    avl avl;                        // indexing
+    avl avl;                        // indexing - has to be first
 
     const char *name;               // the name of the metric
     uint32_t hash;                  // hash of the name
@@ -122,9 +122,9 @@ typedef struct statsd_metric {
 
     // chart related members
     STATS_METRIC_OPTIONS options;   // STATSD_METRIC_OPTION_* (bitfield)
-    char reset;                     // set to 1 to reset this metric to zero
+    char reset;                     // set to 1 by the charting thread to instruct the collector thread(s) to reset this metric
     collected_number last;          // the last value sent to netdata
-    RRDSET *st;                     // the chart of this metric
+    RRDSET *st;                     // the private chart of this metric
     RRDDIM *rd_value;               // the dimension of this metric value
     RRDDIM *rd_count;               // the dimension for the number of events received
 


### PR DESCRIPTION
1. statsd sets now show zeros when no data are collected
2. statsd histograms and timers were wasting some resources due to unnecessary mutex access on every flush - so when there are many thousands of  histograms and timers there was increased CPU usage of the charting thread
3. several minor optimizations have been applied to lower the CPU usage of the charting thread when there are several millions of statsd metrics collected.
4. When there are several millions of statsd metrics, the charting thread used constant but quite high CPU. The reason was that each second it needed to loop through all the metrics. Now, netdata statsd tracks which statsd metrics are charted (i.e. they are useful) and completely disables all its functions for the not useful ones (i.e. it does not actually parse the collected values and it does not flush them).