### PR TITLE
OpenVPN Plugin: Fix for IPv6 connections & ignore unauthenticated Clients

### DIFF
--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -107,8 +107,10 @@ class Service(SimpleService):
 
         data = dict(users=0, bytes_in=0, bytes_out=0)
         for row in raw_data:
-            row = ' '.join(row.split(',')) if ',' in row else ' '.join(row.split())
-            match = self.regex['tls'].search(row)
+            columns = row.split(',') if ',' in row else row.split()
+            if columns[0] == 'UNDEF': continue # see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html
+
+            match = self.regex['tls'].search(' '.join(columns))
             if match:
                 match = match.groupdict()
                 data['users'] += 1

--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -32,7 +32,7 @@ class Service(SimpleService):
         self.order = ORDER
         self.definitions = CHARTS
         self.log_path = self.configuration.get('log_path')
-        self.regex = dict(tls=r_compile(r'(?:(?:[0-9a-f]|:){1,4}(:(?:[0-9a-f]{0,4})*){1,7}|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
+        self.regex = dict(tls=r_compile(r'(?:[0-9a-f:]+|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
                           static_key=r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)'))
 
     def check(self):

--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -32,7 +32,7 @@ class Service(SimpleService):
         self.order = ORDER
         self.definitions = CHARTS
         self.log_path = self.configuration.get('log_path')
-        self.regex = dict(tls=r_compile(r'\d{1,3}(?:\.\d{1,3}){3}(?::\d+)? (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
+        self.regex = dict(tls=r_compile(r'(?:(?:[0-9a-f]|:){1,4}(:(?:[0-9a-f]{0,4})*){1,7}|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
                           static_key=r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)'))
 
     def check(self):

--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -108,7 +108,7 @@ class Service(SimpleService):
         data = dict(users=0, bytes_in=0, bytes_out=0)
         for row in raw_data:
             columns = row.split(',') if ',' in row else row.split()
-            if columns[0] == 'UNDEF': continue # see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html
+            if 'UNDEF' in columns: continue # see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html
 
             match = self.regex['tls'].search(' '.join(columns))
             if match:


### PR DESCRIPTION
The regex for matching the client list did depend on an IPv4 address, so if a client was connected to the OpenVPN server via IPv6, it got ignored.

So I modified the regex to also match IPv6 addresses; and also ignored clients with the Common Name `UNDEF`, which are unauthenticated clients.

( if you get DoS-ed, the plugin currently reports hundreds of `UNDEF` clients, see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html )