### PR TITLE
Add support for arbitrary date formats for netdata alerts.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -44,6 +44,23 @@
 
 
 #------------------------------------------------------------------------------
+# date handling
+#
+# You can configure netdata alerts to send dates in any format you want.
+# This uses standard `date` command format strings.  See `man date` for
+# more info on what you can put in here.  Note that this has to start with a '+', otherwise it won't work.
+#
+# For ISO 8601 dates, use '+%FT%T%z'
+# For RFC 5322 dates, use '+%a, %d %b %Y %H:%M:%S %z'
+# For RFC 3339 dates, use '+%F %T%:z'
+# For RFC 1123 dates, use '+%a, %d %b %Y %H:%M:%S %Z'
+# For RFC 1036 dates, use '+%A, %d-%b-%y %H:%M:%S %Z'
+# For a reasonably local date and time (in that order), use '+%x %X'
+# For the old default behavior (compatible with ANSI C's asctime() function), leave this empty.
+date_format=''
+
+
+#------------------------------------------------------------------------------
 # external commands
 
 # The full path to the sendmail command.

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -745,8 +745,10 @@ fi
 # -----------------------------------------------------------------------------
 # get the date the alarm happened
 
-date="$(date --date=@${when} 2>/dev/null)"
-[ -z "${date}" ] && date="$(date 2>/dev/null)"
+date=$(date --date=@${when} "${DATE_FORMAT}" 2>/dev/null)
+[ -z "${date}" ] && date=$(date "${DATE_FORMAT}" 2>/dev/null)
+[ -z "${date}" ] && date=$(date --date=@${when} 2>/dev/null)
+[ -z "${date}" ] && date=$(date 2>/dev/null)
 
 # -----------------------------------------------------------------------------
 # function to URL encode a string


### PR DESCRIPTION
This adds support to alarm-notify.sh to report dates in alert notifications using an arbitrary format string.

The current default behavior (just using the default format from `date`, which is simply the ANSI C asctime() default) is preserved. In the event that the user specified format string doesn't work, the script will fall back to using the default output of the date command.

The config file includes comments listing a handful of widely used internet date formats as examples, including the rather ubiquitous RFC 3339 and RFC 1123 formats).

This also removes the explicit quoting around the shell expansion used to get the date, as it's unneeded (shell expansion results are implicitly treated as a single string in bash, so you don't have to quote the expansion), and makes it very hard to get this working properly (or it imposes a restriction that there be no whitespace in the format string, which severely limits it's usefulness).

This was primarily motivated by my desire to have ISO 8601 timestamps in alert messages, but I wanted to make it as generic as reasonably possible so that others who may want different date formats can easily use them.

Currently, this has only been tested against the GNU `date` implementation.  I unfortunately do not have a BSD system I can test on, or one which uses the busybox `date` implementation.  It _should_ work fine on both because of the fall back behavior and retaining the existing default, but it would be nice to have confirmation at least on BSD systems that it works before it gets merged.