### PR TITLE
enable bash loadable module for sleep when available; 

### DIFF
--- a/makeself/Makefile.am
+++ b/makeself/Makefile.am
@@ -10,8 +10,8 @@ dist_noinst_SCRIPTS = \
 	install-alpine-packages.sh \
 	post-installer.sh \
 	jobs/10-prepare-destination.install.sh \
-	jobs/50-curl-7.53.1.install.sh \
-	jobs/50-bash-4.4.install.sh \
+	jobs/50-curl-7.60.0.install.sh \
+	jobs/50-bash-4.4.18.install.sh \
 	jobs/50-fping-4.0.install.sh \
 	jobs/70-netdata-git.install.sh \
 	jobs/99-makeself.install.sh \

--- a/makeself/jobs/50-bash-4.4.18.install.sh
+++ b/makeself/jobs/50-bash-4.4.18.install.sh
@@ -2,13 +2,16 @@
 
 . $(dirname "${0}")/../functions.sh "${@}" || exit 1
 
-fetch "bash-4.4" "http://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz"
+fetch "bash-4.4.18" "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
 
 run ./configure \
 	--prefix=${NETDATA_INSTALL_PATH} \
-	--enable-static-link \
-	--disable-nls \
 	--without-bash-malloc \
+	--enable-static-link \
+	--enable-net-redirections \
+	--enable-array-variables \
+	--disable-profiling \
+	--disable-nls \
 #	--disable-rpath \
 #	--enable-alias \
 #	--enable-arith-for-command \

--- a/makeself/jobs/50-curl-7.60.0.install.sh
+++ b/makeself/jobs/50-curl-7.60.0.install.sh
@@ -2,7 +2,7 @@
 
 . $(dirname "${0}")/../functions.sh "${@}" || exit 1
 
-fetch "curl-curl-7_53_1" "https://github.com/curl/curl/archive/curl-7_53_1.tar.gz"
+fetch "curl-curl-7_60_0" "https://github.com/curl/curl/archive/curl-7_60_0.tar.gz"
 
 export LDFLAGS="-static"
 export PKG_CONFIG="pkg-config --static"

--- a/makeself/jobs/99-makeself.install.sh
+++ b/makeself/jobs/99-makeself.install.sh
@@ -64,7 +64,7 @@ run mv "${NETDATA_INSTALL_PATH}/bin/netdata" \
 
 cat >"${NETDATA_INSTALL_PATH}/bin/netdata" <<EOF
 #!${NETDATA_INSTALL_PATH}/bin/bash
-export BASH_LOADABLES_PATH="${NETDATA_INSTALL_PATH}/lib/bash"
+export NETDATA_BASH_LOADABLES="DISABLE"
 export PATH="${NETDATA_INSTALL_PATH}/bin:\${PATH}"
 exec "${NETDATA_INSTALL_PATH}/bin/srv/netdata" "\${@}"
 EOF

--- a/makeself/jobs/99-makeself.install.sh
+++ b/makeself/jobs/99-makeself.install.sh
@@ -64,6 +64,7 @@ run mv "${NETDATA_INSTALL_PATH}/bin/netdata" \
 
 cat >"${NETDATA_INSTALL_PATH}/bin/netdata" <<EOF
 #!${NETDATA_INSTALL_PATH}/bin/bash
+export BASH_LOADABLES_PATH="${NETDATA_INSTALL_PATH}/lib/bash"
 export PATH="${NETDATA_INSTALL_PATH}/bin:\${PATH}"
 exec "${NETDATA_INSTALL_PATH}/bin/srv/netdata" "\${@}"
 EOF

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -133,12 +133,14 @@ if [ -z "${mysleep}" -a "$((BASH_VERSINFO[0] +0))" -ge 3 ]
                 if enable -f "${bash_modules_path}/${bash_module_sleep}" sleep 2>/dev/null
                     then
                     mysleep="builtin_sleep"
-                    #echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
+                    # echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
                     break
                 fi
             fi
+
         done
 
+        [ ! -z "${mysleep}" ] && break
     done
 fi
 

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -102,6 +102,33 @@ mysleep_read() {
     fi
 }
 
+# -----------------------------------------------------------------------------
+# use bash loadable module for sleep
+
+# BASH_LOADABLE_MODULES_DIR can be used in various netdata config files to
+# set the directory the loadable bash modules can be found.
+
+if [ "$((BASH_VERSINFO[0] +0))" -ge 3 ]
+    then
+    # enable modules only for bash version 3+
+
+    for bash_modules_path in "${BASH_LOADABLE_MODULES_DIR}" "/usr/lib/bash" "/lib/bash" "/lib64/bash" "/usr/local/lib/bash" "/usr/local/lib64/bash"
+    do
+        [ -z "${bash_modules_path}" -o ! -d "${bash_modules_path}" ] && continue
+
+        # check for sleep
+        if [ -f "${bash_modules_path}/sleep" ]
+            then
+            if enable -f "${bash_modules_path}/sleep" sleep 2>/dev/null
+                then
+                mysleep="sleep"
+                #echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
+                break
+            fi
+        fi
+    done
+fi
+
 
 # -----------------------------------------------------------------------------
 # this function is used to sleep a fraction of a second

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -85,11 +85,12 @@ fi
 # -----------------------------------------------------------------------------
 # use read with timeout for sleep
 
-mysleep="mysleep_read"
+mysleep=""
 
 mysleep_fifo="${NETDATA_CACHE_DIR-/tmp}/.netdata_bash_sleep_timer_fifo"
-[ ! -e "${mysleep_fifo}" ] && mkfifo "${mysleep_fifo}"
-[ ! -e "${mysleep_fifo}" ] && mysleep="sleep"
+[ -f "${mysleep_fifo}" ] && rm "${mysleep_fifo}"
+[ ! -p "${mysleep_fifo}" ] && mkfifo "${mysleep_fifo}"
+[ -p "${mysleep_fifo}" ] && mysleep="mysleep_read"
 
 mysleep_read() {
     read -t "${1}" <>"${mysleep_fifo}"
@@ -105,7 +106,18 @@ mysleep_read() {
 # -----------------------------------------------------------------------------
 # use bash loadable module for sleep
 
-if [ "$((BASH_VERSINFO[0] +0))" -ge 3 ]
+builtin_sleep() {
+    builtin sleep "${1}"
+    ret=$?
+    if [ $ret -ne 0 ]
+        then
+        echo >&2 "$0: Cannot use builtin sleep for sleeping (return code ${ret})."
+        mysleep="sleep"
+        ${mysleep} "${1}"
+    fi
+}
+
+if [ -z "${mysleep}" -a "$((BASH_VERSINFO[0] +0))" -ge 3 ]
     then
     # enable modules only for bash version 3+
 
@@ -120,7 +132,7 @@ if [ "$((BASH_VERSINFO[0] +0))" -ge 3 ]
                 then
                 if enable -f "${bash_modules_path}/${bash_module_sleep}" sleep 2>/dev/null
                     then
-                    mysleep="builtin sleep"
+                    mysleep="builtin_sleep"
                     #echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
                     break
                 fi
@@ -129,6 +141,11 @@ if [ "$((BASH_VERSINFO[0] +0))" -ge 3 ]
 
     done
 fi
+
+# -----------------------------------------------------------------------------
+# fallback to external sleep
+
+[ -z "${mysleep}" ] && mysleep="sleep"
 
 
 # -----------------------------------------------------------------------------

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -105,27 +105,28 @@ mysleep_read() {
 # -----------------------------------------------------------------------------
 # use bash loadable module for sleep
 
-# BASH_LOADABLE_MODULES_DIR can be used in various netdata config files to
-# set the directory the loadable bash modules can be found.
-
 if [ "$((BASH_VERSINFO[0] +0))" -ge 3 ]
     then
     # enable modules only for bash version 3+
 
-    for bash_modules_path in "${BASH_LOADABLE_MODULES_DIR}" "/usr/lib/bash" "/lib/bash" "/lib64/bash" "/usr/local/lib/bash" "/usr/local/lib64/bash"
+    for bash_modules_path in ${BASH_LOADABLES_PATH//:/ } "$(pkg-config bash --variable=loadablesdir 2>/dev/null)" "/usr/lib/bash" "/lib/bash" "/lib64/bash" "/usr/local/lib/bash" "/usr/local/lib64/bash"
     do
         [ -z "${bash_modules_path}" -o ! -d "${bash_modules_path}" ] && continue
 
         # check for sleep
-        if [ -f "${bash_modules_path}/sleep" ]
-            then
-            if enable -f "${bash_modules_path}/sleep" sleep 2>/dev/null
+        for bash_module_sleep in "sleep" "sleep.so"
+        do
+            if [ -f "${bash_modules_path}/${bash_module_sleep}" ]
                 then
-                mysleep="sleep"
-                #echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
-                break
+                if enable -f "${bash_modules_path}/${bash_module_sleep}" sleep 2>/dev/null
+                    then
+                    mysleep="builtin sleep"
+                    #echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
+                    break
+                fi
             fi
-        fi
+        done
+
     done
 fi
 

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -106,7 +106,7 @@ mysleep_read() {
 # -----------------------------------------------------------------------------
 # use bash loadable module for sleep
 
-builtin_sleep() {
+mysleep_builtin() {
     builtin sleep "${1}"
     ret=$?
     if [ $ret -ne 0 ]
@@ -132,8 +132,8 @@ if [ -z "${mysleep}" -a "$((BASH_VERSINFO[0] +0))" -ge 3 ]
                 then
                 if enable -f "${bash_modules_path}/${bash_module_sleep}" sleep 2>/dev/null
                     then
-                    mysleep="builtin_sleep"
-                    # echo >&2 "$0: Using bash loadable ${bash_modules_path}/sleep for sleep"
+                    mysleep="mysleep_builtin"
+                    # echo >&2 "$0: Using bash loadable ${bash_modules_path}/${bash_module_sleep} for sleep"
                     break
                 fi
             fi

--- a/plugins.d/loopsleepms.sh.inc
+++ b/plugins.d/loopsleepms.sh.inc
@@ -117,7 +117,7 @@ mysleep_builtin() {
     fi
 }
 
-if [ -z "${mysleep}" -a "$((BASH_VERSINFO[0] +0))" -ge 3 ]
+if [ -z "${mysleep}" -a "$((BASH_VERSINFO[0] +0))" -ge 3 -a "${NETDATA_BASH_LOADABLES}" != "DISABLE" ]
     then
     # enable modules only for bash version 3+
 


### PR DESCRIPTION
fixes #3754

bash scripts now use the following methods for sleeping (in this order):

1. `read -t TIMEOUT <>fifo_file`
2. `builtin sleep` (if found available)
3. external `sleep` command

The first 2, are automatically detected and automatically fallback to external `sleep` if for any reason they fail at any point.

To use `read` netdata needs a fifo file. This file is created at `"${NETDATA_CACHE_DIR-/tmp}/.netdata_bash_sleep_timer_fifo"`, which resolves either to:

- `/var/cache/netdata/.netdata_bash_sleep_timer_fifo` (when run by netdata)
- `/tmp/.netdata_bash_sleep_timer_fifo` (when run by hand)

If these files are not named pipes (fifo), they are removed and a fifo is created at their place.

The static netdata builds do not attempt to use `builtin sleep`. I tried compiling a static bash with loadable module support. It compiles, but the shared modules depend on system libraries, which will break due to ABI differences. So, I chose to disable this feature entirely on static builds.

---

btw, updated bash to 4.4.18 and curl to 7.60.0 for the static builds.