### PR TITLE
Add the option to thread email notifications.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -171,6 +171,14 @@ DEFAULT_RECIPIENT_EMAIL="root"
 # autodetected from the environment.
 #EMAIL_CHARSET="UTF-8"
 
+# You can also have netdata add headers to the message that will
+# cause most e-mail clients to treat all notifications for a given
+# chart+alarm+host combination as a single thread.  This can help
+# simplify tracking of alarms, as it provides an easy wway for scripts
+# to corelate messages and also will cause most clients to group all the
+# messages together.  THis is off by default.
+#EMAIL_THREADING="YES"
+
 
 #------------------------------------------------------------------------------
 # pushover (pushover.net) global notification options

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -326,6 +326,7 @@ declare -A role_recipients_custom=()
 EMAIL_SENDER=
 DEFAULT_RECIPIENT_EMAIL="root"
 EMAIL_CHARSET=$(locale charmap 2>/dev/null)
+EMAIL_THREADING=
 declare -A role_recipients_email=()
 
 # irc configs
@@ -780,6 +781,14 @@ date=$(date --date=@${when} "${date_format}" 2>/dev/null)
 [ -z "${date}" ] && date=$(date "${date_format}" 2>/dev/null)
 [ -z "${date}" ] && date=$(date --date=@${when} 2>/dev/null)
 [ -z "${date}" ] && date=$(date 2>/dev/null)
+
+# ----------------------------------------------------------------------------
+# prepare some extra headers if we've been asked to thread e-mails
+if [ "${SEND_EMAIL}" == "YES" -a "${EMAIL_THREADING}" == "YES" ] ; then
+    email_thread_headers="In-Reply-To: <${chart}-${name}@${host}>\nReferences: <${chart}-${name}@${host}>"
+else
+    email_thread_headers=
+fi
 
 # -----------------------------------------------------------------------------
 # function to URL encode a string
@@ -1891,6 +1900,7 @@ To: ${to_email}
 Subject: ${host} ${status_message} - ${name//_/ } - ${chart}
 MIME-Version: 1.0
 Content-Type: multipart/alternative; boundary="multipart-boundary"
+${email_thread_headers}
 
 This is a MIME-encoded multipart message
 


### PR DESCRIPTION
This adds a new configuration option in health_alarm_nofity.conf to insert In-Reply-To and References headers in email notifications.  The contents of these headers are composed in a deterministic way from the chart name, alarm name, and host name.

This allows email clients to sort netdata alert emails into groups based on the combination of chart, alarm, and host, which can help significantly when dealing with a large number of alerts.  It also provides something for scripts that might process and filter thes emails to match on that's a bit easier to parse than the subject line.

We default to not enabling this so that people who have their e-mail clients configured for threaded reading don't see an unexpected change in behavior.

Strictly speaking, this is technically a misuse of the headers, as they are supposed to only reference the Message-ID header of an existing e-mail.  However, I know of no e-mail clients that enforce standards compliant behavior (as it would break threading picked up partway through a thread), so we should be safe.

Minimally tested (using the test-alert.sh script and running for a short while on a server where I synthetically induced lots of alerts).

I've been thinking about doing this for a while now, as it _really_ simplifies keeping tracking of alerts via email (open the thread, and the last message is the last state the alarm was in, so earlier messages only matter for historical reasons).  I was reminded of this by recent activity in #2956, and after mentioning it there, decided to just take the time to implement it.