### PR TITLE
Add a plugin for monitoring BOINC clients.

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -30,6 +30,7 @@ dist_pythonconfig_DATA = \
     python.d/apache.conf \
     python.d/beanstalk.conf \
     python.d/bind_rndc.conf \
+    python.d/boinc.conf \
     python.d/ceph.conf \
     python.d/chrony.conf \
     python.d/couchdb.conf \

--- a/conf.d/health.d/boinc.conf
+++ b/conf.d/health.d/boinc.conf
@@ -6,11 +6,11 @@ template: boinc_compute_errors
       os: *
    hosts: *
 families: *
-  lookup: sum -10m unaligned of comperror
+  lookup: average -10m unaligned of comperror
    units: tasks
    every: 1m
-    warn: $this > 1
-    crit: $this > 4
+    warn: $this > 0
+    crit: $this > 1
    delay: up 1m down 5m multiplier 1.5 max 1h
     info: the total number of compute errors over the past 10 minutes
       to: sysadmin
@@ -21,11 +21,11 @@ template: boinc_upload_errors
       os: *
    hosts: *
 families: *
-  lookup: max -10m unaligned of upload_failed
+  lookup: average -10m unaligned of upload_failed
    units: tasks
    every: 1m
-    warn: $this > 2
-    crit: $this > 4
+    warn: $this > 0
+    crit: $this > 1
    delay: up 1m down 5m multiplier 1.5 max 1h
     info: the average number of failed uploads over the past 10 minutes
       to: sysadmin

--- a/conf.d/health.d/boinc.conf
+++ b/conf.d/health.d/boinc.conf
@@ -1,0 +1,62 @@
+# Alarms for various BOINC issues.
+
+# Warn on any compute errors encountered.
+template: boinc_compute_errors
+      on: boinc.states
+      os: *
+   hosts: *
+families: *
+  lookup: sum -10m unaligned of comperror
+   units: tasks
+   every: 1m
+    warn: $this > 1
+    crit: $this > 4
+   delay: up 1m down 5m multiplier 1.5 max 1h
+    info: the total number of compute errors over the past 10 minutes
+      to: sysadmin
+
+# Warn on lots of upload errors
+template: boinc_upload_errors
+      on: boinc.states
+      os: *
+   hosts: *
+families: *
+  lookup: max -10m unaligned of upload_failed
+   units: tasks
+   every: 1m
+    warn: $this > 2
+    crit: $this > 4
+   delay: up 1m down 5m multiplier 1.5 max 1h
+    info: the average number of failed uploads over the past 10 minutes
+      to: sysadmin
+
+# Warn on the task queue being empty
+template: boinc_total_tasks
+      on: boinc.tasks
+      os: *
+   hosts: *
+families: *
+  lookup: average -10m unaligned of total
+   units: tasks
+   every: 1m
+    warn: $this < 1
+    crit: $this < 0.1
+   delay: up 5m down 10m multiplier 1.5 max 1h
+    info: the total number of locally available tasks
+      to: sysadmin
+
+# Warn on no active tasks with a non-empty queue
+template: boinc_active_tasks
+      on: boinc.tasks
+      os: *
+   hosts: *
+families: *
+  lookup: average -10m unaligned of active
+    calc: ($boinc_total_tasks >= 1) ? ($this) : (inf)
+   units: tasks
+   every: 1m
+    warn: $this < 1
+    crit: $this < 0.1
+   delay: up 5m down 10m multiplier 1.5 max 1h
+    info: the total number of active tasks
+      to: sysadmin

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -24,6 +24,7 @@ apache_cache: no
 # apache: yes
 # beanstalk: yes
 # bind_rndc: yes
+# boinc: yes
 # ceph: yes
 chrony: no
 # couchdb: yes

--- a/conf.d/python.d/boinc.conf
+++ b/conf.d/python.d/boinc.conf
@@ -1,0 +1,68 @@
+# netdata python.d.plugin configuration for boinc
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 60
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     retries: 60             # the JOB's number of restoration attempts
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, boinc also supports the following:
+#
+#     hostname: localhost     # The host running the BOINC client
+#     port: 31416             # The remote GUI RPC port for BOINC
+#     password: ''            # The remote GUI RPC password

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -103,7 +103,7 @@ dist_third_party_DATA = \
     python_modules/third_party/ordereddict.py \
     python_modules/third_party/lm_sensors.py \
     python_modules/third_party/mcrcon.py \
-    python_Modules/third_party/boinc_client.py \
+    python_modules/third_party/boinc_client.py \
     $(NULL)
 
 pythonyaml2dir=$(pythonmodulesdir)/pyyaml2

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -102,6 +102,7 @@ dist_third_party_DATA = \
     python_modules/third_party/ordereddict.py \
     python_modules/third_party/lm_sensors.py \
     python_modules/third_party/mcrcon.py \
+    python_Modules/third_party/boinc_client.py \
     $(NULL)
 
 pythonyaml2dir=$(pythonmodulesdir)/pyyaml2

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -17,6 +17,7 @@ dist_python_DATA = \
     apache.chart.py \
     beanstalk.chart.py \
     bind_rndc.chart.py \
+    boinc.chart.py \
     ceph.chart.py \
     chrony.chart.py \
     couchdb.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -291,6 +291,35 @@ If no configuration is given, module will attempt to read named.stats file  at `
 
 ---
 
+# boinc
+
+This module monitors task counts for the Berkely Open Infrastructure
+Networking Computing (BOINC) distributed computing client using the same
+RPC interface that the BOINC monitoring GUI does.
+
+It provides charts tracking the total number of tasks and active tasks,
+as well as ones tracking each of the possible states for tasks.
+
+### configuration
+
+BOINC requires use of a password to access it's RPC interface.  You can
+find this password in the `gui_rpc_auth.cfg` file in your BOINC directory.
+
+By default, the module will try to auto-detect the password by looking
+in `/var/lib/boinc` for this file (this is the location most Linux
+distributions use for a system-wide BOINC installation), so things may
+just work without needing configuration for the local system.
+
+You can monitor remote systems as well:
+
+```yaml
+remote:
+  hostname: some-host
+  password: some-password
+```
+
+---
+
 # chrony
 
 This module monitors the precision and statistics of a local chronyd server.

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -139,6 +139,10 @@ class Service(SimpleService):
 
     def is_alive(self):
         if (not self.alive) or \
+        # TODO: This final check should ideally not be needed, but the
+        # boinc_client code does not currenlty handle remote disconnects
+        # gracefully in a threaded environment.  This is the only thing
+        # making this module Linux specific.
            self.client.rpc.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1:
             return self.reconnect()
         return True

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -138,11 +138,11 @@ class Service(SimpleService):
         return self.connect()
 
     def is_alive(self):
-        if (not self.alive) or \
         # TODO: This final check should ideally not be needed, but the
         # boinc_client code does not currenlty handle remote disconnects
         # gracefully in a threaded environment.  This is the only thing
         # making this module Linux specific.
+        if (not self.alive) or \
            self.client.rpc.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1:
             return self.reconnect()
         return True

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -128,7 +128,7 @@ class Service(SimpleService):
 
     def connect(self):
         self.client.connect()
-        self.alive = self.client.connected and self.client.authorized:
+        self.alive = self.client.connected and self.client.authorized
         return self.alive
 
     def reconnect(self):

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -121,9 +121,6 @@ class Service(SimpleService):
         self.alive = False
 
     def check(self):
-        if platform.system() != 'Linux':
-            self.error('Only supported on Linux.')
-            return False
         return self.connect()
 
     def connect(self):
@@ -138,12 +135,7 @@ class Service(SimpleService):
         return self.connect()
 
     def is_alive(self):
-        # TODO: This final check should ideally not be needed, but the
-        # boinc_client code does not currenlty handle remote disconnects
-        # gracefully in a threaded environment.  This is the only thing
-        # making this module Linux specific.
-        if (not self.alive) or \
-           self.client.rpc.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1:
+        if not self.alive:
             return self.reconnect()
         return True
 

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -6,8 +6,6 @@
 import platform
 import socket
 
-from copy import deepcopy
-
 from bases.FrameworkServices.SimpleService import SimpleService
 
 from third_party import boinc_client
@@ -127,10 +125,7 @@ class Service(SimpleService):
             self.error('Only supported on Linux.')
             return False
         self.connect()
-        if self.client.connected and self.client.authorized:
-            self.alive = True
-        else:
-            self.alive = False
+        self.alive = self.client.connected and self.client.authorized:
         return self.alive
 
     def connect(self):
@@ -142,10 +137,7 @@ class Service(SimpleService):
         except socket.error:
             pass
         self.client.connect()
-        if self.client.connected and self.client.authorized:
-            self.alive = True
-        else:
-            self.alive = False
+        self.alive = self.client.connected and self.client.authorized:
         return self.alive
 
     def is_alive(self):
@@ -157,7 +149,7 @@ class Service(SimpleService):
     def _get_data(self):
         if not self.is_alive():
             return None
-        data = deepcopy(_DATA_TEMPLATE)
+        data = dict(_DATA_TEMPLATE)
         results = []
         try:
             results = self.client.get_tasks()

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -124,21 +124,18 @@ class Service(SimpleService):
         if platform.system() != 'Linux':
             self.error('Only supported on Linux.')
             return False
-        self.connect()
-        self.alive = self.client.connected and self.client.authorized:
-        return self.alive
+        return self.connect()
 
     def connect(self):
         self.client.connect()
-
-    def reconnect(self):
-        try:
-            self.client.disconnect()
-        except socket.error:
-            pass
-        self.client.connect()
         self.alive = self.client.connected and self.client.authorized:
         return self.alive
+
+    def reconnect(self):
+        # The client class itself actually disconnects existing
+        # connections when it is told to connect, so we don't need to
+        # explicitly disconnect when we're just trying to reconnect.
+        return self.connect()
 
     def is_alive(self):
         if (not self.alive) or \

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+# Description: BOINC netdata python.d module
+# Author: Austin S. Hemmelgarn (Ferroin)
+# SPDX-License-Identifier: GPL-3.0+
+
+import platform
+import socket
+
+from copy import deepcopy
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from third_party import boinc_client
+
+
+ORDER = ['tasks', 'states', 'sched_states', 'process_states']
+
+CHARTS = {
+    'tasks': {
+        'options': [None, 'Overall Tasks', 'tasks', 'boinc', 'boinc.tasks', 'line'],
+        'lines': [
+            ['total', 'Total', 'absolute', 1, 1],
+            ['active', 'Active', 'absolute', 1, 1]
+        ]
+    },
+    'states': {
+        'options': [None, 'Tasks per State', 'tasks', 'boinc', 'boinc.states', 'line'],
+        'lines': [
+            ['new', 'New', 'absolute', 1, 1],
+            ['downloading', 'Downloading', 'absolute', 1, 1],
+            ['downloaded', 'Ready to Run', 'absolute', 1, 1],
+            ['comperror', 'Compute Errors', 'absolute', 1, 1],
+            ['uploading', 'Uploading', 'absolute', 1, 1],
+            ['uploaded', 'Uploaded', 'absolute', 1, 1],
+            ['aborted', 'Aborted', 'absolute', 1, 1],
+            ['upload_failed', 'Failed Uploads', 'absolute', 1, 1]
+        ]
+    },
+    'sched_states': {
+        'options': [None, 'Tasks per Scheduler State', 'tasks', 'boinc', 'boinc.sched', 'line'],
+        'lines': [
+            ['uninit_sched', 'Uninitialized', 'absolute', 1, 1],
+            ['preempted', 'Preempted', 'absolute', 1, 1],
+            ['scheduled', 'Scheduled', 'absolute', 1, 1]
+        ]
+    },
+    'process_states': {
+        'options': [None, 'Tasks per Process State', 'tasks', 'boinc', 'boinc.process', 'line'],
+        'lines': [
+            ['uninit_proc', 'Uninitialized', 'absolute', 1, 1],
+            ['executing', 'Executing', 'absolute', 1, 1],
+            ['suspended', 'Suspended', 'absolute', 1, 1],
+            ['aborting', 'Aborted', 'absolute', 1, 1],
+            ['quit', 'Quit', 'absolute', 1, 1],
+            ['copy_pending', 'Copy Pending', 'absolute', 1, 1]
+        ]
+    }
+}
+
+# A simple template used for pre-loading the return dictionary to make
+# the _get_data() method simpler.
+_DATA_TEMPLATE = {
+    'total': 0,
+    'active': 0,
+    'new': 0,
+    'downloading': 0,
+    'downloaded': 0,
+    'comperror': 0,
+    'uploading': 0,
+    'uploaded': 0,
+    'aborted': 0,
+    'upload_failed': 0,
+    'uninit_sched': 0,
+    'preempted': 0,
+    'scheduled': 0,
+    'uninit_proc': 0,
+    'executing': 0,
+    'suspended': 0,
+    'aborting': 0,
+    'quit': 0,
+    'copy_pending': 0
+}
+
+# Map task states to dimensions
+_TASK_MAP = {
+    boinc_client.ResultState.NEW: 'new',
+    boinc_client.ResultState.FILES_DOWNLOADING: 'downloading',
+    boinc_client.ResultState.FILES_DOWNLOADED: 'downloaded',
+    boinc_client.ResultState.COMPUTE_ERROR: 'comperror',
+    boinc_client.ResultState.FILES_UPLOADING: 'uploading',
+    boinc_client.ResultState.FILES_UPLOADED: 'uploaded',
+    boinc_client.ResultState.ABORTED: 'aborted',
+    boinc_client.ResultState.UPLOAD_FAILED: 'upload_failed'
+}
+
+# Map scheduler states to dimensions
+_SCHED_MAP = {
+    boinc_client.CpuSched.UNINITIALIZED: 'uninit_sched',
+    boinc_client.CpuSched.PREEMPTED: 'preempted',
+    boinc_client.CpuSched.SCHEDULED: 'scheduled',
+}
+
+# Maps process states to dimensions
+_PROC_MAP = {
+    boinc_client.Process.UNINITIALIZED: 'uninit_proc',
+    boinc_client.Process.EXECUTING: 'executing',
+    boinc_client.Process.SUSPENDED: 'suspended',
+    boinc_client.Process.ABORT_PENDING: 'aborted',
+    boinc_client.Process.QUIT_PENDING: 'quit',
+    boinc_client.Process.COPY_PENDING: 'copy_pending'
+}
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.host = self.configuration.get('host', 'localhost')
+        self.port = self.configuration.get('port', 0)
+        self.password = self.configuration.get('password', '')
+        self.client = boinc_client.BoincClient(host=self.host, port=self.port, passwd=self.password)
+        self.alive = False
+
+    def check(self):
+        if platform.system() != 'Linux':
+            self.error('Only supported on Linux.')
+            return False
+        self.connect()
+        if self.client.connected and self.client.authorized:
+            self.alive = True
+        else:
+            self.alive = False
+        return self.alive
+
+    def connect(self):
+        self.client.connect()
+
+    def reconnect(self):
+        try:
+            self.client.disconnect()
+        except socket.error:
+            pass
+        self.client.connect()
+        if self.client.connected and self.client.authorized:
+            self.alive = True
+        else:
+            self.alive = False
+        return self.alive
+
+    def is_alive(self):
+        if (not self.alive) or \
+           self.client.rpc.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1:
+            return self.reconnect()
+        return True
+
+    def _get_data(self):
+        if not self.is_alive():
+            return None
+        data = deepcopy(_DATA_TEMPLATE)
+        results = []
+        try:
+            results = self.client.get_tasks()
+        except socket.error:
+            self.error('Connection is dead')
+            self.alive = False
+            return None
+        for task in results:
+            data['total'] += 1
+            data[_TASK_MAP[task.state]] += 1
+            try:
+                if task.active_task:
+                    data['active'] += 1
+                    data[_SCHED_MAP[task.scheduler_state]] += 1
+                    data[_PROC_MAP[task.active_task_state]] += 1
+            except AttributeError:
+                pass
+        return data

--- a/python.d/boinc.chart.py
+++ b/python.d/boinc.chart.py
@@ -3,7 +3,6 @@
 # Author: Austin S. Hemmelgarn (Ferroin)
 # SPDX-License-Identifier: GPL-3.0+
 
-import platform
 import socket
 
 from bases.FrameworkServices.SimpleService import SimpleService

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -21,7 +21,7 @@ GUI_RPC_PASSWD_FILE = "/var/lib/boinc/gui_rpc_auth.cfg"
 
 GUI_RPC_HOSTNAME    = None  # localhost
 GUI_RPC_PORT        = 31416
-GUI_RPC_TIMEOUT     = 30
+GUI_RPC_TIMEOUT     = 1
 
 class Rpc(object):
     ''' Class to perform GUI RPC calls to a BOINC core client.

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -82,8 +82,7 @@ class Rpc(object):
 
         # pack request
         end = '\003'
-        req = "<boinc_gui_rpc_request>\n%s\n</boinc_gui_rpc_request>\n%s" \
-            % (ElementTree.tostring(request).replace(' />','/>'), end)
+        req = "<boinc_gui_rpc_request>\n{0}\n</boinc_gui_rpc_request>\n{1}".format(ElementTree.tostring(request).replace(' />', '/>'), end)
 
         try:
             self.sock.sendall(req)
@@ -169,7 +168,7 @@ def parse_str(e):
 
 
 def parse_list(e):
-    ''' Helper to convert ElementTree.Element to list. For now, simply return
+    ''' Helper to convert  ElementTree.Element to list. For now, simply return
         the list of root element's children
     '''
     return list(e)
@@ -332,15 +331,15 @@ class _Struct(object):
         return setattrs_from_xml(cls(), xml)
 
     def __str__(self, indent=0):
-        buf = '%s%s:\n' % ('\t' * indent, self.__class__.__name__)
+        buf = '{0}{1}:\n'.format('\t' * indent, self.__class__.__name__)
         for attr in self.__dict__:
             value = getattr(self, attr)
             if isinstance(value, list):
-                buf += '%s\t%s [\n' % ('\t' * indent, attr)
-                for v in value: buf += '\t\t%s\t\t,\n' % v
+                buf += '{0}\t{1} [\n'.format('\t' * indent, attr)
+                for v in value: buf += '\t\t{0}\t\t,\n'.format(v)
                 buf += '\t]\n'
             else:
-                buf += '%s\t%s\t%s\n' % ('\t' * indent,
+                buf += '{0}\t{1}\t{2}\n'.format('\t' * indent,
                                          attr,
                                          value.__str__(indent+2)
                                             if isinstance(value, _Struct)
@@ -371,10 +370,10 @@ class VersionInfo(_Struct):
         return self._tuple > other._tuple
 
     def __str__(self):
-        return "%d.%d.%d" % (self.major, self.minor, self.release)
+        return "{0}.{1}.{2}".format(self.major, self.minor, self.release)
 
     def __repr__(self):
-        return "%s%r" % (self.__class__.__name__, self._tuple)
+        return "{0}{1}".format(self.__class__.__name__, self._tuple)
 
 
 class CcStatus(_Struct):
@@ -598,12 +597,12 @@ class Result(_Struct):
         return result
 
     def __str__(self):
-        buf = '%s:\n' % self.__class__.__name__
+        buf = '{0}:\n'.format(self.__class__.__name__)
         for attr in self.__dict__:
             value = getattr(self, attr)
             if attr in ['received_time', 'report_deadline']:
                 value = time.ctime(value)
-            buf += '\t%s\t%r\n' % (attr, value)
+            buf += '\t{0}\t{1}\n'.format(attr, value)
         return buf
 
 
@@ -651,8 +650,8 @@ class BoincClient(object):
         if password is None and not self.hostname:
             password = read_gui_rpc_password() or ""
         nonce = self.rpc.call('<auth1/>').text
-        hash = hashlib.md5('%s%s' % (nonce, password)).hexdigest().lower()
-        reply = self.rpc.call('<auth2><nonce_hash>%s</nonce_hash></auth2>' % hash)
+        authhash = hashlib.md5('{0}{1}'.format(nonce, password).encode()).hexdigest().lower()
+        reply = self.rpc.call('<auth2><nonce_hash>{0}</nonce_hash></auth2>'.format(authhash))
 
         if reply.tag == 'authorized':
             return True
@@ -688,8 +687,7 @@ class BoincClient(object):
             Use CC_STATE::lookup_result() to find this result in the current static state;
             if it's not there, call get_state() again.
         '''
-        reply = self.rpc.call("<get_results><active_only>%d</active_only></get_results>"
-                               % (1 if active_only else 0))
+        reply = self.rpc.call("<get_results><active_only>{0}</active_only></get_results>".format(1 if active_only else 0))
         if not reply.tag == 'results':
             return []
 
@@ -704,15 +702,12 @@ class BoincClient(object):
             This method is not part of the original API.
             Valid components are 'run' (or 'cpu'), 'gpu', 'network' (or 'net')
         '''
-        component = component.replace('cpu','run')
-        component = component.replace('net','network')
+        component = component.replace('cpu', 'run')
+        component = component.replace('net', 'network')
         try:
-            reply = self.rpc.call("<set_%s_mode>"
-                                  "<%s/><duration>%f</duration>"
-                                  "</set_%s_mode>"
-                                  % (component,
-                                     RunMode.name(mode).lower(), duration,
-                                     component))
+            reply = self.rpc.call("<set_{0}_mode>"
+                                  "<{1}/><duration>{2]</duration>"
+                                  "</set_{0}_mode>".format(component, RunMode.name(mode).lower(), duration))
             return (reply.tag == 'success')
         except socket.error:
             return False

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -711,9 +711,7 @@ class BoincClient(object):
         component = component.replace('cpu', 'run')
         component = component.replace('net', 'network')
         try:
-            reply = self.rpc.call("<set_{0}_mode>"
-                                  "<{1}/><duration>{2]</duration>"
-                                  "</set_{0}_mode>".format(component, RunMode.name(mode).lower(), duration))
+            reply = self.rpc.call("<set_{0}_mode><{1}/>\n<duration>{2]</duration>\n</set_{0}_mode>".format(component, RunMode.name(mode).lower(), duration))
             return (reply.tag == 'success')
         except socket.error:
             return False

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -12,6 +12,7 @@
 
 import hashlib
 import socket
+import sys
 import time
 from functools import total_ordering
 from xml.etree import ElementTree
@@ -82,7 +83,10 @@ class Rpc(object):
 
         # pack request
         end = '\003'
-        req = "<boinc_gui_rpc_request>\n{0}\n</boinc_gui_rpc_request>\n{1}".format(ElementTree.tostring(request).replace(' />', '/>'), end)
+        if sys.version_info[0] < 3:
+            req = "<boinc_gui_rpc_request>\n{0}\n</boinc_gui_rpc_request>\n{1}".format(ElementTree.tostring(request).replace(' />', '/>'), end)
+        else:
+            req = "<boinc_gui_rpc_request>\n{0}\n</boinc_gui_rpc_request>\n{1}".format(ElementTree.tostring(request, encoding='unicode').replace(' />', '/>'), end).encode()
 
         try:
             self.sock.sendall(req)
@@ -95,6 +99,8 @@ class Rpc(object):
                 buf = self.sock.recv(8192)
                 if not buf:
                     raise socket.error("No data from socket")
+                if sys.version_info[0] >= 3:
+                    buf = buf.decode()
             except socket.error:
                 raise
             n = buf.find(end)

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -201,83 +201,6 @@ class Enum(object):
         return cls.name(Enum.UNKNOWN)
 
 
-class NetworkStatus(Enum):
-    ''' Values of "network_status" '''
-    ONLINE                 =    0  #// have network connections open
-    WANT_CONNECTION        =    1  #// need a physical connection
-    WANT_DISCONNECT        =    2  #// don't have any connections, and don't need any
-    LOOKUP_PENDING         =    3  #// a website lookup is pending (try again later)
-
-    @classmethod
-    def name(cls, v):
-        if   v == cls.UNKNOWN:         return "unknown"
-        elif v == cls.ONLINE:          return "online"  # misleading
-        elif v == cls.WANT_CONNECTION: return "need connection"
-        elif v == cls.WANT_DISCONNECT: return "don't need connection"
-        elif v == cls.LOOKUP_PENDING:  return "reference site lookup pending"
-        else: return super(NetworkStatus, cls).name(v)
-
-
-class SuspendReason(Enum):
-    ''' bitmap defs for task_suspend_reason, network_suspend_reason
-        Note: doesn't need to be a bitmap, but keep for compatibility
-    '''
-    NOT_SUSPENDED          =    0  # Not in original API
-    BATTERIES              =    1
-    USER_ACTIVE            =    2
-    USER_REQ               =    4
-    TIME_OF_DAY            =    8
-    BENCHMARKS             =   16
-    DISK_SIZE              =   32
-    CPU_THROTTLE           =   64
-    NO_RECENT_INPUT        =  128
-    INITIAL_DELAY          =  256
-    EXCLUSIVE_APP_RUNNING  =  512
-    CPU_USAGE              = 1024
-    NETWORK_QUOTA_EXCEEDED = 2048
-    OS                     = 4096
-    WIFI_STATE             = 4097
-    BATTERY_CHARGING       = 4098
-    BATTERY_OVERHEATED     = 4099
-
-    @classmethod
-    def name(cls, v):
-        if   v == cls.UNKNOWN:                return "unknown reason"
-        elif v == cls.BATTERIES:              return "on batteries"
-        elif v == cls.USER_ACTIVE:            return "computer is in use"
-        elif v == cls.USER_REQ:               return "user request"
-        elif v == cls.TIME_OF_DAY:            return "time of day"
-        elif v == cls.BENCHMARKS:             return "CPU benchmarks in progress"
-        elif v == cls.DISK_SIZE:              return "need disk space - check preferences"
-        elif v == cls.NO_RECENT_INPUT:        return "no recent user activity"
-        elif v == cls.INITIAL_DELAY:          return "initial delay"
-        elif v == cls.EXCLUSIVE_APP_RUNNING:  return "an exclusive app is running"
-        elif v == cls.CPU_USAGE:              return "CPU is busy"
-        elif v == cls.NETWORK_QUOTA_EXCEEDED: return "network bandwidth limit exceeded"
-        elif v == cls.OS:                     return "requested by operating system"
-        elif v == cls.WIFI_STATE:             return "not connected to WiFi network"
-        elif v == cls.BATTERY_CHARGING:       return "battery is recharging"
-        elif v == cls.BATTERY_OVERHEATED:     return "battery is overheated"
-        else: return super(SuspendReason, cls).name(v)
-
-
-class RunMode(Enum):
-    ''' Run modes for CPU, GPU, network,
-        controlled by Activity menu and snooze button
-    '''
-    ALWAYS                 =    1
-    AUTO                   =    2
-    NEVER                  =    3
-    RESTORE                =    4
-        #// restore permanent mode - used only in set_X_mode() GUI RPC
-
-    @classmethod
-    def name(cls, v):
-        # all other modes use the fallback name
-        if v == cls.AUTO: return "according to prefs"
-        else: return super(RunMode, cls).name(v)
-
-
 class CpuSched(Enum):
     ''' values of ACTIVE_TASK::scheduler_state and ACTIVE_TASK::next_scheduler_state
         "SCHEDULED" is synonymous with "executing" except when CPU throttling
@@ -380,118 +303,6 @@ class VersionInfo(_Struct):
 
     def __repr__(self):
         return "{0}{1}".format(self.__class__.__name__, self._tuple)
-
-
-class CcStatus(_Struct):
-    def __init__(self):
-        self.network_status         = NetworkStatus.UNKNOWN
-        self.ams_password_error     = False
-        self.manager_must_quit      = False
-
-        self.task_suspend_reason    = SuspendReason.UNKNOWN  #// bitmap
-        self.task_mode              = RunMode.UNKNOWN
-        self.task_mode_perm         = RunMode.UNKNOWN        #// same, but permanent version
-        self.task_mode_delay        = 0.0                    #// time until perm becomes actual
-
-        self.network_suspend_reason = SuspendReason.UNKNOWN
-        self.network_mode           = RunMode.UNKNOWN
-        self.network_mode_perm      = RunMode.UNKNOWN
-        self.network_mode_delay     = 0.0
-
-        self.gpu_suspend_reason     = SuspendReason.UNKNOWN
-        self.gpu_mode               = RunMode.UNKNOWN
-        self.gpu_mode_perm          = RunMode.UNKNOWN
-        self.gpu_mode_delay         = 0.0
-
-        self.disallow_attach        = False
-        self.simple_gui_only        = False
-
-
-class HostInfo(_Struct):
-    def __init__(self):
-        self.timezone     = 0    #// local STANDARD time - UTC time (in seconds)
-        self.domain_name  = ""
-        self.ip_addr      = ""
-        self.host_cpid    = ""
-
-        self.p_ncpus      = 0    #// Number of CPUs on host
-        self.p_vendor     = ""   #// Vendor name of CPU
-        self.p_model      = ""   #// Model of CPU
-        self.p_features   = ""
-        self.p_fpops      = 0.0  #// measured floating point ops/sec of CPU
-        self.p_iops       = 0.0  #// measured integer ops/sec of CPU
-        self.p_membw      = 0.0  #// measured memory bandwidth (bytes/sec) of CPU
-            #// The above are per CPU, not total
-        self.p_calculated = 0.0  #// when benchmarks were last run, or zero
-        self.p_vm_extensions_disabled = False
-
-        self.m_nbytes     = 0    #// Size of memory in bytes
-        self.m_cache      = 0    #// Size of CPU cache in bytes (L1 or L2?)
-        self.m_swap       = 0    #// Size of swap space in bytes
-
-        self.d_total      = 0    #// Total disk space on volume containing
-                                    #// the BOINC client directory.
-        self.d_free       = 0    #// how much is free on that volume
-
-        self.os_name      = ""   #// Name of operating system
-        self.os_version   = ""   #// Version of operating system
-
-        #// the following is non-empty if VBox is installed
-        self.virtualbox_version = ""
-
-        self.coprocs = [] # COPROCS
-
-        # The following are currently unused (not in RPC XML)
-        self.serialnum    = ""   #// textual description of coprocessors
-
-    @classmethod
-    def parse(cls, xml):
-        if not isinstance(xml, ElementTree.Element):
-            xml = ElementTree.fromstring(xml)
-
-        # parse main XML
-        hostinfo = super(HostInfo, cls).parse(xml)
-
-        # parse each coproc in coprocs list
-        aux = []
-        for c in hostinfo.coprocs:
-            aux.append(Coproc.parse(c))
-        hostinfo.coprocs = aux
-
-        return hostinfo
-
-
-class Coproc(_Struct):
-    ''' represents a set of identical coprocessors on a particular computer.
-        Abstract class;
-        objects will always be a derived class (COPROC_CUDA, COPROC_ATI)
-        Used in both client and server.
-    '''
-    def __init__(self):
-        self.type        = ""     #// must be unique
-        self.count       = 0      #// how many are present
-        self.peak_flops  = 0.0
-        self.used        = 0.0    #// how many are in use (used by client)
-        self.have_cuda   = False  #// True if this GPU supports CUDA on this computer
-        self.have_cal    = False  #// True if this GPU supports CAL on this computer
-        self.have_opencl = False  #// True if this GPU supports openCL on this computer
-        self.available_ram = 0
-        self.specified_in_config = False
-            #// If true, this coproc was listed in cc_config.xml
-            #// rather than being detected by the client.
-
-        #// the following are used in both client and server for work-fetch info
-        self.req_secs = 0.0
-            #// how many instance-seconds of work requested
-        self.req_instances = 0.0
-            #// client is requesting enough jobs to use this many instances
-        self.estimated_delay = 0
-            #// resource will be saturated for this long
-
-        self.opencl_device_count = 0
-        self.last_print_time = 0.0
-
-        #self.opencl_prop = None  # OPENCL_DEVICE_PROP
 
 
 class Result(_Struct):
@@ -668,20 +479,6 @@ class BoincClient(object):
         ''' Return VersionInfo instance with core client version info '''
         return VersionInfo.parse(self.rpc.call('<exchange_versions/>'))
 
-    def get_cc_status(self):
-        ''' Return CcStatus instance containing basic status, such as
-            CPU / GPU / Network active/suspended, etc
-        '''
-        if not self.connected: self.connect()
-        try:
-            return CcStatus.parse(self.rpc.call('<get_cc_status/>'))
-        except socket.error:
-            self.connected = False
-
-    def get_host_info(self):
-        ''' Get information about host hardware and usage. '''
-        return HostInfo.parse(self.rpc.call('<get_host_info/>'))
-
     def get_tasks(self):
         ''' Same as get_results(active_only=False) '''
         return self.get_results(False)
@@ -702,50 +499,6 @@ class BoincClient(object):
             results.append(Result.parse(item))
 
         return results
-
-    def set_mode(self, component, mode, duration=0):
-        ''' Do the real work of set_{run,gpu,network}_mode()
-            This method is not part of the original API.
-            Valid components are 'run' (or 'cpu'), 'gpu', 'network' (or 'net')
-        '''
-        component = component.replace('cpu', 'run')
-        component = component.replace('net', 'network')
-        try:
-            reply = self.rpc.call("<set_{0}_mode><{1}/>\n<duration>{2]</duration>\n</set_{0}_mode>".format(component, RunMode.name(mode).lower(), duration))
-            return (reply.tag == 'success')
-        except socket.error:
-            return False
-
-    def set_run_mode(self, mode, duration=0):
-        ''' Set the run mode (RunMode.NEVER/AUTO/ALWAYS/RESTORE)
-            NEVER will suspend all activity, including CPU, GPU and Network
-            AUTO will run according to preferences.
-            If duration is zero, mode is permanent. Otherwise revert to last
-            permanent mode after duration seconds elapse.
-        '''
-        return self.set_mode('cpu', mode, duration)
-
-    def set_gpu_mode(self, mode, duration=0):
-        ''' Set the GPU run mode, similar to set_run_mode() but for GPU only
-        '''
-        return self.set_mode('gpu', mode, duration)
-
-    def set_network_mode(self, mode, duration=0):
-        ''' Set the Network run mode, similar to set_run_mode()
-            but for network activity only
-        '''
-        return self.set_mode('net', mode, duration)
-
-    def run_benchmarks(self):
-        ''' Run benchmarks. Computing will suspend during benchmarks '''
-        return self.rpc.call('<run_benchmarks/>').tag == "success"
-
-    def quit(self):
-        ''' Tell the core client to exit '''
-        if self.rpc.call('<quit/>').tag == "success":
-            self.connected = False
-            return True
-        return False
 
 
 def read_gui_rpc_password():

--- a/python.d/python_modules/third_party/boinc_client.py
+++ b/python.d/python_modules/third_party/boinc_client.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# client.py - Somewhat higher-level GUI_RPC API for BOINC core client
+#
+#    Copyright (C) 2013 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>
+#    Copyright (C) 2017 Austin S. Hemmelgarn
+#
+# SPDX-License-Identifier: GPL-3.0
+
+# Based on client/boinc_cmd.cpp
+
+import hashlib
+import socket
+import time
+from functools import total_ordering
+from xml.etree import ElementTree
+
+GUI_RPC_PASSWD_FILE = "/var/lib/boinc/gui_rpc_auth.cfg"
+
+GUI_RPC_HOSTNAME    = None  # localhost
+GUI_RPC_PORT        = 31416
+GUI_RPC_TIMEOUT     = 30
+
+class Rpc(object):
+    ''' Class to perform GUI RPC calls to a BOINC core client.
+        Usage in a context manager ('with' block) is recommended to ensure
+        disconnect() is called. Using the same instance for all calls is also
+        recommended so it reuses the same socket connection
+        '''
+    def __init__(self, hostname="", port=0, timeout=0, text_output=False):
+        self.hostname = hostname
+        self.port     = port
+        self.timeout  = timeout
+        self.sock = None
+        self.text_output = text_output
+
+    @property
+    def sockargs(self):
+        return (self.hostname, self.port, self.timeout)
+
+    def __enter__(self): self.connect(*self.sockargs); return self
+    def __exit__(self, *args): self.disconnect()
+
+    def connect(self, hostname="", port=0, timeout=0):
+        ''' Connect to (hostname, port) with timeout in seconds.
+            Hostname defaults to None (localhost), and port to 31416
+            Calling multiple times will disconnect previous connection (if any),
+            and (re-)connect to host.
+        '''
+        if self.sock:
+            self.disconnect()
+
+        self.hostname = hostname or GUI_RPC_HOSTNAME
+        self.port     = port     or GUI_RPC_PORT
+        self.timeout  = timeout  or GUI_RPC_TIMEOUT
+
+        self.sock = socket.create_connection(self.sockargs[0:2], self.sockargs[2])
+
+    def disconnect(self):
+        ''' Disconnect from host. Calling multiple times is OK (idempotent)
+        '''
+        if self.sock:
+            self.sock.close()
+            self.sock = None
+
+    def call(self, request, text_output=None):
+        ''' Do an RPC call. Pack and send the XML request and return the
+            unpacked reply. request can be either plain XML text or a
+            xml.etree.ElementTree.Element object. Return ElementTree.Element
+            or XML text according to text_output flag.
+            Will auto-connect if not connected.
+        '''
+        if text_output is None:
+            text_output = self.text_output
+
+        if not self.sock:
+            self.connect(*self.sockargs)
+
+        if not isinstance(request, ElementTree.Element):
+            request = ElementTree.fromstring(request)
+
+        # pack request
+        end = '\003'
+        req = "<boinc_gui_rpc_request>\n%s\n</boinc_gui_rpc_request>\n%s" \
+            % (ElementTree.tostring(request).replace(' />','/>'), end)
+
+        try:
+            self.sock.sendall(req)
+        except (socket.error, socket.herror, socket.gaierror, socket.timeout):
+            raise
+
+        req = ""
+        while True:
+            try:
+                buf = self.sock.recv(8192)
+                if not buf:
+                    raise socket.error("No data from socket")
+            except socket.error:
+                raise
+            n = buf.find(end)
+            if not n == -1: break
+            req += buf
+        req += buf[:n]
+
+        # unpack reply (remove root tag, ie: first and last lines)
+        req = '\n'.join(req.strip().rsplit('\n')[1:-1])
+
+        if text_output:
+            return req
+        else:
+            return ElementTree.fromstring(req)
+
+def setattrs_from_xml(obj, xml, attrfuncdict={}):
+    ''' Helper to set values for attributes of a class instance by mapping
+        matching tags from a XML file.
+        attrfuncdict is a dict of functions to customize value data type of
+        each attribute. It falls back to simple int/float/bool/str detection
+        based on values defined in __init__(). This would not be needed if
+        Boinc used standard RPC protocol, which includes data type in XML.
+    '''
+    if not isinstance(xml, ElementTree.Element):
+        xml = ElementTree.fromstring(xml)
+    for e in list(xml):
+        if hasattr(obj, e.tag):
+            attr = getattr(obj, e.tag)
+            attrfunc = attrfuncdict.get(e.tag, None)
+            if attrfunc is None:
+                if   isinstance(attr, bool):  attrfunc = parse_bool
+                elif isinstance(attr, int):   attrfunc = parse_int
+                elif isinstance(attr, float): attrfunc = parse_float
+                elif isinstance(attr, str):   attrfunc = parse_str
+                elif isinstance(attr, list):  attrfunc = parse_list
+                else:                         attrfunc = lambda x: x
+            setattr(obj, e.tag, attrfunc(e))
+        else:
+            pass
+            #print "class missing attribute '%s': %r" % (e.tag, obj)
+    return obj
+
+
+def parse_bool(e):
+    ''' Helper to convert ElementTree.Element.text to boolean.
+        Treat '<foo/>' (and '<foo>[[:blank:]]</foo>') as True
+        Treat '0' and 'false' as False
+    '''
+    if e.text is None:
+        return True
+    else:
+        return bool(e.text) and not e.text.strip().lower() in ('0', 'false')
+
+
+def parse_int(e):
+    ''' Helper to convert ElementTree.Element.text to integer.
+        Treat '<foo/>' (and '<foo></foo>') as 0
+    '''
+    # int(float()) allows casting to int a value expressed as float in XML
+    return 0 if e.text is None else int(float(e.text.strip()))
+
+
+def parse_float(e):
+    ''' Helper to convert ElementTree.Element.text to float. '''
+    return 0.0 if e.text is None else float(e.text.strip())
+
+
+def parse_str(e):
+    ''' Helper to convert ElementTree.Element.text to string. '''
+    return "" if e.text is None else e.text.strip()
+
+
+def parse_list(e):
+    ''' Helper to convert ElementTree.Element to list. For now, simply return
+        the list of root element's children
+    '''
+    return list(e)
+
+
+class Enum(object):
+    UNKNOWN                =   -1  # Not in original API
+
+    @classmethod
+    def name(cls, value):
+        ''' Quick-and-dirty fallback for getting the "name" of an enum item '''
+
+        # value as string, if it matches an enum attribute.
+        # Allows short usage as Enum.name("VALUE") besides Enum.name(Enum.VALUE)
+        if hasattr(cls, str(value)):
+            return cls.name(getattr(cls, value, None))
+
+        # value not handled in subclass name()
+        for k, v in cls.__dict__.items():
+            if v == value:
+                return k.lower().replace('_', ' ')
+
+        # value not found
+        return cls.name(Enum.UNKNOWN)
+
+
+class NetworkStatus(Enum):
+    ''' Values of "network_status" '''
+    ONLINE                 =    0  #// have network connections open
+    WANT_CONNECTION        =    1  #// need a physical connection
+    WANT_DISCONNECT        =    2  #// don't have any connections, and don't need any
+    LOOKUP_PENDING         =    3  #// a website lookup is pending (try again later)
+
+    @classmethod
+    def name(cls, v):
+        if   v == cls.UNKNOWN:         return "unknown"
+        elif v == cls.ONLINE:          return "online"  # misleading
+        elif v == cls.WANT_CONNECTION: return "need connection"
+        elif v == cls.WANT_DISCONNECT: return "don't need connection"
+        elif v == cls.LOOKUP_PENDING:  return "reference site lookup pending"
+        else: return super(NetworkStatus, cls).name(v)
+
+
+class SuspendReason(Enum):
+    ''' bitmap defs for task_suspend_reason, network_suspend_reason
+        Note: doesn't need to be a bitmap, but keep for compatibility
+    '''
+    NOT_SUSPENDED          =    0  # Not in original API
+    BATTERIES              =    1
+    USER_ACTIVE            =    2
+    USER_REQ               =    4
+    TIME_OF_DAY            =    8
+    BENCHMARKS             =   16
+    DISK_SIZE              =   32
+    CPU_THROTTLE           =   64
+    NO_RECENT_INPUT        =  128
+    INITIAL_DELAY          =  256
+    EXCLUSIVE_APP_RUNNING  =  512
+    CPU_USAGE              = 1024
+    NETWORK_QUOTA_EXCEEDED = 2048
+    OS                     = 4096
+    WIFI_STATE             = 4097
+    BATTERY_CHARGING       = 4098
+    BATTERY_OVERHEATED     = 4099
+
+    @classmethod
+    def name(cls, v):
+        if   v == cls.UNKNOWN:                return "unknown reason"
+        elif v == cls.BATTERIES:              return "on batteries"
+        elif v == cls.USER_ACTIVE:            return "computer is in use"
+        elif v == cls.USER_REQ:               return "user request"
+        elif v == cls.TIME_OF_DAY:            return "time of day"
+        elif v == cls.BENCHMARKS:             return "CPU benchmarks in progress"
+        elif v == cls.DISK_SIZE:              return "need disk space - check preferences"
+        elif v == cls.NO_RECENT_INPUT:        return "no recent user activity"
+        elif v == cls.INITIAL_DELAY:          return "initial delay"
+        elif v == cls.EXCLUSIVE_APP_RUNNING:  return "an exclusive app is running"
+        elif v == cls.CPU_USAGE:              return "CPU is busy"
+        elif v == cls.NETWORK_QUOTA_EXCEEDED: return "network bandwidth limit exceeded"
+        elif v == cls.OS:                     return "requested by operating system"
+        elif v == cls.WIFI_STATE:             return "not connected to WiFi network"
+        elif v == cls.BATTERY_CHARGING:       return "battery is recharging"
+        elif v == cls.BATTERY_OVERHEATED:     return "battery is overheated"
+        else: return super(SuspendReason, cls).name(v)
+
+
+class RunMode(Enum):
+    ''' Run modes for CPU, GPU, network,
+        controlled by Activity menu and snooze button
+    '''
+    ALWAYS                 =    1
+    AUTO                   =    2
+    NEVER                  =    3
+    RESTORE                =    4
+        #// restore permanent mode - used only in set_X_mode() GUI RPC
+
+    @classmethod
+    def name(cls, v):
+        # all other modes use the fallback name
+        if v == cls.AUTO: return "according to prefs"
+        else: return super(RunMode, cls).name(v)
+
+
+class CpuSched(Enum):
+    ''' values of ACTIVE_TASK::scheduler_state and ACTIVE_TASK::next_scheduler_state
+        "SCHEDULED" is synonymous with "executing" except when CPU throttling
+        is in use.
+    '''
+    UNINITIALIZED          =    0
+    PREEMPTED              =    1
+    SCHEDULED              =    2
+
+
+class ResultState(Enum):
+    ''' Values of RESULT::state in client.
+        THESE MUST BE IN NUMERICAL ORDER
+        (because of the > comparison in RESULT::computing_done())
+        see html/inc/common_defs.inc
+    '''
+    NEW                    =    0
+        #// New result
+    FILES_DOWNLOADING      =    1
+        #// Input files for result (WU, app version) are being downloaded
+    FILES_DOWNLOADED       =    2
+        #// Files are downloaded, result can be (or is being) computed
+    COMPUTE_ERROR          =    3
+        #// computation failed; no file upload
+    FILES_UPLOADING        =    4
+        #// Output files for result are being uploaded
+    FILES_UPLOADED         =    5
+        #// Files are uploaded, notify scheduling server at some point
+    ABORTED                =    6
+        #// result was aborted
+    UPLOAD_FAILED          =    7
+        #// some output file permanent failure
+
+
+class Process(Enum):
+    ''' values of ACTIVE_TASK::task_state '''
+    UNINITIALIZED          =    0
+        #// process doesn't exist yet
+    EXECUTING              =    1
+        #// process is running, as far as we know
+    SUSPENDED              =    9
+        #// we've sent it a "suspend" message
+    ABORT_PENDING          =    5
+        #// process exceeded limits; send "abort" message, waiting to exit
+    QUIT_PENDING           =    8
+        #// we've sent it a "quit" message, waiting to exit
+    COPY_PENDING           =   10
+        #// waiting for async file copies to finish
+
+
+class _Struct(object):
+    ''' base helper class with common methods for all classes derived from
+        BOINC's C++ structs
+    '''
+    @classmethod
+    def parse(cls, xml):
+        return setattrs_from_xml(cls(), xml)
+
+    def __str__(self, indent=0):
+        buf = '%s%s:\n' % ('\t' * indent, self.__class__.__name__)
+        for attr in self.__dict__:
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                buf += '%s\t%s [\n' % ('\t' * indent, attr)
+                for v in value: buf += '\t\t%s\t\t,\n' % v
+                buf += '\t]\n'
+            else:
+                buf += '%s\t%s\t%s\n' % ('\t' * indent,
+                                         attr,
+                                         value.__str__(indent+2)
+                                            if isinstance(value, _Struct)
+                                            else repr(value))
+        return buf
+
+
+@total_ordering
+class VersionInfo(_Struct):
+    def __init__(self, major=0, minor=0, release=0):
+        self.major     = major
+        self.minor     = minor
+        self.release   = release
+
+    @property
+    def _tuple(self):
+        return  (self.major, self.minor, self.release)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._tuple == other._tuple
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __gt__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._tuple > other._tuple
+
+    def __str__(self):
+        return "%d.%d.%d" % (self.major, self.minor, self.release)
+
+    def __repr__(self):
+        return "%s%r" % (self.__class__.__name__, self._tuple)
+
+
+class CcStatus(_Struct):
+    def __init__(self):
+        self.network_status         = NetworkStatus.UNKNOWN
+        self.ams_password_error     = False
+        self.manager_must_quit      = False
+
+        self.task_suspend_reason    = SuspendReason.UNKNOWN  #// bitmap
+        self.task_mode              = RunMode.UNKNOWN
+        self.task_mode_perm         = RunMode.UNKNOWN        #// same, but permanent version
+        self.task_mode_delay        = 0.0                    #// time until perm becomes actual
+
+        self.network_suspend_reason = SuspendReason.UNKNOWN
+        self.network_mode           = RunMode.UNKNOWN
+        self.network_mode_perm      = RunMode.UNKNOWN
+        self.network_mode_delay     = 0.0
+
+        self.gpu_suspend_reason     = SuspendReason.UNKNOWN
+        self.gpu_mode               = RunMode.UNKNOWN
+        self.gpu_mode_perm          = RunMode.UNKNOWN
+        self.gpu_mode_delay         = 0.0
+
+        self.disallow_attach        = False
+        self.simple_gui_only        = False
+
+
+class HostInfo(_Struct):
+    def __init__(self):
+        self.timezone     = 0    #// local STANDARD time - UTC time (in seconds)
+        self.domain_name  = ""
+        self.ip_addr      = ""
+        self.host_cpid    = ""
+
+        self.p_ncpus      = 0    #// Number of CPUs on host
+        self.p_vendor     = ""   #// Vendor name of CPU
+        self.p_model      = ""   #// Model of CPU
+        self.p_features   = ""
+        self.p_fpops      = 0.0  #// measured floating point ops/sec of CPU
+        self.p_iops       = 0.0  #// measured integer ops/sec of CPU
+        self.p_membw      = 0.0  #// measured memory bandwidth (bytes/sec) of CPU
+            #// The above are per CPU, not total
+        self.p_calculated = 0.0  #// when benchmarks were last run, or zero
+        self.p_vm_extensions_disabled = False
+
+        self.m_nbytes     = 0    #// Size of memory in bytes
+        self.m_cache      = 0    #// Size of CPU cache in bytes (L1 or L2?)
+        self.m_swap       = 0    #// Size of swap space in bytes
+
+        self.d_total      = 0    #// Total disk space on volume containing
+                                    #// the BOINC client directory.
+        self.d_free       = 0    #// how much is free on that volume
+
+        self.os_name      = ""   #// Name of operating system
+        self.os_version   = ""   #// Version of operating system
+
+        #// the following is non-empty if VBox is installed
+        self.virtualbox_version = ""
+
+        self.coprocs = [] # COPROCS
+
+        # The following are currently unused (not in RPC XML)
+        self.serialnum    = ""   #// textual description of coprocessors
+
+    @classmethod
+    def parse(cls, xml):
+        if not isinstance(xml, ElementTree.Element):
+            xml = ElementTree.fromstring(xml)
+
+        # parse main XML
+        hostinfo = super(HostInfo, cls).parse(xml)
+
+        # parse each coproc in coprocs list
+        aux = []
+        for c in hostinfo.coprocs:
+            aux.append(Coproc.parse(c))
+        hostinfo.coprocs = aux
+
+        return hostinfo
+
+
+class Coproc(_Struct):
+    ''' represents a set of identical coprocessors on a particular computer.
+        Abstract class;
+        objects will always be a derived class (COPROC_CUDA, COPROC_ATI)
+        Used in both client and server.
+    '''
+    def __init__(self):
+        self.type        = ""     #// must be unique
+        self.count       = 0      #// how many are present
+        self.peak_flops  = 0.0
+        self.used        = 0.0    #// how many are in use (used by client)
+        self.have_cuda   = False  #// True if this GPU supports CUDA on this computer
+        self.have_cal    = False  #// True if this GPU supports CAL on this computer
+        self.have_opencl = False  #// True if this GPU supports openCL on this computer
+        self.available_ram = 0
+        self.specified_in_config = False
+            #// If true, this coproc was listed in cc_config.xml
+            #// rather than being detected by the client.
+
+        #// the following are used in both client and server for work-fetch info
+        self.req_secs = 0.0
+            #// how many instance-seconds of work requested
+        self.req_instances = 0.0
+            #// client is requesting enough jobs to use this many instances
+        self.estimated_delay = 0
+            #// resource will be saturated for this long
+
+        self.opencl_device_count = 0
+        self.last_print_time = 0.0
+
+        #self.opencl_prop = None  # OPENCL_DEVICE_PROP
+
+
+class Result(_Struct):
+    ''' Also called "task" in some contexts '''
+    def __init__(self):
+        # Names and values follow lib/gui_rpc_client.h @ RESULT
+        # Order too, except when grouping contradicts client/result.cpp
+        # RESULT::write_gui(), then XML order is used.
+
+        self.name                         = ""
+        self.wu_name                      = ""
+        self.version_num                  = 0
+            #// identifies the app used
+        self.plan_class                   = ""
+        self.project_url                  = ""  # from PROJECT.master_url
+        self.report_deadline              = 0.0 # seconds since epoch
+        self.received_time                = 0.0 # seconds since epoch
+            #// when we got this from server
+        self.ready_to_report              = False
+            #// we're ready to report this result to the server;
+            #// either computation is done and all the files have been uploaded
+            #// or there was an error
+        self.got_server_ack               = False
+            #// we've received the ack for this result from the server
+        self.final_cpu_time               = 0.0
+        self.final_elapsed_time           = 0.0
+        self.state                        = ResultState.NEW
+        self.estimated_cpu_time_remaining = 0.0
+            #// actually, estimated elapsed time remaining
+        self.exit_status                  = 0
+            #// return value from the application
+        self.suspended_via_gui            = False
+        self.project_suspended_via_gui    = False
+        self.edf_scheduled                = False
+            #// temporary used to tell GUI that this result is deadline-scheduled
+        self.coproc_missing               = False
+            #// a coproc needed by this job is missing
+            #// (e.g. because user removed their GPU board).
+        self.scheduler_wait               = False
+        self.scheduler_wait_reason        = ""
+        self.network_wait                 = False
+        self.resources                    = ""
+            #// textual description of resources used
+
+        #// the following defined if active
+        # XML is generated in client/app.cpp ACTIVE_TASK::write_gui()
+        self.active_task                  = False
+        self.active_task_state            = Process.UNINITIALIZED
+        self.app_version_num              = 0
+        self.slot                         = -1
+        self.pid                          = 0
+        self.scheduler_state              = CpuSched.UNINITIALIZED
+        self.checkpoint_cpu_time          = 0.0
+        self.current_cpu_time             = 0.0
+        self.fraction_done                = 0.0
+        self.elapsed_time                 = 0.0
+        self.swap_size                    = 0
+        self.working_set_size_smoothed    = 0.0
+        self.too_large                    = False
+        self.needs_shmem                  = False
+        self.graphics_exec_path           = ""
+        self.web_graphics_url             = ""
+        self.remote_desktop_addr          = ""
+        self.slot_path                    = ""
+            #// only present if graphics_exec_path is
+
+        # The following are not in original API, but are present in RPC XML reply
+        self.completed_time               = 0.0
+            #// time when ready_to_report was set
+        self.report_immediately           = False
+        self.working_set_size             = 0
+        self.page_fault_rate              = 0.0
+            #// derived by higher-level code
+
+        # The following are in API, but are NEVER in RPC XML reply. Go figure
+        self.signal                       = 0
+
+        self.app                          = None  # APP*
+        self.wup                          = None  # WORKUNIT*
+        self.project                      = None  # PROJECT*
+        self.avp                          = None  # APP_VERSION*
+
+    @classmethod
+    def parse(cls, xml):
+        if not isinstance(xml, ElementTree.Element):
+            xml = ElementTree.fromstring(xml)
+
+        # parse main XML
+        result = super(Result, cls).parse(xml)
+
+        # parse '<active_task>' children
+        active_task = xml.find('active_task')
+        if active_task is None:
+            result.active_task = False  # already the default after __init__()
+        else:
+            result.active_task = True   # already the default after main parse
+            result = setattrs_from_xml(result, active_task)
+
+        #// if CPU time is nonzero but elapsed time is zero,
+        #// we must be talking to an old client.
+        #// Set elapsed = CPU
+        #// (easier to deal with this here than in the manager)
+        if result.current_cpu_time != 0 and result.elapsed_time == 0:
+            result.elapsed_time = result.current_cpu_time
+
+        if result.final_cpu_time != 0 and result.final_elapsed_time == 0:
+            result.final_elapsed_time = result.final_cpu_time
+
+        return result
+
+    def __str__(self):
+        buf = '%s:\n' % self.__class__.__name__
+        for attr in self.__dict__:
+            value = getattr(self, attr)
+            if attr in ['received_time', 'report_deadline']:
+                value = time.ctime(value)
+            buf += '\t%s\t%r\n' % (attr, value)
+        return buf
+
+
+class BoincClient(object):
+
+    def __init__(self, host="", port=0, passwd=None):
+        self.hostname   = host
+        self.port       = port
+        self.passwd     = passwd
+        self.rpc        = Rpc(text_output=False)
+        self.version    = None
+        self.authorized = False
+
+        # Informative, not authoritative. Records status of *last* RPC call,
+        # but does not infer success about the *next* one.
+        # Thus, it should be read *after* an RPC call, not prior to one
+        self.connected = False
+
+    def __enter__(self): self.connect(); return self
+    def __exit__(self, *args): self.disconnect()
+
+    def connect(self):
+        try:
+            self.rpc.connect(self.hostname, self.port)
+            self.connected = True
+        except socket.error:
+            self.connected = False
+            return
+        self.authorized = self.authorize(self.passwd)
+        self.version = self.exchange_versions()
+
+    def disconnect(self):
+        self.rpc.disconnect()
+
+    def authorize(self, password):
+        ''' Request authorization. If password is None and we are connecting
+            to localhost, try to read password from the local config file
+            GUI_RPC_PASSWD_FILE. If file can't be read (not found or no
+            permission to read), try to authorize with a blank password.
+            If authorization is requested and fails, all subsequent calls
+            will be refused with socket.error 'Connection reset by peer' (104).
+            Since most local calls do no require authorization, do not attempt
+            it if you're not sure about the password.
+        '''
+        if password is None and not self.hostname:
+            password = read_gui_rpc_password() or ""
+        nonce = self.rpc.call('<auth1/>').text
+        hash = hashlib.md5('%s%s' % (nonce, password)).hexdigest().lower()
+        reply = self.rpc.call('<auth2><nonce_hash>%s</nonce_hash></auth2>' % hash)
+
+        if reply.tag == 'authorized':
+            return True
+        else:
+            return False
+
+    def exchange_versions(self):
+        ''' Return VersionInfo instance with core client version info '''
+        return VersionInfo.parse(self.rpc.call('<exchange_versions/>'))
+
+    def get_cc_status(self):
+        ''' Return CcStatus instance containing basic status, such as
+            CPU / GPU / Network active/suspended, etc
+        '''
+        if not self.connected: self.connect()
+        try:
+            return CcStatus.parse(self.rpc.call('<get_cc_status/>'))
+        except socket.error:
+            self.connected = False
+
+    def get_host_info(self):
+        ''' Get information about host hardware and usage. '''
+        return HostInfo.parse(self.rpc.call('<get_host_info/>'))
+
+    def get_tasks(self):
+        ''' Same as get_results(active_only=False) '''
+        return self.get_results(False)
+
+    def get_results(self, active_only=False):
+        ''' Get a list of results.
+            Those that are in progress will have information such as CPU time
+            and fraction done. Each result includes a name;
+            Use CC_STATE::lookup_result() to find this result in the current static state;
+            if it's not there, call get_state() again.
+        '''
+        reply = self.rpc.call("<get_results><active_only>%d</active_only></get_results>"
+                               % (1 if active_only else 0))
+        if not reply.tag == 'results':
+            return []
+
+        results = []
+        for item in list(reply):
+            results.append(Result.parse(item))
+
+        return results
+
+    def set_mode(self, component, mode, duration=0):
+        ''' Do the real work of set_{run,gpu,network}_mode()
+            This method is not part of the original API.
+            Valid components are 'run' (or 'cpu'), 'gpu', 'network' (or 'net')
+        '''
+        component = component.replace('cpu','run')
+        component = component.replace('net','network')
+        try:
+            reply = self.rpc.call("<set_%s_mode>"
+                                  "<%s/><duration>%f</duration>"
+                                  "</set_%s_mode>"
+                                  % (component,
+                                     RunMode.name(mode).lower(), duration,
+                                     component))
+            return (reply.tag == 'success')
+        except socket.error:
+            return False
+
+    def set_run_mode(self, mode, duration=0):
+        ''' Set the run mode (RunMode.NEVER/AUTO/ALWAYS/RESTORE)
+            NEVER will suspend all activity, including CPU, GPU and Network
+            AUTO will run according to preferences.
+            If duration is zero, mode is permanent. Otherwise revert to last
+            permanent mode after duration seconds elapse.
+        '''
+        return self.set_mode('cpu', mode, duration)
+
+    def set_gpu_mode(self, mode, duration=0):
+        ''' Set the GPU run mode, similar to set_run_mode() but for GPU only
+        '''
+        return self.set_mode('gpu', mode, duration)
+
+    def set_network_mode(self, mode, duration=0):
+        ''' Set the Network run mode, similar to set_run_mode()
+            but for network activity only
+        '''
+        return self.set_mode('net', mode, duration)
+
+    def run_benchmarks(self):
+        ''' Run benchmarks. Computing will suspend during benchmarks '''
+        return self.rpc.call('<run_benchmarks/>').tag == "success"
+
+    def quit(self):
+        ''' Tell the core client to exit '''
+        if self.rpc.call('<quit/>').tag == "success":
+            self.connected = False
+            return True
+        return False
+
+
+def read_gui_rpc_password():
+    ''' Read password string from GUI_RPC_PASSWD_FILE file, trim the last CR
+        (if any), and return it
+    '''
+    try:
+        with open(GUI_RPC_PASSWD_FILE, 'r') as f:
+            buf = f.read()
+            if buf.endswith('\n'): return buf[:-1]  # trim last CR
+            else: return buf
+    except IOError:
+        # Permission denied or File not found.
+        pass

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -2133,7 +2133,7 @@ netdataDashboard.context = {
     },
 
     'boinc.states': {
-        info: 'Counts of tasks in each task state.  The normal sequence of states is <code>New</code>, <code>Downloading</code>, <code>Ready to Run<c/ode>, <code>Uploading</code>, <code>Uploaded</code>.  Tasks which are marked <code>Ready to Run</code> may be actively running, or may be waiting to be scheduled.  <code>Compute Errors</code> are tasks which failed for some reason during execution.  <code>Aborted</code> tasks were manually cancelled, and will not be processed.  <code>Failed Uploads</code> are otherwise finished tasks which failed to upload to the server, and usually indicate networking issues.'
+        info: 'Counts of tasks in each task state.  The normal sequence of states is <code>New</code>, <code>Downloading</code>, <code>Ready to Run</code>, <code>Uploading</code>, <code>Uploaded</code>.  Tasks which are marked <code>Ready to Run</code> may be actively running, or may be waiting to be scheduled.  <code>Compute Errors</code> are tasks which failed for some reason during execution.  <code>Aborted</code> tasks were manually cancelled, and will not be processed.  <code>Failed Uploads</code> are otherwise finished tasks which failed to upload to the server, and usually indicate networking issues.'
     },
 
     'boinc.sched': {

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -373,10 +373,17 @@ netdataDashboard.menu = {
         icon: '<i class="fas fa-eye"></i>',
         info: 'Provides basic performance statistics for the <b><a href="https://www.spigotmc.org/">Spigot Minecraft</a></b> server.'
     },
+
     'unbound': {
         title: 'Unbound',
         icon: '<i class="fas fa-tag"></i>',
         info: undefined
+    },
+
+    'boinc': {
+        title: 'BOINC'
+        icon: '<i class="fas fa-microchip"></i>',
+        info: 'Provides task counts for <b><a href="http://boinc.berkeley.edu/">BOINC</a></b> distributed computing clients.'
     }
 };
 
@@ -2119,6 +2126,22 @@ netdataDashboard.context = {
 
     'unbound.threads.recursion': {
         height: 0.2
+    },
+
+    'boinc.tasks': {
+        info: 'The total number of tasks and the number of active tasks.  Active tasks are those which are either currently being processed, or are partialy processed but suspended.
+    },
+
+    'boinc.states': {
+        info: 'Counts of tasks in each task state.  The normal sequence of states is <code>New</code>, <code>Downloading</code>, <code>Ready to Run<c/ode>, <code>Uploading</code>, <code>Uploaded</code>.  Tasks which are marked <code>Ready to Run</code> may be actively running, or may be waiting to be scheduled.  <code>Compute Errors</code> are tasks which failed for some reason during execution.  <code>Aborted</code> tasks were manually cancelled, and will not be processed.  <code>Failed Uploads</code> are otherwise finished tasks which failed to upload to the server, and usually indicate networking issues.'
+    },
+
+    'boinc.sched': {
+        info: 'Counts of active tasks in each scheduling state.  <code>Scheduled</code> tasks are the ones which will run if the system is permitted to process tasks.  <code>Preempted</code> tasks are on standby, and will run if a <code>Scheduled</code> task stops running for some reason.  <code>Uninitialized</code> tasks should never be present, and indicate tha the scheduler has not tried to schedule them yet.'
+    },
+
+    'boinc.process': {
+        info: 'Counts of active tasks in each process state.  <code>Executing</code> tasks are running right now.  <code>Suspended</code> tasks have an associated process, but are not currently running (either because the system isn\'t processing any tasks right now, or because they have been preempted by higher priority tasks).  <code>Quit</code> tasks are exiting gracefully.  <code>Aborted</code> tasks exceeded some resource limit, and are being shut down.  code>Copy Pending</code> tasks are waiting on a background file transfer to finish.  <code>Uninitialized</code> tasks do not have an associated process yet.'
     }
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -381,7 +381,7 @@ netdataDashboard.menu = {
     },
 
     'boinc': {
-        title: 'BOINC'
+        title: 'BOINC',
         icon: '<i class="fas fa-microchip"></i>',
         info: 'Provides task counts for <b><a href="http://boinc.berkeley.edu/">BOINC</a></b> distributed computing clients.'
     }
@@ -2129,7 +2129,7 @@ netdataDashboard.context = {
     },
 
     'boinc.tasks': {
-        info: 'The total number of tasks and the number of active tasks.  Active tasks are those which are either currently being processed, or are partialy processed but suspended.
+        info: 'The total number of tasks and the number of active tasks.  Active tasks are those which are either currently being processed, or are partialy processed but suspended.'
     },
 
     'boinc.states': {


### PR DESCRIPTION
This adds a python.d module for monitoring Berkeley Open Infrastructure Network Computing clients.  This is the framework utilized by a vast majority of publicly run distributed computing projects (including
SETI@Home and World Community Grid).

The first two commits add a third-party module used to do the actual RPC with the BOINC client.  The original code for this is from https://github.com/MestreLion/boinc-indicator.  That project is unfortunately dead though, so the local changes I've made are not likely to ever get merged back into the upstream code.  For the record, the my changes for this specific code are:

* Merging the low-level and high-level RPC interfaces into one file so it's easier to track.
* Cleaning up the high-level interface a bit so it has a saner way to pass in the hostname and port.
* Removing the superfluous `if __name__ == 'main':` section at the end, since this won't ever be run by itself.
* Silencing the complaints the original code printed about missing attributes that were expected to be missing.

The second commit adds the BOINC module itself.

The module  only tracks the number of tasks in various task states on the system, as almost everything else is trivial to track using other existing plugins (such as apps.plugin).  It utilizes the same RPC mechanism that the official GUI management tool for BOINC clients uses.

In most cases, the data this tracks is not hugely interesting (it doesn't change very often, and generally doesn't change very much on any given system), but there are a handful of situations that it lets us provide alerts for that are of particular interest to users running BOINC on headless systems (namely computational errors, reporting failures, and running out of tasks to run).

Internally, BOINC has 3 state-machines that a given task will advance through, the task state, scheduling state, and process state.  The task state tracks the high-level status of the task (is it new, ready to run, finished running and being reported, hit a computational error, etc). the scheduling state tracks whether the scheduling algorithm says the task can run or not, and the process state tracks the status of the
associated process for the task that does the actual computing.  This module provides charts tracking task counts in each state for each of these state machines, as well as one counting total number of local
tasks, and how many tasks are 'active' (that is, how many are being considered for processing).

We also provide a set of default alarms to alert on compute errors, upload/reporting failures, an empty local task queue, and a low number of active tasks.

Here's a screenshot from the graphs right after a couple of tasks finished processing and the client issued a scheduling request:

![boinc-plugin](https://user-images.githubusercontent.com/905151/40979758-ba220d42-68a4-11e8-9abf-034393c98964.png)

Does not show any dashboard info because I took it before I got the dashboard info displaying correctly.