### PR TITLE
more apps.plugin security fixes by Synacktiv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,10 @@ AC_HEADER_MAJOR
 AC_HEADER_RESOLV
 
 AC_CHECK_HEADERS_ONCE([sys/prctl.h])
+AC_CHECK_HEADERS_ONCE([sys/vfs.h])
+AC_CHECK_HEADERS_ONCE([sys/statfs.h])
+AC_CHECK_HEADERS_ONCE([sys/statvfs.h])
+AC_CHECK_HEADERS_ONCE([sys/mount.h])
 
 if test "${enable_accept4}" != "no"; then
     AC_CHECK_FUNCS_ONCE(accept4)

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -856,7 +856,7 @@ static inline int read_proc_pid_cmdline(struct pid_stat *p) {
         p->cmdline_filename = strdupz(filename);
     }
 
-    int fd = open(p->cmdline_filename, O_RDONLY, 0666);
+    int fd = open(p->cmdline_filename, procfile_open_flags, 0666);
     if(unlikely(fd == -1)) goto cleanup;
 
     ssize_t i, bytes = read(fd, cmdline, MAX_CMDLINE);
@@ -3314,7 +3314,6 @@ cleanup:
 static void parse_args(int argc, char **argv)
 {
     int i, freq = 0;
-    char *name = NULL;
 
     for(i = 1; i < argc; i++) {
         if(!freq) {
@@ -3428,20 +3427,14 @@ static void parse_args(int argc, char **argv)
             exit(1);
         }
 
-        if(!name) {
-            name = argv[i];
-            continue;
-        }
-
         error("Cannot understand option %s", argv[i]);
         exit(1);
     }
 
     if(freq > 0) update_every = freq;
-    if(!name || !*name) name = "groups";
 
-    if(read_apps_groups_conf(name)) {
-        error("Cannot read process groups '%s/apps_%s.conf'. There are no internal defaults. Failing.", config_dir, name);
+    if(read_apps_groups_conf("groups")) {
+        error("Cannot read process groups '%s/apps_groups.conf'. There are no internal defaults. Failing.", config_dir);
         exit(1);
     }
 }
@@ -3523,12 +3516,11 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    // since apps.plugin runs as root, prevent it from opening symbolic links
+    procfile_open_flags = O_RDONLY|O_NOFOLLOW;
+
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(netdata_configured_host_prefix == NULL) {
-        // info("NETDATA_HOST_PREFIX is not passed from netdata");
-        netdata_configured_host_prefix = "";
-    }
-    // else info("Found NETDATA_HOST_PREFIX='%s'", netdata_configured_host_prefix);
+    if(verify_netdata_host_prefix() == -1) exit(1);
 
     config_dir = getenv("NETDATA_CONFIG_DIR");
     if(config_dir == NULL) {
@@ -3563,14 +3555,14 @@ int main(int argc, char **argv) {
         error("apps.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities. "
                       "Without these, apps.plugin cannot report disk I/O utilization of other processes. "
                       "To enable capabilities run: sudo setcap cap_dac_read_search,cap_sys_ptrace+ep %s; "
-                      "To enable setuid to root run: sudo chown root %s; sudo chmod 4755 %s; "
+                      "To enable setuid to root run: sudo chown root:netdata %s; sudo chmod 4750 %s; "
               , uid, euid, argv[0], argv[0], argv[0]
         );
 #else
         error("apps.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities. "
                       "Without these, apps.plugin cannot report disk I/O utilization of other processes. "
                       "Your system does not support capabilities. "
-                      "To enable setuid to root run: sudo chown root %s; sudo chmod 4755 %s; "
+                      "To enable setuid to root run: sudo chown root:netdata %s; sudo chmod 4750 %s; "
               , uid, euid, argv[0], argv[0]
         );
 #endif

--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -3416,10 +3416,6 @@ static void parse_args(int argc, char **argv)
                     " without-files     enable / disable reporting files, sockets, pipes\n"
                     "                   (default is enabled)\n"
                     "\n"
-                    " NAME              read apps_NAME.conf instead of\n"
-                    "                   apps_groups.conf\n"
-                    "                   (default NAME=groups)\n"
-                    "\n"
                     " version or -v or -V print program version and exit\n"
                     "\n"
                     , VERSION

--- a/src/cgroup-network.c
+++ b/src/cgroup-network.c
@@ -39,8 +39,10 @@ struct iface {
 };
 
 unsigned int read_iface_iflink(const char *prefix, const char *iface) {
+    if(!prefix) prefix = "";
+
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/sys/class/net/%s/iflink", prefix?prefix:"", iface);
+    snprintfz(filename, FILENAME_MAX, "%s/sys/class/net/%s/iflink", prefix, iface);
 
     unsigned long long iflink = 0;
     int ret = read_single_number_file(filename, &iflink);
@@ -50,8 +52,10 @@ unsigned int read_iface_iflink(const char *prefix, const char *iface) {
 }
 
 unsigned int read_iface_ifindex(const char *prefix, const char *iface) {
+    if(!prefix) prefix = "";
+
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/sys/class/net/%s/ifindex", prefix?prefix:"", iface);
+    snprintfz(filename, FILENAME_MAX, "%s/sys/class/net/%s/ifindex", prefix, iface);
 
     unsigned long long ifindex = 0;
     int ret = read_single_number_file(filename, &ifindex);
@@ -61,10 +65,12 @@ unsigned int read_iface_ifindex(const char *prefix, const char *iface) {
 }
 
 struct iface *read_proc_net_dev(const char *prefix) {
+    if(!prefix) prefix = "";
+
     procfile *ff = NULL;
     char filename[FILENAME_MAX + 1];
 
-    snprintfz(filename, FILENAME_MAX, "%s%s", prefix?prefix:"", "/proc/net/dev");
+    snprintfz(filename, FILENAME_MAX, "%s%s", prefix, (*prefix)?"/proc/1/net/dev":"/proc/net/dev");
     ff = procfile_open(filename, " \t,:|", PROCFILE_FLAG_DEFAULT);
     if(unlikely(!ff)) {
         error("Cannot open file '%s'", filename);
@@ -161,12 +167,14 @@ static void continue_as_child(void) {
 }
 
 int proc_pid_fd(const char *prefix, const char *ns, pid_t pid) {
+    if(!prefix) prefix = "";
+
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/proc/%d/%s", prefix?prefix:"", (int)pid, ns);
-    int fd = open(filename, procfile_open_flags);
+    snprintfz(filename, FILENAME_MAX, "%s/proc/%d/%s", prefix, (int)pid, ns);
+    int fd = open(filename, O_RDONLY);
 
     if(fd == -1)
-        error("Cannot open file '%s'", filename);
+        error("Cannot open proc_pid_fd() file '%s'", filename);
 
     return fd;
 }
@@ -191,6 +199,8 @@ static struct ns {
 };
 
 int switch_namespace(const char *prefix, pid_t pid) {
+    if(!prefix) prefix = "";
+
 #ifdef HAVE_SETNS
 
     int i;
@@ -272,13 +282,13 @@ int switch_namespace(const char *prefix, pid_t pid) {
 pid_t read_pid_from_cgroup_file(const char *filename) {
     int fd = open(filename, procfile_open_flags);
     if(fd == -1) {
-        error("Cannot open file '%s'.", filename);
+        error("Cannot open pid_from_cgroup() file '%s'.", filename);
         return 0;
     }
 
     FILE *fp = fdopen(fd, "r");
     if(!fp) {
-        error("Cannot open file '%s'.", filename);
+        error("Cannot upgrade fd to fp for file '%s'.", filename);
         return 0;
     }
 
@@ -392,9 +402,8 @@ int send_devices(void) {
 
 void detect_veth_interfaces(pid_t pid) {
     struct iface *host, *cgroup, *h, *c;
-    const char *prefix = getenv("NETDATA_HOST_PREFIX");
 
-    host = read_proc_net_dev(prefix);
+    host = read_proc_net_dev(netdata_configured_host_prefix);
     if(!host) {
         errno = 0;
         error("cannot read host interface list.");
@@ -407,7 +416,7 @@ void detect_veth_interfaces(pid_t pid) {
         goto cleanup;
     }
 
-    if(switch_namespace(prefix, pid)) {
+    if(switch_namespace(netdata_configured_host_prefix, pid)) {
         errno = 0;
         error("cannot switch to the namespace of pid %u", (unsigned int) pid);
         goto cleanup;

--- a/src/cgroup-network.c
+++ b/src/cgroup-network.c
@@ -8,8 +8,6 @@
 #include <sched.h>
 #endif
 
-char *host_prefix = "";
-
 char environment_variable2[FILENAME_MAX + 50] = "";
 char *environment[] = {
         "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
@@ -592,18 +590,17 @@ int main(int argc, char **argv) {
     // ------------------------------------------------------------------------
     // make sure NETDATA_HOST_PREFIX is safe
 
-    host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(!host_prefix || !*host_prefix)
-        host_prefix = "";
+    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(verify_netdata_host_prefix() == -1) exit(1);
 
-    if(host_prefix[0] != '\0' && verify_path(host_prefix) == -1)
-        fatal("invalid NETDATA_HOST_PREFIX '%s'", host_prefix);
+    if(netdata_configured_host_prefix[0] != '\0' && verify_path(netdata_configured_host_prefix) == -1)
+        fatal("invalid NETDATA_HOST_PREFIX '%s'", netdata_configured_host_prefix);
 
     // ------------------------------------------------------------------------
     // build a safe environment for our script
 
     // the first environment variable is a fixed PATH=
-    snprintfz(environment_variable2, sizeof(environment_variable2) - 1, "NETDATA_HOST_PREFIX=%s", host_prefix);
+    snprintfz(environment_variable2, sizeof(environment_variable2) - 1, "NETDATA_HOST_PREFIX=%s", netdata_configured_host_prefix);
 
     // ------------------------------------------------------------------------
 

--- a/src/common.c
+++ b/src/common.c
@@ -1419,6 +1419,9 @@ int verify_netdata_host_prefix() {
     if(is_virtual_filesystem(path, &reason) == -1)
         goto failed;
 
+    if(netdata_configured_host_prefix && *netdata_configured_host_prefix)
+        info("Using host prefix directory '%s'", netdata_configured_host_prefix);
+
     return 0;
 
 failed:

--- a/src/common.c
+++ b/src/common.c
@@ -1361,6 +1361,8 @@ int recursively_delete_dir(const char *path, const char *reason) {
 }
 
 static int is_virtual_filesystem(const char *path, char **reason) {
+
+#ifdef __Linux__
     struct statfs stat;
     // stat.f_fsid.__val[0] is a file system id
     // stat.f_fsid.__val[1] is the inode
@@ -1376,6 +1378,7 @@ static int is_virtual_filesystem(const char *path, char **reason) {
         if(reason) *reason = "is not a virtual file system";
         return -1;
     }
+#endif
 
     return 0;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -1362,7 +1362,10 @@ int recursively_delete_dir(const char *path, const char *reason) {
 
 static int is_virtual_filesystem(const char *path, char **reason) {
 
-#ifdef __Linux__
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    (void)path;
+    (void)reason;
+#else
     struct statfs stat;
     // stat.f_fsid.__val[0] is a file system id
     // stat.f_fsid.__val[1] is the inode

--- a/src/common.h
+++ b/src/common.h
@@ -5,7 +5,6 @@
 #include <config.h>
 #endif
 
-
 // ----------------------------------------------------------------------------
 // system include files for all netdata C programs
 
@@ -76,6 +75,7 @@
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 #include <sys/statvfs.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
@@ -333,6 +333,7 @@ extern char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
 
 extern int processors;
 extern long get_system_cpus(void);
+extern int verify_netdata_host_prefix();
 
 extern pid_t pid_max;
 extern pid_t get_system_pid_max(void);

--- a/src/common.h
+++ b/src/common.h
@@ -74,9 +74,27 @@
 
 #include <sys/resource.h>
 #include <sys/socket.h>
+
+#ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
+#endif
+
+#ifdef HAVE_SYS_VFS_H
 #include <sys/vfs.h>
+#endif
+
+#ifdef HAVE_SYS_STATFS_H
+#include <sys/statfs.h>
+#endif
+
+#ifdef HAVE_SYS_MOUNT_H
+#include <sys/mount.h>
+#endif
+
+#ifdef HAVE_SYS_STATVFS_H
 #include <sys/statvfs.h>
+#endif
+
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/main.c
+++ b/src/main.c
@@ -480,6 +480,7 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
 
     netdata_configured_host_prefix = config_get(CONFIG_SECTION_GLOBAL, "host access prefix", "");
+    verify_netdata_host_prefix();
 
     // --------------------------------------------------------------------
     // get KSM settings

--- a/src/proc_net_dev.c
+++ b/src/proc_net_dev.c
@@ -452,7 +452,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/dev");
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, (*netdata_configured_host_prefix)?"/proc/1/net/dev":"/proc/net/dev");
         ff = procfile_open(config_get("plugin:proc:/proc/net/dev", "filename to monitor", filename), " \t,:|", PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) return 1;
     }

--- a/src/procfile.c
+++ b/src/procfile.c
@@ -7,6 +7,8 @@
 #define PFLINES_INCREASE_STEP 10
 #define PROCFILE_INCREMENT_BUFFER 512
 
+int procfile_open_flags = O_RDONLY;
+
 int procfile_adaptive_initial_allocation = 0;
 
 // if adaptive allocation is set, these store the
@@ -391,7 +393,7 @@ void procfile_set_open_close(procfile *ff, const char *open, const char *close) 
 procfile *procfile_open(const char *filename, const char *separators, uint32_t flags) {
     debug(D_PROCFILE, PF_PREFIX ": Opening file '%s'", filename);
 
-    int fd = open(filename, O_RDONLY, 0666);
+    int fd = open(filename, procfile_open_flags, 0666);
     if(unlikely(fd == -1)) {
         if(unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot open file '%s'", filename);
         return NULL;
@@ -427,7 +429,7 @@ procfile *procfile_reopen(procfile *ff, const char *filename, const char *separa
         close(ff->fd);
     }
 
-    ff->fd = open(filename, O_RDONLY, 0666);
+    ff->fd = open(filename, procfile_open_flags, 0666);
     if(unlikely(ff->fd == -1)) {
         procfile_close(ff);
         return NULL;

--- a/src/procfile.h
+++ b/src/procfile.h
@@ -103,6 +103,9 @@ extern char *procfile_filename(procfile *ff);
 
 // ----------------------------------------------------------------------------
 
+// set to the O_XXXX flags, to have procfile_open and procfile_reopen use them when opening proc files
+extern int procfile_open_flags;
+
 // set this to 1, to have procfile adapt its initial buffer allocation to the max allocation used so far
 extern int procfile_adaptive_initial_allocation;
 


### PR DESCRIPTION
This PR introduces the following changes:

1. apps.plugin no longer accepts the name of the config file as a parameter. It is always `apps_groups.conf`.

2. apps.plugin, cgroup-network and netdata itself now validate the host prefix given:

   - they make sure the path given exists
   - they call `statfs()` and verify the `f_fsid` member is set to zero (meaning virtual filesystem) for both directories `path/proc` and `path/sys`.

   If these checks fail, netdata ignores the host prefix (with an error logged), while apps.plugin and cgroup-network exit with failure.

3. apps.plugin and cgroup-network do not allow symlinks in files read from `/proc` and `/sys`.

@titpetric I would need your help to verify the second check works under docker. Can you help?
