### PR TITLE
Add a plugin for the Unbound DNS server.

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -72,6 +72,7 @@ dist_pythonconfig_DATA = \
     python.d/smartd_log.conf \
     python.d/tomcat.conf \
     python.d/traefik.conf \
+    python.d/unbound.conf \
     python.d/varnish.conf \
     python.d/web_log.conf \
     $(NULL)

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -75,5 +75,6 @@ nginx_log: no
 # squid: yes
 # springboot: yes
 # tomcat: yes
+unbound: no
 # varnish: yes
 # web_log: yes

--- a/conf.d/python.d/unbound.conf
+++ b/conf.d/python.d/unbound.conf
@@ -1,0 +1,86 @@
+# netdata python.d.plugin configuration for unbound
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_everye
+# and only if the module has collected values in the past.
+# retries: 60
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     retries: 60             # the JOB's number of restoration attempts
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, unbound also supports the following:
+#
+#    host: localhost          # The host to connect to.
+#    port: 8953               # WHat port to use (defaults to 8953)
+#    socket: /path/to/socket  # A path to a UNIX socket to use instead
+#                             # of a TCP connection
+#    ssl_key: /path/to/key    # The keyfile to use for authentication
+#    ssl_cert: /path/to/key   # The certificate to use for authentication
+#    extended: false          @ Whether to collect extended stats or not
+#
+# In addition to the above, you can set the following to try and
+# auto-detect settings based on the unbound configuration:
+#
+#    ubconf: /etc/unbound/unbound.conf
+#
+# Note that the SSL key and certificate need to be readable by the user
+# unbound runs as if you're using the regular control interface.
+# If you're using a UNIX socket, that has to be readable by the netdata user.
+
+# The following should work for most users if they have unbound configured
+# correctly.
+local:
+  ubconf: /etc/unbound/unbound.conf

--- a/conf.d/python.d/unbound.conf
+++ b/conf.d/python.d/unbound.conf
@@ -67,8 +67,8 @@
 #    port: 8953               # WHat port to use (defaults to 8953)
 #    socket: /path/to/socket  # A path to a UNIX socket to use instead
 #                             # of a TCP connection
-#    ssl_key: /path/to/key    # The keyfile to use for authentication
-#    ssl_cert: /path/to/key   # The certificate to use for authentication
+#    tls_key_file: /path/to/key    # The key file to use for authentication
+#    tls_cert_file: /path/to/key   # The certificate to use for authentication
 #    extended: false          @ Whether to collect extended stats or not
 #
 # In addition to the above, you can set the following to try and

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -60,6 +60,7 @@ dist_python_DATA = \
     smartd_log.chart.py \
     tomcat.chart.py \
     traefik.chart.py \
+    unbound.chart.py \
     varnish.chart.py \
     web_log.chart.py \
     $(NULL)

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -2227,6 +2227,77 @@ Without configuration, module attempts to connect to `http://localhost:8080/heal
 
 ---
 
+# Unbound
+
+Monitoring uses the remote control interface to fetch statistics.
+
+Provides the following charts:
+
+1. **Queries Processed**
+ * Ratelimited
+ * Cache Misses
+ * Cache Hits
+ * Expired
+ * Prefetched
+ * Recursive
+
+2. **Request List**
+ * Average Size
+ * Max Size
+ * Overwritten Requests
+ * Overruns
+ * Current Size
+ * User Requests
+
+3. **Recursion Timings**
+ * Average recursion processing time
+ * Median recursion processing time
+
+If extended stats are enabled, also provides:
+
+4. **Cache Sizes**
+ * Message Cache
+ * RRset Cache
+ * Infra Cache
+ * DNSSEC Key Cache
+ * DNSCrypt Shared Secret Cache
+ * DNSCrypt Nonce Cache
+
+### configuration
+
+Unbound must be manually configured to enable the remote-control protocol.
+Check the Unbound documentation for info on how to do this.  Additionally,
+if you want to take advantage of the autodetection this plugin offers,
+you will need to make sure your `unbound.conf` file only uses spaces for
+indentation (the default config shipped by most distributions uses tabs
+instead of spaces).
+
+Once you have the Unbound control protocol enabled, you need to make sure
+that either the certificate and key are readable by Netdata (if you're
+using the regular control interface), or that the socket is accessible
+to Netdata (if you're using a UNIX socket for the contorl interface).
+
+By default, for the local system, every thing can be auto-detected
+assumign Unbound is configured correctly and has been told to listen
+on the loopback interface or a UNIX socket.  This is done by looking
+up info in the Unbound config file specified by the `ubconf` key.
+
+To enable extended stats for a given job, add `extended: yes` to the
+definition.
+
+A basic local configuration with extended statistics looks like this:
+
+```yaml
+local:
+    ubconf: /etc/unbound/unbound.conf
+    extended: yes
+```
+
+While it's a bit more complicated to set up correctly, it is recommended
+that you use a UNIX socket as it provides far better performance.
+
+---
+
 # varnish cache
 
 Module uses the `varnishstat` command to provide varnish cache statistics.

--- a/python.d/python_modules/bases/FrameworkServices/SocketService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SocketService.py
@@ -281,8 +281,8 @@ class SocketService(SimpleService):
                 self.debug('No SSL preference specified, not using SSL.')
 
             if self.ssl and _SSL_SUPPORT:
-                self.key = str(self.configuration.get('ssl_key'))
-                self.cert = str(self.configuration.get('ssl_cert'))
+                self.key = self.configuration.get('ssl_key')
+                self.cert = self.configuration.get('ssl_cert')
                 if not self.cert:
                     # If there's not a valid certificate, clear the key too.
                     self.debug('No valid SSL client certificate configuration found.')

--- a/python.d/python_modules/bases/FrameworkServices/SocketService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SocketService.py
@@ -74,7 +74,7 @@ class SocketService(SimpleService):
                                              certfile=self.cert,
                                              server_side=False,
                                              cert_reqs=ssl.CERT_NONE)
-            except (socket.error, ssl.TLSError) as error:
+            except (socket.error, ssl.SSLError) as error:
                 self.error('Failed to wrap socket.')
                 self._disconnect()
                 self.__socket_config = None
@@ -83,7 +83,7 @@ class SocketService(SimpleService):
         try:
             self.debug('connecting socket to "{address}", port {port}'.format(address=sa[0], port=sa[1]))
             self._sock.connect(sa)
-        except (socket.error, ssl.TLSError) as error:
+        except (socket.error, ssl.SSLError) as error:
             self.error('Failed to connect to "{address}", port {port}, error: {error}'.format(address=sa[0],
                                                                                               port=sa[1],
                                                                                               error=error))

--- a/python.d/python_modules/bases/FrameworkServices/SocketService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SocketService.py
@@ -6,7 +6,7 @@ import socket
 
 try:
     import ssl
-except:
+except ImportError:
     _SSL_SUPPORT = False
 else:
     _SSL_SUPPORT = True

--- a/python.d/python_modules/bases/FrameworkServices/SocketService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SocketService.py
@@ -273,20 +273,24 @@ class SocketService(SimpleService):
             except (KeyError, TypeError):
                 self.debug('No port specified. Using: "{0}"'.format(self.port))
 
-            if _SSL_SUPPORT:
-                try:
-                    self.ssl = bool(self.configuration['ssl'])
-                except (KeyError, TypeError):
-                    self.debug('No SSL preference specified, not using SSL.')
+            try:
+                self.ssl = bool(self.configuration['ssl'])
+                if self.ssl and not _SSL_SUPPORT:
+                    self.warning('SSL requested but not SSL module found, disabling SSL support.')
                     self.ssl = False
-                else:
-                    try:
-                        self.key = str(self.configuration['ssl_key'])
-                        self.cert = str(self.configuration['ssl_cert'])
-                    except (KeyError, TypeError):
-                        self.debug('No SSL client certificate configuration found.')
-                        self.key = None
-                        self.cert = None
+            except (KeyError, TypeError):
+                if _SSL_SUPPORT:
+                    self.debug('No SSL preference specified, not using SSL.')
+                self.ssl = False
+
+            if self.ssl and _SSL_SUPPORT:
+                try:
+                    self.key = str(self.configuration['ssl_key'])
+                    self.cert = str(self.configuration['ssl_cert'])
+                except (KeyError, TypeError):
+                    self.debug('No SSL client certificate configuration found.')
+                    self.key = None
+                    self.cert = None
 
         try:
             self.request = str(self.configuration['request'])

--- a/python.d/python_modules/bases/FrameworkServices/SocketService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SocketService.py
@@ -292,7 +292,7 @@ class SocketService(SimpleService):
                     # If a key isn't listed, the config may still be
                     # valid, because there may be a key attached to the
                     # certificate.
-                    self.notice('No TLS client key specified, assuming it\'s attached to the certificate.')
+                    self.info('No TLS client key specified, assuming it\'s attached to the certificate.')
                     self.key = None
 
         try:

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -130,8 +130,7 @@ class Service(SocketService):
                     self.cert = self.cert or conf['remote-control'].get('control-cert-file')
                     self.port = self.port or conf['remote-control'].get('control-port')
                 else:
-                    if not self.unix_socket:
-                        self.unix_socket = conf['remote-control'].get('control-interface')
+                    self.unix_socket = self.unix_socket or conf['remote-control'].get('control-interface')
         else:
             self.debug('Unbound configuration not found.')
         if not self.key:

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -89,10 +89,10 @@ STAT_MAP = {
 
 class Service(SocketService):
     def __init__(self, configuration=None, name=None):
-        # The unbound control protocol is always SSL encapsulated
-        # unless it's used over a UNIX socket, so enable SSL _before_
+        # The unbound control protocol is always TLS encapsulated
+        # unless it's used over a UNIX socket, so enable TLS _before_
         # doing the normal SocketService initialization.
-        configuration['ssl'] = True
+        configuration['tls'] = True
         self.port = 8935
         SocketService.__init__(self, configuration, name)
         self.ext = self.configuration.get('extended', None)

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -126,12 +126,9 @@ class Service(SocketService):
                     self.ext = conf['server']['extended-statistics']
             if 'remote-control' in conf:
                 if conf['remote-control'].get('control-use-cert', False):
-                    if not self.key:
-                        self.key = conf['remote-control'].get('control-key-file')
-                    if not self.cert:
-                        self.cert = conf['remote-control'].get('control-cert-file')
-                    if not self.port:
-                        self.port = conf['remote-control'].get('control-port')
+                    self.key = self.key or conf['remote-control'].get('control-key-file')
+                    self.cert = self.cert or conf['remote-control'].get('control-cert-file')
+                    self.port = self.port or conf['remote-control'].get('control-port')
                 else:
                     if not self.unix_socket:
                         self.unix_socket = conf['remote-control'].get('control-interface')

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -4,6 +4,8 @@
 
 import os
 
+from copy import deepcopy
+
 from bases.FrameworkServices.SocketService import SocketService
 from bases.loaders import YamlOrderedLoader
 
@@ -95,8 +97,8 @@ class Service(SocketService):
         SocketService.__init__(self, configuration, name)
         self.ext = self.configuration.get('extended', None)
         self.ubconf = self.configuration.get('ubconf', None)
-        self.order = ORDER
-        self.definitions = CHARTS
+        self.order = deepcopy(ORDER)
+        self.definitions = deepcopy(CHARTS)
         self.request = 'UBCT1 stats\n'
         self._parse_config()
         self._auto_config()

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# Description: unbound netdata python.d module
+# Author: Austin S. Hemmelgarn (Ferroin)
+
+import os
+import yaml
+
+from base.FrameworkServices.SocketService import SocketService
+
+
+ORDER = ['queries', 'reqlist', 'recursion']
+
+CHARTS = {
+    'queries': {
+        'options': [None, 'Queries Processed', 'queries', 'Unbound', 'unbound.queries', 'line'],
+        'lines': [
+            ['ratelimit', 'Ratelimited', 'absolute', 1, 1],
+            ['cachemiss', 'Cache Miss', 'absolute', 1, 1],
+            ['cachehit', 'Cache Hit', 'absolute', 1, 1],
+            ['expired', 'Expired', 'absolute', 1, 1],
+            ['prefetch', 'Prefetched', 'absolute', 1, 1],
+            ['recursive', 'Recursive', 'absolute', 1, 1]
+        ]
+    },
+    'reqlist': {
+        'options': [None, 'Request List', 'items', 'Unbound', 'unbound.reqlist', 'line'],
+        'lines': [
+            ['reqlist_avg', 'Average Size', 'absolute', 1, 1],
+            ['reqlist_max', 'Maximum Size', 'absolute', 1, 1],
+            ['reqlist_overwritten', 'Overwritten Requests', 'absolute', 1, 1],
+            ['reqlist_exceeded', 'Overruns', 'absolute', 1, 1],
+            ['reqlist_current', 'Current Size', 'absolute', 1, 1],
+            ['reqlist_user', 'User Requests', 'absolute', 1, 1]
+        ]
+    },
+    'recursion': {
+        'options': [None, 'Recursion Timings', 'seconds', 'Unbound', 'unbound.recursion', 'line'],
+        'lines': [
+            ['recursive_avg', 'Average', 'absolute', 1, 1],
+            ['recursive_med', 'Median', 'absolute', 1, 1]
+        ]
+    }
+}
+
+# These get added too if we are told to use extended stats.
+EXTENDED_ORDER = ['cache']
+
+EXTENDED_CHARTS = {
+    'cache': {
+        'options': [None, 'Cache Sizes', 'items', 'Unbound', 'unbound.cache', 'line'],
+        'lines': [
+            ['cache_message', 'Message Cache', 'absolute', 1, 1],
+            ['cache_rrset', 'RRSet Cache', 'absolute', 1, 1],
+            ['cache_infra', 'Infra Cache', 'absolute', 1, 1],
+            ['cache_key', 'DNSSEC Key Cache', 'absolute', 1, 1],
+            ['cache_dnscss', 'DNSCrypt Shared Secret Cache', 'absolute', 1, 1],
+            ['cache_dnscn', 'DNSCrypt Nonce Cache', 'absolute', 1, 1]
+        ]
+    }
+}
+
+# This maps the Unbound stat names to our names.
+STAT_MAP = {
+    'total.num.queries_ip_ratelimited': 'ratelimit',
+    'total.num.cachehits': 'cachehit',
+    'total.num.cachemiss': 'cachemiss',
+    'total.num.zero_ttl': 'expired',
+    'total.num.prefetch': 'prefetch',
+    'total.num.recursivereplies': 'recursive',
+    'total.requestlist.avg': 'reqlist_avg',
+    'total.requestlist.max': 'reqlist_max',
+    'total.requestlist.overwritten': 'reqlist_overwritten',
+    'total.requestlist.exceeded': 'reqlist_exceeded',
+    'total.requestlist.current.all': 'reqlist_current',
+    'total.requestlist.current.user': 'reqlist_user',
+    'total.recursion.time.avg': 'recursive_avg',
+    'total.recursion.time.median': 'recursive_med',
+    'msg.cache.count': 'cache_message',
+    'rrset.cache.count': 'cache_rrset',
+    'infra.cache.count': 'cache_infra',
+    'key.cache.count': 'cache_key',
+    'dnscrypt_shared_secret.cache.count': 'cache_dnscss',
+    'dnscrypt_nonce.cache.count': 'cache_dnscn'
+}
+
+
+class Service(SocketService):
+    def __init__(self, configuration=None, name=None):
+        # The unbound control protocol is always SSL encapsulated
+        # unless it's used over a UNIX socket, so enable SSL _before_
+        # doing the normal SocketService initialization.
+        configuration['ssl'] = True
+        self.port = 8935
+        SocketService.__init__(self, configuration, name)
+        self.ext = self.configuration.get('extended', None)
+        self.ubconf = self.configuration.get('ubconf', '/etc/unbound/unbound.conf')
+        self.order = ORDER
+        self.definitions = CHARTS
+        if self.ext:
+            self.order = self.order + EXTENDED_ORDER
+            self.definitions.update(EXTENDED_CHARTS)
+        self.request = 'UBCT1 stats\n'
+        self._parse_config()
+        self.debug('Unbound config: {0}'.format(self.ubconf)
+        if os.access(self.ubconf, os.R_OK):
+            with open(self.ubconf, 'r') as ubconf:
+                try:
+                    conf = yaml.load(ubconf)
+                except yaml.YAMLError:
+                    conf = dict()
+            if self.ext is None:
+                if 'extended-statistics' in conf['server'].keys():
+                    self.ext = conf['server']['extended-statistics']
+            if 'remote-control' in conf.keys():
+                if conf['remote-control'].get('control-use-cert', False):
+                    if not self.key:
+                        self.key = conf['remote-control'].get('control-key-file', '/etc/unbound/unbound_control.key')
+                    if not self.cert:
+                        self.cert = conf['remote-control'].get('control-cert-file', '/etc/unbound/unbound_control.pem')
+                    self.port = conf['remote-control'].get('control-port', 8953)
+                else:
+                    if not self.unix_socket:
+                        self.unix_socket = conf['remote-control'].get('control-interface')
+        self.debug('Extended stats: {0}'.format(self.ext))
+        if self.unix_socket:
+            self.debug('Using unix socket: {0}'.format(self.unix_socket))
+            for key in self.definitions.keys():
+                self.definitions[key]['options'][4] = 'Local'
+        else:
+            self.debug('Connecting to: {0}:{1}'.format(self.host, self.port))
+            self.debug('Using key: {0}'.format(self.key))
+            self.debug('Using certificate: {0}'.format(self.cert))
+            for key in self.definitions.keys():
+                self.definitions[key]['options'][4] = self.host
+
+
+    def check(self):
+        # We need to check that auth works, otherwise there's no point.
+        self._connect()
+        self._disconnect()
+        return bool(self._sock)
+
+    def _check_raw_data(self, data):
+        # The server will close the connection when it's done sending
+        # data, so just keep looping until that happens.
+        return False
+
+    def _get_data(self):
+        raw = self._get_raw_data()
+        data = dict()
+        tmp = dict()
+        for line in raw.splitlines():
+            stat = line.split('=')
+            tmp[stat[0]] = stat[1]
+        for item in STAT_MAP.keys():
+            if item in tmp.keys():
+                data[STAT_MAP[item]] = float(tmp[item])
+        return data

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -97,14 +97,13 @@ class Service(SocketService):
         self.ubconf = self.configuration.get('ubconf', None)
         self.order = ORDER
         self.definitions = CHARTS
+        self.request = 'UBCT1 stats\n'
+        self._parse_config()
+        self._auto_config()
+        self.debug('Extended stats: {0}'.format(self.ext))
         if self.ext:
             self.order = self.order + EXTENDED_ORDER
             self.definitions.update(EXTENDED_CHARTS)
-        self.request = 'UBCT1 stats\n'
-        self._parse_config()
-        self.debug('Unbound config: {0}'.format(self.ubconf))
-        self._auto_config()
-        self.debug('Extended stats: {0}'.format(self.ext))
         if self.unix_socket:
             self.debug('Using unix socket: {0}'.format(self.unix_socket))
             for key in self.definitions.keys():
@@ -118,6 +117,7 @@ class Service(SocketService):
 
     def _auto_config(self):
         if self.ubconf and os.access(self.ubconf, os.R_OK):
+            self.debug('Unbound config: {0}'.format(self.ubconf))
             conf = YamlOrderedLoader.load_config_from_file(self.ubconf)[0]
             if self.ext is None:
                 if 'extended-statistics' in conf['server'].keys():
@@ -133,6 +133,8 @@ class Service(SocketService):
                 else:
                     if not self.unix_socket:
                         self.unix_socket = conf['remote-control'].get('control-interface')
+        else:
+            self.debug('Unbound configuration not found.')
         if not self.key:
             self.key = '/etc/unbound/unbound_control.key'
         if not self.cert:

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -148,7 +148,8 @@ class Service(SocketService):
         self._disconnect()
         return result
 
-    def _check_raw_data(self, data):
+    @staticmethod
+    def _check_raw_data(data):
         # The server will close the connection when it's done sending
         # data, so just keep looping until that happens.
         return False

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -101,7 +101,7 @@ class Service(SocketService):
             self.definitions.update(EXTENDED_CHARTS)
         self.request = 'UBCT1 stats\n'
         self._parse_config()
-        self.debug('Unbound config: {0}'.format(self.ubconf)
+        self.debug('Unbound config: {0}'.format(self.ubconf))
         if os.access(self.ubconf, os.R_OK):
             with open(self.ubconf, 'r') as ubconf:
                 try:

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -106,13 +106,13 @@ class Service(SocketService):
             self.definitions.update(EXTENDED_CHARTS)
         if self.unix_socket:
             self.debug('Using unix socket: {0}'.format(self.unix_socket))
-            for key in self.definitions.keys():
+            for key in self.definitions:
                 self.definitions[key]['options'][4] = 'Local'
         else:
             self.debug('Connecting to: {0}:{1}'.format(self.host, self.port))
             self.debug('Using key: {0}'.format(self.key))
             self.debug('Using certificate: {0}'.format(self.cert))
-            for key in self.definitions.keys():
+            for key in self.definitions:
                 self.definitions[key]['options'][4] = self.host
 
     def _auto_config(self):
@@ -120,9 +120,9 @@ class Service(SocketService):
             self.debug('Unbound config: {0}'.format(self.ubconf))
             conf = YamlOrderedLoader.load_config_from_file(self.ubconf)[0]
             if self.ext is None:
-                if 'extended-statistics' in conf['server'].keys():
+                if 'extended-statistics' in conf['server']:
                     self.ext = conf['server']['extended-statistics']
-            if 'remote-control' in conf.keys():
+            if 'remote-control' in conf:
                 if conf['remote-control'].get('control-use-cert', False):
                     if not self.key:
                         self.key = conf['remote-control'].get('control-key-file')
@@ -161,7 +161,7 @@ class Service(SocketService):
         for line in raw.splitlines():
             stat = line.split('=')
             tmp[stat[0]] = stat[1]
-        for item in STAT_MAP.keys():
-            if item in tmp.keys():
+        for item in STAT_MAP:
+            if item in tmp:
                 data[STAT_MAP[item][0]] = float(tmp[item]) * STAT_MAP[item][1]
         return data

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -359,6 +359,12 @@ netdataDashboard.menu = {
         title: 'ntpd',
         icon: '<i class="fas fa-clock"></i>',
         info: 'Provides statistics for the internal variables of the Network Time Protocol daemon <b><a href="http://www.ntp.org/">ntpd</a></b> and optional including the configured peers (if enabled in the module configuration). The module presents the performance metrics as shown by <b><a href="http://doc.ntp.org/current-stable/ntpq.html">ntpq</a></b> (the standard NTP query program) using NTP mode 6 UDP packets to communicate with the NTP server.'
+    },
+
+    'unbound' {
+        title: 'Unbound',
+        icon: '<i class="fas fa-tag"></i>',
+        info: undefined
     }
 };
 
@@ -2064,6 +2070,22 @@ netdataDashboard.context = {
 
     'ntpd.peer_precision': {
         height: 0.2
+    },
+
+    'unbound.queries': {
+        info: 'Shows the number of queries being processed of each type.  Note that <code>Recursive</code> queries are also accounted as cache misses.'
+    },
+
+    'unbound.reqlist': {
+        info: 'Shows various stats about Unbound\'s internal request list.'
+    },
+
+    'unbound.recursion': {
+        info: 'Average and median time to complete recursive name resolution.'
+    },
+
+    'unbound.cache': {
+        info: 'The number of items in each of the various caches.'
     }
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -361,7 +361,7 @@ netdataDashboard.menu = {
         info: 'Provides statistics for the internal variables of the Network Time Protocol daemon <b><a href="http://www.ntp.org/">ntpd</a></b> and optional including the configured peers (if enabled in the module configuration). The module presents the performance metrics as shown by <b><a href="http://doc.ntp.org/current-stable/ntpq.html">ntpq</a></b> (the standard NTP query program) using NTP mode 6 UDP packets to communicate with the NTP server.'
     },
 
-    'unbound' {
+    'unbound': {
         title: 'Unbound',
         icon: '<i class="fas fa-tag"></i>',
         info: undefined


### PR DESCRIPTION
Unbound is a caching, recursive DNS resolver primarily used as a local DNS cache for Linux client systems, and to provide basic DNS service for a local network from a router.  It provides a bunch of statistics over it's remote control interface for tools like Netdata to collect.

This PR first adds rudimentary TLS encapsulation and client authentication support to `SocketService`, which is needed to allow TCP based communication with the Unbound remote control interface (they insist on using TLS with an X.509 client certificate for authentication if you're not using a UNIX socket for the connection).  This adds a conditional dependency on the `ssl` module from the Python standard library, if this module isn't found (and it may not be on some embedded systems where space is at a premium, because it depends on a big library and is pretty big itself) then there just won't be any TLS support, but everything else will continue to work as normal.  TLS support comes with 3 new keys for the `SocketService` configuration:

* `ssl`: A simple boolean toggle controlling whether to use SSL/TLS or not.
* `ssl_key`: Specifies the path to an X.509 private key to use for client authentication.
* `ssl_cert`: Specifies the path to an X.509 certificate to be used for client authentication.

In the current default case of not using TLS support, this adds about 1.5-2.5ms to the initialization time of plugins using `SocketService` on most of my systems.  I've verified that this works correctly (that is, just like the existing `SocketService` module on systems that don't have the Python `ssl` module, and that existing modules work the same as before (other than the slightly higher initialization time mentioned above).

The plugin is then added by the second commit.  It currently collects the following stats:

* Query rates, including cache hit and miss rates, how many were dropped due to rate limiting, how many served expired data still in the cache, how many times items were pre-fetched into the cache and how many triggered upstream recursion.
* Various stats about the internal request processing list, including the average and maximum size over the previous collection period, the current number of requests in the list, how many are user requests (as opposed to internal requests such as pre-fetching requests), and how many requests had to be dropped because the list was full (which should obviously be zero most of the time).
* Average and median (50th percentile) processing times for upstream recursive requests.
* Optionally (if you turn on extended stats in both Unbound and the plugin), how many items are in each of the caches.

Unbound actually provides more stats than what this plugin collects, but most of them are largely only of interest to developers or individuals who are debugging low-level issues with Unbound's internals (things like exact memory usage of the various components, or per-thread stats).  Most of these (other than the per-thread stats) can be added pretty easily if desired, but I didn't include them here because I have no use for them.

The plugin supports auto-detection of most of the required settings when connecting to the local host if you tell it where the config for Unbound is, although this is dependent on `unbound.conf` being parseable as YAML (technically, it _is_YAML file, except Unbound allows tabs for indentation, and the upstream config example (and therefore almost every distribution config) use tabs).

The plugin itself is disabled by default as it requires some non-trivial changes from the default Unbound configuration to set up and enable the remote control interface, as well as some mucking about with permissions to get it all working correctly (although the permissions changes can be avoided by running Netdata either as root or as the same user as the Unbound server process).  

Example graphs from one of my systems (which has very little DNS load and as a result doesn't show most of the stats (because they're all just zero)):
![image](https://user-images.githubusercontent.com/905151/39487804-5747b9a4-4d4e-11e8-9346-429d348609cd.png)

Lightly tested on half a dozen of my own systems using a variety of remote-control interface configurations.