### PR TITLE
fix security issues identified by Synacktiv

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -991,8 +991,8 @@ To run apps.plugin with escalated capabilities:
 
 or, to run apps.plugin as root:
 
-    ${TPUT_YELLOW}${TPUT_BOLD}sudo chown root \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin\"${TPUT_RESET}
-    ${TPUT_YELLOW}${TPUT_BOLD}sudo chmod 4755 \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin\"${TPUT_RESET}
+    ${TPUT_YELLOW}${TPUT_BOLD}sudo chown root:${NETDATA_GROUP} \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin\"${TPUT_RESET}
+    ${TPUT_YELLOW}${TPUT_BOLD}sudo chmod 4750 \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin\"${TPUT_RESET}
 
 apps.plugin is performing a hard-coded function of data collection for all
 running processes. It cannot be instructed from the netdata daemon to perform

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -807,7 +807,7 @@ static inline void assign_target_to_pid(struct pid_stat *p) {
 
     struct target *w;
     for(w = apps_groups_root_target; w ; w = w->next) {
-        // if(debug_enabled || (p->target && p->target->debug_enabled)) debug_log("\t\tcomparing '%s' with '%s'", w->compare, p->comm);
+        // if(debug_enabled || (p->target && p->target->debug_enabled)) debug_log_int("\t\tcomparing '%s' with '%s'", w->compare, p->comm);
 
         // find it - 4 cases:
         // 1. the target is not a pattern
@@ -825,7 +825,7 @@ static inline void assign_target_to_pid(struct pid_stat *p) {
             else p->target = w;
 
             if(debug_enabled || (p->target && p->target->debug_enabled))
-                debug_log("%s linked to target %s", p->comm, p->target->name);
+                debug_log_int("%s linked to target %s", p->comm, p->target->name);
 
             break;
         }
@@ -1180,7 +1180,7 @@ static inline int read_proc_pid_stat(struct pid_stat *p, void *ptr) {
 #endif
 
     if(unlikely(debug_enabled || (p->target && p->target->debug_enabled)))
-        debug_log("READ PROC/PID/STAT: %s/proc/%d/stat, process: '%s' on target '%s' (dt=%llu) VALUES: utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT ", threads=%d", netdata_configured_host_prefix, p->pid, p->comm, (p->target)?p->target->name:"UNSET", p->stat_collected_usec - p->last_stat_collected_usec, p->utime, p->stime, p->cutime, p->cstime, p->minflt, p->majflt, p->cminflt, p->cmajflt, p->num_threads);
+        debug_log_int("READ PROC/PID/STAT: %s/proc/%d/stat, process: '%s' on target '%s' (dt=%llu) VALUES: utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT ", threads=%d", netdata_configured_host_prefix, p->pid, p->comm, (p->target)?p->target->name:"UNSET", p->stat_collected_usec - p->last_stat_collected_usec, p->utime, p->stime, p->cutime, p->cstime, p->minflt, p->majflt, p->cminflt, p->cmajflt, p->num_threads);
 
     if(unlikely(global_iterations_counter == 1)) {
         p->minflt           = 0;
@@ -2058,7 +2058,7 @@ static inline void link_all_processes_to_their_parents(void) {
             pp->children_count++;
 
             if(unlikely(debug_enabled || (p->target && p->target->debug_enabled)))
-                debug_log("child %d (%s, %s) on target '%s' has parent %d (%s, %s). Parent: utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", gtime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", cgtime=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT "", p->pid, p->comm, p->updated?"running":"exited", (p->target)?p->target->name:"UNSET", pp->pid, pp->comm, pp->updated?"running":"exited", pp->utime, pp->stime, pp->gtime, pp->minflt, pp->majflt, pp->cutime, pp->cstime, pp->cgtime, pp->cminflt, pp->cmajflt);
+                debug_log_int("child %d (%s, %s) on target '%s' has parent %d (%s, %s). Parent: utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", gtime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", cgtime=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT "", p->pid, p->comm, p->updated?"running":"exited", (p->target)?p->target->name:"UNSET", pp->pid, pp->comm, pp->updated?"running":"exited", pp->utime, pp->stime, pp->gtime, pp->minflt, pp->majflt, pp->cutime, pp->cstime, pp->cgtime, pp->cminflt, pp->cmajflt);
         }
         else {
             p->parent = NULL;
@@ -2350,7 +2350,7 @@ static void apply_apps_groups_targets_inheritance(void) {
                 found++;
 
                 if(debug_enabled || (p->target && p->target->debug_enabled))
-                    debug_log("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s).", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
+                    debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s).", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
             }
         }
     }
@@ -2386,7 +2386,7 @@ static void apply_apps_groups_targets_inheritance(void) {
                     p->parent->target = p->target;
 
                     if(debug_enabled || (p->target && p->target->debug_enabled))
-                        debug_log("TARGET INHERITANCE: %s is inherited by %d (%s) from its child %d (%s).", p->target->name, p->parent->pid, p->parent->comm, p->pid, p->comm);
+                        debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its child %d (%s).", p->target->name, p->parent->pid, p->parent->comm, p->pid, p->comm);
                 }
 
                 found++;
@@ -2431,7 +2431,7 @@ static void apply_apps_groups_targets_inheritance(void) {
                 found++;
 
                 if(debug_enabled || (p->target && p->target->debug_enabled))
-                    debug_log("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s) at phase 2.", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
+                    debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s) at phase 2.", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
             }
         }
     }
@@ -2630,7 +2630,7 @@ static inline void aggregate_pid_on_target(struct target *w, struct pid_stat *p,
     w->num_threads += p->num_threads;
 
     if(unlikely(debug_enabled || w->debug_enabled))
-        debug_log("aggregating '%s' pid %d on target '%s' utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", gtime=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", cgtime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT "", p->comm, p->pid, w->name, p->utime, p->stime, p->gtime, p->cutime, p->cstime, p->cgtime, p->minflt, p->majflt, p->cminflt, p->cmajflt);
+        debug_log_int("aggregating '%s' pid %d on target '%s' utime=" KERNEL_UINT_FORMAT ", stime=" KERNEL_UINT_FORMAT ", gtime=" KERNEL_UINT_FORMAT ", cutime=" KERNEL_UINT_FORMAT ", cstime=" KERNEL_UINT_FORMAT ", cgtime=" KERNEL_UINT_FORMAT ", minflt=" KERNEL_UINT_FORMAT ", majflt=" KERNEL_UINT_FORMAT ", cminflt=" KERNEL_UINT_FORMAT ", cmajflt=" KERNEL_UINT_FORMAT "", p->comm, p->pid, w->name, p->utime, p->stime, p->gtime, p->cutime, p->cstime, p->cgtime, p->minflt, p->majflt, p->cminflt, p->cmajflt);
 }
 
 static void calculate_netdata_statistics(void) {
@@ -3150,7 +3150,7 @@ static void send_charts_updates_to_netdata(struct target *root, const char *type
             newly_added++;
             w->exposed = 1;
             if (debug_enabled || w->debug_enabled)
-                debug_log("%s just added - regenerating charts.", w->name);
+                debug_log_int("%s just added - regenerating charts.", w->name);
         }
     }
 

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -53,6 +53,18 @@ static inline int web_client_uncrock_socket(struct web_client *w) {
     return 0;
 }
 
+static inline char *strip_control_characters(char *url) {
+    char *s = url;
+    if(!s) return "";
+
+    if(iscntrl(*s)) *s = ' ';
+    while(*++s) {
+        if(iscntrl(*s)) *s = ' ';
+    }
+
+    return url;
+}
+
 void web_client_request_done(struct web_client *w) {
     web_client_uncrock_socket(w);
 
@@ -120,7 +132,7 @@ void web_client_request_done(struct web_client *w) {
                    , dt_usec(&tv, &w->tv_ready) / 1000.0
                    , dt_usec(&tv, &w->tv_in) / 1000.0
                    , w->response.code
-                   , w->last_url
+                   , strip_control_characters(w->last_url)
         );
     }
 


### PR DESCRIPTION
I received an email from Nicolas Collignon from Synacktiv demonstrating 2 issues in netdata:

1. apps.plugin debug feature can be manipulated to read arbitrary files of the filesystem. Normally (under default installation settings) apps.plugin can only be run by user `netdata`, though there were wrong printed instructions by the installer.

   This PR fixes the wrong installer printed instructions and compiles apps.plugin without debugging.

2. the netdata web server accepts URLs with `\n` in them, allowing log lines injection to `access.log`. 

   This PR removes control characters from URLs before printing them.

---

Thank you Synacktiv !