### PR TITLE
Update .gitignore to ignore `.swp` files created by Vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 config.h.in
 Makefile.in
 *~
+.*.swp
 *.old
 *.log
 *.pyc


### PR DESCRIPTION
Discovered that this wasn't already the case when I almost accidentally committed such a file while working on PR #3670.

Vim (and some other Vi derivatives) create these files while editing other files, they can safely be ignored.