### PR TITLE
Add a plugin for Spigot Minecraft server stats.

### DIFF
--- a/LICENSE-REDISTRIBUTED.md
+++ b/LICENSE-REDISTRIBUTED.md
@@ -192,3 +192,10 @@ connectivity is not available.
 
     Copyright (c) 2010-2015 Benjamin Peterson
     [MIT License](https://github.com/firehol/netdata/blob/master/python.d/python_modules/urllib3/packages/six.py)
+
+
+- [mcrcon](https://github.com/barneygale/MCRcon)
+
+    Copyright (C) 2015 Barnaby Gale
+    [MIT License](https://raw.githubusercontent.com/barneygale/MCRcon/master/COPYING.txt)
+

--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -68,6 +68,7 @@ dist_pythonconfig_DATA = \
     python.d/samba.conf \
     python.d/sensors.conf \
     python.d/springboot.conf \
+    python.d/spigotmc.conf \
     python.d/squid.conf \
     python.d/smartd_log.conf \
     python.d/tomcat.conf \

--- a/conf.d/python.d/spigotmc.conf
+++ b/conf.d/python.d/spigotmc.conf
@@ -1,0 +1,68 @@
+# netdata python.d.plugin configuration for spigotmc
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 60
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     retries: 60             # the JOB's number of restoration attempts
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# In addition to the above, spigotmc supports the following:
+#
+#     host: localhost         # The host to connect to.  Defaults to the local system.
+#     port: 25575             # THe port the remote console is listening on.
+#     password: ''            # The remote console password.  Most be set correctly.

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -55,6 +55,7 @@ dist_python_DATA = \
     retroshare.chart.py \
     samba.chart.py \
     sensors.chart.py \
+    spigotmc.chart.py \
     springboot.chart.py \
     squid.chart.py \
     smartd_log.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -2027,6 +2027,29 @@ Please join this discussion for help.
 
 ---
 
+# spigotmc
+
+This module does some really basic monitoring for Spigot Minecraft servers.
+
+It provides two charts, one tracking server-side ticks-per-second in
+1, 5 and 15 minute averages, and one tracking the number of currently
+active users.
+
+This is not compatible with Spigot plugins which change the format of
+the data returned by the `tps` or `list` console commands.
+
+### configuration
+
+```yaml
+host: localhost
+port: 25575
+password: pass
+```
+
+By default, a connection to port 25575 on the local system is attempted with an empty password.
+
+---
+
 # springboot
 
 This module will monitor one or more Java Spring-boot applications depending on configuration.

--- a/python.d/python_modules/third_party/mcrcon.py
+++ b/python.d/python_modules/third_party/mcrcon.py
@@ -1,0 +1,90 @@
+# Minecraft Remote Console module.
+#
+# Copyright (C) 2015 Barnaby Gale
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of the Software and its documentation and acknowledgment shall be
+# given in the documentation and software packages that this Software was
+# used.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import socket
+import select
+import struct
+import time
+
+
+class MCRconException(Exception):
+    pass
+
+
+class MCRcon(object):
+    socket = None
+
+    def connect(self, host, port, password):
+        if self.socket is not None:
+            raise MCRconException("Already connected")
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.connect((host, port))
+        self.send(3, password)
+
+    def disconnect(self):
+        if self.socket is None:
+            raise MCRconException("Already disconnected")
+        self.socket.close()
+        self.socket = None
+
+    def read(self, length):
+        data = b""
+        while len(data) < length:
+            data += self.socket.recv(length - len(data))
+        return data
+
+    def send(self, out_type, out_data):
+        if self.socket is None:
+            raise MCRconException("Must connect before sending data")
+
+        # Send a request packet
+        out_payload = struct.pack('<ii', 0, out_type) + out_data.encode('utf8') + b'\x00\x00'
+        out_length = struct.pack('<i', len(out_payload))
+        self.socket.send(out_length + out_payload)
+
+        # Read response packets
+        in_data = ""
+        while True:
+            # Read a packet
+            in_length, = struct.unpack('<i', self.read(4))
+            in_payload = self.read(in_length)
+            in_id, in_type = struct.unpack('<ii', in_payload[:8])
+            in_data_partial, in_padding = in_payload[8:-2], in_payload[-2:]
+
+            # Sanity checks
+            if in_padding != b'\x00\x00':
+                raise MCRconException("Incorrect padding")
+            if in_id == -1:
+                raise MCRconException("Login failed")
+
+            # Record the response
+            in_data += in_data_partial.decode('utf8')
+
+            # If there's nothing more to receive, return the response
+            if len(select.select([self.socket], [], [], 0)[0]) == 0:
+                return in_data
+
+    def command(self, command):
+        result = self.send(2, command)
+        time.sleep(0.003) # MC-72390 workaround
+        return result

--- a/python.d/spigotmc.chart.py
+++ b/python.d/spigotmc.chart.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Description: spigotmc netdata python.d module
+# Author: Austin S. Hemmelgarn (Ferroin)
+
+import socket
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from third_party import mcrcon
+
+PRECISION = 100
+
+ORDER = ['tps', 'users']
+
+CHARTS = {
+    'tps': {
+        'options': [None, 'Spigot Ticks Per Second', 'ticks', 'spigotmc', 'spigotmc.tps', 'line'],
+        'lines': [
+            ['tps1', '1 Minute Average', 'absolute', 1, PRECISION],
+            ['tps5', '5 Minute Average', 'absolute', 1, PRECISION],
+            ['tps15', '15 Minute Average', 'absolute', 1, PRECISION]
+        ]
+    },
+    'users': {
+        'options': [None, 'Minecraft Users', 'users', 'spigotmc', 'spigotmc.users', 'area'],
+        'lines': [
+            ['users', 'Users', 'absolute', 1, 1]
+        ]
+    }
+}
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.host = self.configuration.get('host', 'localhost')
+        self.port = self.configuration.get('port', 25575)
+        self.password = self.configuration.get('password', '')
+        self.console = mcrcon.MCRcon()
+
+    def check(self):
+        '''Check plugin configuration validity.
+
+           This really just makes sure we can connect and authenticate
+           correctly.'''
+        try:
+            self.console.connect(self.host, self.port, self.password)
+        except (mcrcon.MCRconException, socket.error):
+            return False
+        return True
+
+    def _get_data(self):
+        data = {}
+        try:
+            raw = self.console.command('tps')
+            # The above command returns a string that looks like this:
+            # '§6TPS from last 1m, 5m, 15m: §a19.99, §a19.99, §a19.99\n'
+            # The values we care about are the three numbers after the :
+            tmp = raw.split(':')[1].split(',')
+            data['tps1'] = float(tmp[0].lstrip()[2:]) * PRECISION
+            data['tps5'] = float(tmp[1].lstrip()[2:]) * PRECISION
+            data['tps15'] = float(tmp[2].lstrip().rstrip()[2:]) * PRECISION
+        except (mcrcon.MCRconException, socket.error):
+            data['tps1'] = None
+            data['tps5'] = None
+            data['tps15'] = None
+            self.error('Unable to fetch TPS values.')
+        try:
+            raw = self.console.command('list')
+            # The above command returns a string that looks like this:
+            # 'There are 0/20 players online:'
+            # We care about the first number here.
+            data['users'] = int(raw.split()[2].split('/')[0])
+        except (mcrcon.MCRconException, socket.error):
+            data['users'] = None
+            self.error('Unable to fetch user counts.')
+        return data

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -359,6 +359,12 @@ netdataDashboard.menu = {
         title: 'ntpd',
         icon: '<i class="fas fa-clock"></i>',
         info: 'Provides statistics for the internal variables of the Network Time Protocol daemon <b><a href="http://www.ntp.org/">ntpd</a></b> and optional including the configured peers (if enabled in the module configuration). The module presents the performance metrics as shown by <b><a href="http://doc.ntp.org/current-stable/ntpq.html">ntpq</a></b> (the standard NTP query program) using NTP mode 6 UDP packets to communicate with the NTP server.'
+    },
+
+    'spigotmc': {
+        title: 'Spigot MC',
+        icon: '<i class="fas fa-eye"></i>',
+        info: 'Provides basic performance statistics for the <b><a href=""https://www.spigotmc.org/">Spigot Minecraft</a></b> server.'
     }
 };
 
@@ -2064,6 +2070,14 @@ netdataDashboard.context = {
 
     'ntpd.peer_precision': {
         height: 0.2
+    },
+
+    'spigotmc.tps': {
+        info: 'The running 1, 5, and 15 minute average number of server ticks per second.  An idealized server will show 20.0 for all values, but in practice this almost never happens.  Typical servers should show approximately 19.98-20.0 here.  Lower values indicate progressively more server-side lag (and thus that you need better hardware for your server or a lower user limit).  For every 0.05 ticks below 20, redstone clocks will lag behind by approximately 0.25%.  Values below approximately 19.50 may interfere with complex free-running redstone circuits and will noticeably slow down growth.'
+    },
+
+    'spigotmc.users': {
+        info: 'THe number of currently connect users on the monitored Spigot server.'
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
This adds a plugin which tracks rudimentary stats from a Spigot
Minecraft server using the remote console protocol.  It provides charts
for the number of currently connected users, as well as the number of
ticks the server is processing each second (which correlates strongly
with server-side lag).

The plugin makes use of a Python implementation of the remote console
protocol originally written by Barnaby Gale and released under an MIT
license.  This bundles the module with netdata as it's tiny (less than
100 lines of code) and is not packaged in any distributions I know of.

The default settings are to connect to the local system on the standard
remote console port (25575) without a password, which allows for trivial
setup (users just need to set `enable-rcon` to true in the
server.properties file for their Spigot server).

Currently, this plugin uses the SimpleService framework instead of the
SocketService plugin, which actually makes implementation marginally
simpler.  In theory, it could probably be re-implemented using the
SocketService, but I very much doubt it would be any more efficient than
it is now (we already keep the socket open and connected persistently so
we don't have to re-authenticate, and we make the protocol synchronous
so it's trivial to determine that we've recieved everything because a
read returns no new data).

Example image from an idle server:
![image](https://user-images.githubusercontent.com/905151/39379249-b07db06a-4a28-11e8-8864-91ff8419bb00.png)

The 'Minecraft Users' chart is pretty self explanatory, it literally just tracks how many users are online (which requires far more text processing than it should).

The 'SpigotMC Ticks Per Second' chart takes a bit more explanation.  Minecraft natively processes events at a rate of 20Hz.  Each cycle of processing is called a 'tick'.  Heavily loaded servers may however take longer than the requisite 50ms to process one 'tick', in which case you get the in-game equivalent of time-dilation (the server never drops ticks to catch up, it just starts processing the next one immediately if the previous tick took more than 50ms, so in-game time runs slower than real-time).  Spigot provides a command for retrieving running averages of how many ticks were processed in a second over the past 1, 5 and 15 minutes.  Lower values on this chart indicate higher levels of lag in the server itself (usually because too many things are happening at once for it to keep up).  Typical values for a normal server that has sufficiently good hardware are between 20.00 and 19.95.

Lightly tested on my own (mostly unutilized) server.