### PR TITLE
do not set TCP_NODELAY on unix domain sockets and do not log errors about optional setsockopt() calls

### DIFF
--- a/src/web_client.h
+++ b/src/web_client.h
@@ -70,6 +70,7 @@ typedef enum web_client_flags {
 #define web_client_set_tcp(w) web_client_flag_set(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 #define web_client_set_unix(w) web_client_flag_set(w, WEB_CLIENT_FLAG_UNIX_CLIENT)
 #define web_client_check_unix(w) web_client_flag_check(w, WEB_CLIENT_FLAG_UNIX_CLIENT)
+#define web_client_check_tcp(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 
 #define web_client_is_corkable(w) web_client_flag_check(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -335,12 +335,13 @@ static void web_client_release(struct web_client *w) {
 
 static void web_client_initialize_connection(struct web_client *w) {
     int flag = 1;
-    if(setsockopt(w->ifd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: failed to enable TCP_NODELAY on socket fd %d.", w->id, w->ifd);
+
+    if(unlikely(web_client_check_tcp(w) && setsockopt(w->ifd, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int)) != 0))
+        debug(D_WEB_CLIENT, "%llu: failed to enable TCP_NODELAY on socket fd %d.", w->id, w->ifd);
 
     flag = 1;
-    if(setsockopt(w->ifd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int)) != 0)
-        error("%llu: failed to enable SO_KEEPALIVE on socket fd %d.", w->id, w->ifd);
+    if(unlikely(setsockopt(w->ifd, SOL_SOCKET, SO_KEEPALIVE, (char *) &flag, sizeof(int)) != 0))
+        debug(D_WEB_CLIENT, "%llu: failed to enable SO_KEEPALIVE on socket fd %d.", w->id, w->ifd);
 
     web_client_update_acl_matches(w);
 


### PR DESCRIPTION
fixes #3682