### PR TITLE
bcache improvement (again)

### DIFF
--- a/conf.d/health.d/bcache.conf
+++ b/conf.d/health.d/bcache.conf
@@ -1,13 +1,13 @@
 
-template: bcache_cache_read_races
+template: bcache_cache_errors
       on: disk.bcache_cache_read_races
   lookup: sum -10m unaligned absolute
-   units: races
+   units: errors
    every: 1m
     warn: $this > 0
     crit: $this > ( ($status >= $CRITICAL) ? (0) : (10) )
    delay: down 1h multiplier 1.5 max 2h
-    info: the number of times bcache failed to read from the cache during the last 10 mins (this usually means your SSD cache is failing)
+    info: the number of times bcache had issues using the cache, during the last 10 mins (this usually means your SSD cache is failing)
       to: sysadmin
 
 template: bcache_cache_dirty

--- a/configs.signatures
+++ b/configs.signatures
@@ -1,4 +1,5 @@
 declare -A configs_signatures=(
+  ['00049600c2f9237e6c46b8b0f703c13c']='health.d/bcache.conf'
   ['00403e687213f3b7db9bf4563a5a92cc']='python.d/isc_dhcpd.conf'
   ['0056936ce99788ed9ae1c611c87aa6d8']='apps_groups.conf'
   ['007fc019fb32e952b509d455c016a002']='health.d/tcp_resets.conf'

--- a/src/proc_diskstats.c
+++ b/src/proc_diskstats.c
@@ -141,7 +141,7 @@ static char *path_to_device_mapper = NULL;
 static char *path_to_device_label = NULL;
 static char *path_to_device_id = NULL;
 static int name_disks_by_id = CONFIG_BOOLEAN_NO;
-static int global_bcache_priority_stats_update_every = 60;
+static int global_bcache_priority_stats_update_every = 0; // disabled by default
 
 static int  global_enable_new_disks_detected_at_runtime = CONFIG_BOOLEAN_YES,
         global_enable_performance_for_physical_disks = CONFIG_BOOLEAN_AUTO,


### PR DESCRIPTION
1. disable `priority_stats` by default. This bcache info puts unnecessary stress to the system. So, user can enable it, if they find it useful.

2. added cache `io_errors` and modified the alarm.

related to #3765 #3762 #3504 #3482 