### PR TITLE
Fix the new date handling in alarm-notify.sh

### DIFF
--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -776,8 +776,8 @@ fi
 # -----------------------------------------------------------------------------
 # get the date the alarm happened
 
-date=$(date --date=@${when} "${DATE_FORMAT}" 2>/dev/null)
-[ -z "${date}" ] && date=$(date "${DATE_FORMAT}" 2>/dev/null)
+date=$(date --date=@${when} "${date_format}" 2>/dev/null)
+[ -z "${date}" ] && date=$(date "${date_format}" 2>/dev/null)
 [ -z "${date}" ] && date=$(date --date=@${when} 2>/dev/null)
 [ -z "${date}" ] && date=$(date 2>/dev/null)
 


### PR DESCRIPTION
The original commit unintentionally capitalized the name of the `date_format` variable in plugins.d/alarm-notify.sh, which caused the new date handling support to not work at all (but thankfully did not break any existing functionality).

This corrects that issue, so that the new date handling support works correctly.

Great example of why you should just copy whole files from the system you developed changes on into your git repo instead of manually copying the changes...