### PR TITLE
Per-thread stats for Unbound.

### DIFF
--- a/conf.d/python.d/unbound.conf
+++ b/conf.d/python.d/unbound.conf
@@ -69,10 +69,11 @@
 #                             # of a TCP connection
 #    tls_key_file: /path/to/key    # The key file to use for authentication
 #    tls_cert_file: /path/to/key   # The certificate to use for authentication
-#    extended: false          @ Whether to collect extended stats or not
+#    extended: false          # Whether to collect extended stats or not
+#    per_thread: false        # Whether to show charts for per-thread stats
 #
 # In addition to the above, you can set the following to try and
-# auto-detect settings based on the unbound configuration:
+# auto-detect most settings based on the unbound configuration:
 #
 #    ubconf: /etc/unbound/unbound.conf
 #

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -2349,20 +2349,26 @@ that either the certificate and key are readable by Netdata (if you're
 using the regular control interface), or that the socket is accessible
 to Netdata (if you're using a UNIX socket for the contorl interface).
 
-By default, for the local system, every thing can be auto-detected
-assumign Unbound is configured correctly and has been told to listen
+By default, for the local system, everything can be auto-detected
+assuming Unbound is configured correctly and has been told to listen
 on the loopback interface or a UNIX socket.  This is done by looking
 up info in the Unbound config file specified by the `ubconf` key.
 
 To enable extended stats for a given job, add `extended: yes` to the
 definition.
 
-A basic local configuration with extended statistics looks like this:
+You can also enable per-thread charts for a given job by adding
+`per_thread: yes` to the definition.  Note that the numbe rof threads
+is only checked on startup.
+
+A basic local configuration with extended statistics and per-thread
+charts looks like this:
 
 ```yaml
 local:
     ubconf: /etc/unbound/unbound.conf
     extended: yes
+    per_thread: yes
 ```
 
 While it's a bit more complicated to set up correctly, it is recommended

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -200,7 +200,6 @@ class Service(SocketService):
             longname = 'Thread {0}'.format(thread)
             charts = dict()
             order = [[], [], []]
-            statmap = dict()
             count = 0
             for item in PER_THREAD_CHARTS:
                 chartname = '{0}{1}'.format(shortname, item)

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -3,6 +3,7 @@
 # Author: Austin S. Hemmelgarn (Ferroin)
 
 import os
+import sys
 
 from copy import deepcopy
 
@@ -62,6 +63,40 @@ EXTENDED_CHARTS = {
     }
 }
 
+# This is used as a templates for the per-thread charts.
+PER_THREAD_CHARTS = {
+    '_queries': {
+        'options': [None, '{0} Queries Processed', 'queries', 'Queries Processed', 'unbound.threads.queries', 'line'],
+        'lines': [
+            ['{0}_ratelimit', 'Ratelimited', 'absolute', 1, 1],
+            ['{0}_cachemiss', 'Cache Miss', 'absolute', 1, 1],
+            ['{0}_cachehit', 'Cache Hit', 'absolute', 1, 1],
+            ['{0}_expired', 'Expired', 'absolute', 1, 1],
+            ['{0}_prefetch', 'Prefetched', 'absolute', 1, 1],
+            ['{0}_recursive', 'Recursive', 'absolute', 1, 1]
+        ]
+    },
+    '_reqlist': {
+        'options': [None, '{0} Request List', 'items', 'Request List', 'unbound.threads.reqlist', 'line'],
+        'lines': [
+            ['{0}_reqlist_avg', 'Average Size', 'absolute', 1, 1],
+            ['{0}_reqlist_max', 'Maximum Size', 'absolute', 1, 1],
+            ['{0}_reqlist_overwritten', 'Overwritten Requests', 'absolute', 1, 1],
+            ['{0}_reqlist_exceeded', 'Overruns', 'absolute', 1, 1],
+            ['{0}_reqlist_current', 'Current Size', 'absolute', 1, 1],
+            ['{0}_reqlist_user', 'User Requests', 'absolute', 1, 1]
+        ]
+    },
+    '_recursion': {
+        'options': [None, '{0} Recursion Timings', 'seconds', 'Recursive Timings', 'unbound.threads.recursion', 'line'],
+        'lines': [
+            ['{0}_recursive_avg', 'Average', 'absolute', 1, PRECISION],
+            ['{0}_recursive_med', 'Median', 'absolute', 1, PRECISION]
+        ]
+    }
+}
+
+
 # This maps the Unbound stat names to our names and precision requiremnets.
 STAT_MAP = {
     'total.num.queries_ip_ratelimited': ('ratelimit', 1),
@@ -86,6 +121,24 @@ STAT_MAP = {
     'dnscrypt_nonce.cache.count': ('cache_dnscn', 1)
 }
 
+# Same as above, but for per-thread stats.
+PER_THREAD_STAT_MAP = {
+    '{0}.num.queries_ip_ratelimited': ('{0}_ratelimit', 1),
+    '{0}.num.cachehits': ('{0}_cachehit', 1),
+    '{0}.num.cachemiss': ('{0}_cachemiss', 1),
+    '{0}.num.zero_ttl': ('{0}_expired', 1),
+    '{0}.num.prefetch': ('{0}_prefetch', 1),
+    '{0}.num.recursivereplies': ('{0}_recursive', 1),
+    '{0}.requestlist.avg': ('{0}_reqlist_avg', 1),
+    '{0}.requestlist.max': ('{0}_reqlist_max', 1),
+    '{0}.requestlist.overwritten': ('{0}_reqlist_overwritten', 1),
+    '{0}.requestlist.exceeded': ('{0}_reqlist_exceeded', 1),
+    '{0}.requestlist.current.all': ('{0}_reqlist_current', 1),
+    '{0}.requestlist.current.user': ('{0}_reqlist_user', 1),
+    '{0}.recursion.time.avg': ('{0}_recursive_avg', PRECISION),
+    '{0}.recursion.time.median': ('{0}_recursive_med', PRECISION)
+}
+
 
 class Service(SocketService):
     def __init__(self, configuration=None, name=None):
@@ -97,25 +150,24 @@ class Service(SocketService):
         SocketService.__init__(self, configuration, name)
         self.ext = self.configuration.get('extended', None)
         self.ubconf = self.configuration.get('ubconf', None)
+        self.perthread = self.configuration.get('per_thread', False)
+        self.threads = None
         self.order = deepcopy(ORDER)
         self.definitions = deepcopy(CHARTS)
         self.request = 'UBCT1 stats\n'
         self._parse_config()
         self._auto_config()
         self.debug('Extended stats: {0}'.format(self.ext))
+        self.debug('Per-thread stats: {0}'.format(self.perthread))
         if self.ext:
             self.order = self.order + EXTENDED_ORDER
             self.definitions.update(EXTENDED_CHARTS)
         if self.unix_socket:
             self.debug('Using unix socket: {0}'.format(self.unix_socket))
-            for key in self.definitions:
-                self.definitions[key]['options'][4] = 'Local'
         else:
             self.debug('Connecting to: {0}:{1}'.format(self.host, self.port))
             self.debug('Using key: {0}'.format(self.key))
             self.debug('Using certificate: {0}'.format(self.cert))
-            for key in self.definitions:
-                self.definitions[key]['options'][4] = self.host
 
     def _auto_config(self):
         if self.ubconf and os.access(self.ubconf, os.R_OK):
@@ -140,11 +192,58 @@ class Service(SocketService):
         if not self.port:
             self.port = 8953
 
+    def _generate_perthread_charts(self):
+        # TODO: THis could probably be more efficient, but it's only
+        # run once, so it probably doesn't really matter.
+        for thread in range(0, self.threads):
+            shortname = 'thread{0}'.format(thread)
+            longname = 'Thread {0}'.format(thread)
+            charts = dict()
+            order = [[], [], []]
+            statmap = dict()
+            count = 0
+            for item in PER_THREAD_CHARTS:
+                chartname = '{0}{1}'.format(shortname, item)
+                order[count].append(chartname)
+                count += 1
+                charts[chartname] = deepcopy(PER_THREAD_CHARTS[item])
+                charts[chartname]['options'][1] = charts[chartname]['options'][1].format(longname)
+                for line in range(0, len(charts[chartname]['lines'])):
+                    charts[chartname]['lines'][line][0] = charts[chartname]['lines'][line][0].format(shortname)
+            order = order[0] + order[1] + order[2]
+            for chart in order:
+                params = [chart] + charts[chart]['options']
+                dimensions = charts[chart]['lines']
+                new_chart = self.charts.add_chart(params)
+                for dimension in dimensions:
+                    new_chart.add_dimension(dimension)
+            for key, value in PER_THREAD_STAT_MAP.items():
+                STAT_MAP[key.format(shortname)] = (value[0].format(shortname), value[1])
+
     def check(self):
-        # We need to check that auth works, otherwise there's no point.
+        # Check if authentication is working.
         self._connect()
         result = bool(self._sock)
         self._disconnect()
+        # If auth works, and we need per-thread charts, query the server
+        # to see how many threads it's using.  This somewhat abuses the
+        # SocketService API to get the data we need.
+        if result and self.perthread:
+            tmp = self.request
+            if sys.version_info[0] < 3:
+                self.request = 'UBCT1 status\n'
+            else:
+                self.request = b'UBCT1 status\n'
+            raw = self._get_raw_data()
+            for line in raw.splitlines():
+                if line.startswith('threads'):
+                    self.threads = int(line.split()[1])
+                    self._generate_perthread_charts()
+                    break
+            if self.threads is None:
+                self.info('Unable to auto-detect thread counts, disabling per-thread stats.')
+                self.perthread = False
+            self.request = tmp
         return result
 
     @staticmethod

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -210,13 +210,8 @@ class Service(SocketService):
                 charts[chartname]['options'][1] = charts[chartname]['options'][1].format(longname)
                 for line in range(0, len(charts[chartname]['lines'])):
                     charts[chartname]['lines'][line][0] = charts[chartname]['lines'][line][0].format(shortname)
-            order = order[0] + order[1] + order[2]
-            for chart in order:
-                params = [chart] + charts[chart]['options']
-                dimensions = charts[chart]['lines']
-                new_chart = self.charts.add_chart(params)
-                for dimension in dimensions:
-                    new_chart.add_dimension(dimension)
+            self.order = self.order + order[0] + order[1] + order[2]
+            self.definitions.update(charts)
             for key, value in PER_THREAD_STAT_MAP.items():
                 STAT_MAP[key.format(shortname)] = (value[0].format(shortname), value[1])
 

--- a/python.d/unbound.chart.py
+++ b/python.d/unbound.chart.py
@@ -12,36 +12,36 @@ from bases.loaders import YamlOrderedLoader
 
 PRECISION = 1000
 
-ORDER = ['queries', 'reqlist', 'recursion']
+ORDER = ['queries', 'recursion', 'reqlist']
 
 CHARTS = {
     'queries': {
         'options': [None, 'Queries Processed', 'queries', 'Unbound', 'unbound.queries', 'line'],
         'lines': [
-            ['ratelimit', 'Ratelimited', 'absolute', 1, 1],
-            ['cachemiss', 'Cache Miss', 'absolute', 1, 1],
-            ['cachehit', 'Cache Hit', 'absolute', 1, 1],
-            ['expired', 'Expired', 'absolute', 1, 1],
-            ['prefetch', 'Prefetched', 'absolute', 1, 1],
-            ['recursive', 'Recursive', 'absolute', 1, 1]
-        ]
-    },
-    'reqlist': {
-        'options': [None, 'Request List', 'items', 'Unbound', 'unbound.reqlist', 'line'],
-        'lines': [
-            ['reqlist_avg', 'Average Size', 'absolute', 1, 1],
-            ['reqlist_max', 'Maximum Size', 'absolute', 1, 1],
-            ['reqlist_overwritten', 'Overwritten Requests', 'absolute', 1, 1],
-            ['reqlist_exceeded', 'Overruns', 'absolute', 1, 1],
-            ['reqlist_current', 'Current Size', 'absolute', 1, 1],
-            ['reqlist_user', 'User Requests', 'absolute', 1, 1]
+            ['ratelimit', 'ratelimited', 'absolute', 1, 1],
+            ['cachemiss', 'cache_miss', 'absolute', 1, 1],
+            ['cachehit', 'cache_hit', 'absolute', 1, 1],
+            ['expired', 'expired', 'absolute', 1, 1],
+            ['prefetch', 'prefetched', 'absolute', 1, 1],
+            ['recursive', 'recursive', 'absolute', 1, 1]
         ]
     },
     'recursion': {
         'options': [None, 'Recursion Timings', 'seconds', 'Unbound', 'unbound.recursion', 'line'],
         'lines': [
-            ['recursive_avg', 'Average', 'absolute', 1, PRECISION],
-            ['recursive_med', 'Median', 'absolute', 1, PRECISION]
+            ['recursive_avg', 'average', 'absolute', 1, PRECISION],
+            ['recursive_med', 'median', 'absolute', 1, PRECISION]
+        ]
+    },
+    'reqlist': {
+        'options': [None, 'Request List', 'items', 'Unbound', 'unbound.reqlist', 'line'],
+        'lines': [
+            ['reqlist_avg', 'average_size', 'absolute', 1, 1],
+            ['reqlist_max', 'maximum_size', 'absolute', 1, 1],
+            ['reqlist_overwritten', 'overwritten_requests', 'absolute', 1, 1],
+            ['reqlist_exceeded', 'overruns', 'absolute', 1, 1],
+            ['reqlist_current', 'current_size', 'absolute', 1, 1],
+            ['reqlist_user', 'user_requests', 'absolute', 1, 1]
         ]
     }
 }
@@ -53,12 +53,12 @@ EXTENDED_CHARTS = {
     'cache': {
         'options': [None, 'Cache Sizes', 'items', 'Unbound', 'unbound.cache', 'stacked'],
         'lines': [
-            ['cache_message', 'Message Cache', 'absolute', 1, 1],
-            ['cache_rrset', 'RRSet Cache', 'absolute', 1, 1],
-            ['cache_infra', 'Infra Cache', 'absolute', 1, 1],
-            ['cache_key', 'DNSSEC Key Cache', 'absolute', 1, 1],
-            ['cache_dnscss', 'DNSCrypt Shared Secret Cache', 'absolute', 1, 1],
-            ['cache_dnscn', 'DNSCrypt Nonce Cache', 'absolute', 1, 1]
+            ['cache_message', 'message_cache', 'absolute', 1, 1],
+            ['cache_rrset', 'rrset_cache', 'absolute', 1, 1],
+            ['cache_infra', 'infra_cache', 'absolute', 1, 1],
+            ['cache_key', 'dnssec_key_cache', 'absolute', 1, 1],
+            ['cache_dnscss', 'dnscrypt_Shared_Secret_cache', 'absolute', 1, 1],
+            ['cache_dnscn', 'dnscrypt_Nonce_cache', 'absolute', 1, 1]
         ]
     }
 }
@@ -66,32 +66,32 @@ EXTENDED_CHARTS = {
 # This is used as a templates for the per-thread charts.
 PER_THREAD_CHARTS = {
     '_queries': {
-        'options': [None, '{0} Queries Processed', 'queries', 'Queries Processed', 'unbound.threads.queries', 'line'],
+        'options': [None, '{longname} Queries Processed', 'queries', 'Queries Processed', 'unbound.threads.queries', 'line'],
         'lines': [
-            ['{0}_ratelimit', 'Ratelimited', 'absolute', 1, 1],
-            ['{0}_cachemiss', 'Cache Miss', 'absolute', 1, 1],
-            ['{0}_cachehit', 'Cache Hit', 'absolute', 1, 1],
-            ['{0}_expired', 'Expired', 'absolute', 1, 1],
-            ['{0}_prefetch', 'Prefetched', 'absolute', 1, 1],
-            ['{0}_recursive', 'Recursive', 'absolute', 1, 1]
-        ]
-    },
-    '_reqlist': {
-        'options': [None, '{0} Request List', 'items', 'Request List', 'unbound.threads.reqlist', 'line'],
-        'lines': [
-            ['{0}_reqlist_avg', 'Average Size', 'absolute', 1, 1],
-            ['{0}_reqlist_max', 'Maximum Size', 'absolute', 1, 1],
-            ['{0}_reqlist_overwritten', 'Overwritten Requests', 'absolute', 1, 1],
-            ['{0}_reqlist_exceeded', 'Overruns', 'absolute', 1, 1],
-            ['{0}_reqlist_current', 'Current Size', 'absolute', 1, 1],
-            ['{0}_reqlist_user', 'User Requests', 'absolute', 1, 1]
+            ['{shortname}_ratelimit', 'ratelimited', 'absolute', 1, 1],
+            ['{shortname}_cachemiss', 'cache_miss', 'absolute', 1, 1],
+            ['{shortname}_cachehit', 'cache_hit', 'absolute', 1, 1],
+            ['{shortname}_expired', 'expired', 'absolute', 1, 1],
+            ['{shortname}_prefetch', 'prefetched', 'absolute', 1, 1],
+            ['{shortname}_recursive', 'recursive', 'absolute', 1, 1]
         ]
     },
     '_recursion': {
-        'options': [None, '{0} Recursion Timings', 'seconds', 'Recursive Timings', 'unbound.threads.recursion', 'line'],
+        'options': [None, '{longname} Recursion Timings', 'seconds', 'Recursive Timings', 'unbound.threads.recursion', 'line'],
         'lines': [
-            ['{0}_recursive_avg', 'Average', 'absolute', 1, PRECISION],
-            ['{0}_recursive_med', 'Median', 'absolute', 1, PRECISION]
+            ['{shortname}_recursive_avg', 'average', 'absolute', 1, PRECISION],
+            ['{shortname}_recursive_med', 'median', 'absolute', 1, PRECISION]
+        ]
+    },
+    '_reqlist': {
+        'options': [None, '{longname} Request List', 'items', 'Request List', 'unbound.threads.reqlist', 'line'],
+        'lines': [
+            ['{shortname}_reqlist_avg', 'average_size', 'absolute', 1, 1],
+            ['{shortname}_reqlist_max', 'maximum_size', 'absolute', 1, 1],
+            ['{shortname}_reqlist_overwritten', 'overwritten_requests', 'absolute', 1, 1],
+            ['{shortname}_reqlist_exceeded', 'overruns', 'absolute', 1, 1],
+            ['{shortname}_reqlist_current', 'current_size', 'absolute', 1, 1],
+            ['{shortname}_reqlist_user', 'user_requests', 'absolute', 1, 1]
         ]
     }
 }
@@ -123,21 +123,46 @@ STAT_MAP = {
 
 # Same as above, but for per-thread stats.
 PER_THREAD_STAT_MAP = {
-    '{0}.num.queries_ip_ratelimited': ('{0}_ratelimit', 1),
-    '{0}.num.cachehits': ('{0}_cachehit', 1),
-    '{0}.num.cachemiss': ('{0}_cachemiss', 1),
-    '{0}.num.zero_ttl': ('{0}_expired', 1),
-    '{0}.num.prefetch': ('{0}_prefetch', 1),
-    '{0}.num.recursivereplies': ('{0}_recursive', 1),
-    '{0}.requestlist.avg': ('{0}_reqlist_avg', 1),
-    '{0}.requestlist.max': ('{0}_reqlist_max', 1),
-    '{0}.requestlist.overwritten': ('{0}_reqlist_overwritten', 1),
-    '{0}.requestlist.exceeded': ('{0}_reqlist_exceeded', 1),
-    '{0}.requestlist.current.all': ('{0}_reqlist_current', 1),
-    '{0}.requestlist.current.user': ('{0}_reqlist_user', 1),
-    '{0}.recursion.time.avg': ('{0}_recursive_avg', PRECISION),
-    '{0}.recursion.time.median': ('{0}_recursive_med', PRECISION)
+    '{shortname}.num.queries_ip_ratelimited': ('{shortname}_ratelimit', 1),
+    '{shortname}.num.cachehits': ('{shortname}_cachehit', 1),
+    '{shortname}.num.cachemiss': ('{shortname}_cachemiss', 1),
+    '{shortname}.num.zero_ttl': ('{shortname}_expired', 1),
+    '{shortname}.num.prefetch': ('{shortname}_prefetch', 1),
+    '{shortname}.num.recursivereplies': ('{shortname}_recursive', 1),
+    '{shortname}.requestlist.avg': ('{shortname}_reqlist_avg', 1),
+    '{shortname}.requestlist.max': ('{shortname}_reqlist_max', 1),
+    '{shortname}.requestlist.overwritten': ('{shortname}_reqlist_overwritten', 1),
+    '{shortname}.requestlist.exceeded': ('{shortname}_reqlist_exceeded', 1),
+    '{shortname}.requestlist.current.all': ('{shortname}_reqlist_current', 1),
+    '{shortname}.requestlist.current.user': ('{shortname}_reqlist_user', 1),
+    '{shortname}.recursion.time.avg': ('{shortname}_recursive_avg', PRECISION),
+    '{shortname}.recursion.time.median': ('{shortname}_recursive_med', PRECISION)
 }
+
+
+# Used to actually generate per-thread charts.
+def _get_perthread_info(thread):
+    sname = 'thread{0}'.format(thread)
+    lname = 'Thread {0}'.format(thread)
+    charts = dict()
+    order = []
+    statmap = dict()
+
+    for item in PER_THREAD_CHARTS:
+        cname = '{0}{1}'.format(sname, item)
+        chart = deepcopy(PER_THREAD_CHARTS[item])
+        chart['options'][1] = chart['options'][1].format(longname=lname)
+
+        for index, line in enumerate(chart['lines']):
+            chart['lines'][index][0] = line[0].format(shortname=sname)
+
+        order.append(cname)
+        charts[cname] = chart
+
+    for key, value in PER_THREAD_STAT_MAP.items():
+        statmap[key.format(shortname=sname)] = (value[0].format(shortname=sname), value[1])
+
+    return (charts, order, statmap)
 
 
 class Service(SocketService):
@@ -155,6 +180,7 @@ class Service(SocketService):
         self.order = deepcopy(ORDER)
         self.definitions = deepcopy(CHARTS)
         self.request = 'UBCT1 stats\n'
+        self.statmap = deepcopy(STAT_MAP)
         self._parse_config()
         self._auto_config()
         self.debug('Extended stats: {0}'.format(self.ext))
@@ -193,26 +219,13 @@ class Service(SocketService):
             self.port = 8953
 
     def _generate_perthread_charts(self):
-        # TODO: THis could probably be more efficient, but it's only
-        # run once, so it probably doesn't really matter.
+        tmporder = list()
         for thread in range(0, self.threads):
-            shortname = 'thread{0}'.format(thread)
-            longname = 'Thread {0}'.format(thread)
-            charts = dict()
-            order = [[], [], []]
-            count = 0
-            for item in PER_THREAD_CHARTS:
-                chartname = '{0}{1}'.format(shortname, item)
-                order[count].append(chartname)
-                count += 1
-                charts[chartname] = deepcopy(PER_THREAD_CHARTS[item])
-                charts[chartname]['options'][1] = charts[chartname]['options'][1].format(longname)
-                for line in range(0, len(charts[chartname]['lines'])):
-                    charts[chartname]['lines'][line][0] = charts[chartname]['lines'][line][0].format(shortname)
-            self.order = self.order + order[0] + order[1] + order[2]
+            charts, order, statmap = _get_perthread_info(thread)
+            tmporder.extend(order)
             self.definitions.update(charts)
-            for key, value in PER_THREAD_STAT_MAP.items():
-                STAT_MAP[key.format(shortname)] = (value[0].format(shortname), value[1])
+            self.statmap.update(statmap)
+        self.order.extend(sorted(tmporder))
 
     def check(self):
         # Check if authentication is working.
@@ -253,7 +266,7 @@ class Service(SocketService):
         for line in raw.splitlines():
             stat = line.split('=')
             tmp[stat[0]] = stat[1]
-        for item in STAT_MAP:
+        for item in self.statmap:
             if item in tmp:
-                data[STAT_MAP[item][0]] = float(tmp[item]) * STAT_MAP[item][1]
+                data[self.statmap[item][0]] = float(tmp[item]) * self.statmap[item][1]
         return data

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -2105,15 +2105,15 @@ netdataDashboard.context = {
 
     'unbound.cache': {
         info: 'The number of items in each of the various caches.'
-    }
+    },
 
     'unbound.threads.queries': {
         height: 0.2
-    }
+    },
 
     'unbound.threads.reqlist': {
         height: 0.2
-    }
+    },
 
     'unbound.threads.recursion': {
         height: 0.2

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -2107,5 +2107,17 @@ netdataDashboard.context = {
         info: 'The number of items in each of the various caches.'
     }
 
+    'unbound.threads.queries': {
+        height: 0.2
+    }
+
+    'unbound.threads.reqlist': {
+        height: 0.2
+    }
+
+    'unbound.threads.recursion': {
+        height: 0.2
+    }
+
     // ------------------------------------------------------------------------
 };


### PR DESCRIPTION
Unbound itself provides per-thread versions of almost all the stats we collect (everything we currently collect excpt for the 'extended' stats).  This PR adds the ability to collect this data, and displays it as a set of reduced-height charts below the main (global) charts for each Unbound instance for which it is enabled.  It provides a new configuration key `per_thread`, which if set to yes (defaults to no)  will enable this for the job.

The module queries the monitored instance of Unbound directly (using some rather hackish trickery to leverage the existing data collection code in `SocketService`) to determine how many threads to create charts for during the `check()` function, so it will not respond to changes in the number of threads at runtime, but the number of threads is something which is not likely to change much (if ever), and having this limitation means that the actual collection logic doesn't have to change at all (because we just update the dictionary used for mapping from returned data to dimensions when we create the chart definitions).

The PR also fixes some typos in the Unbound module documentation and config file, and removes the misguided override of the chart families that the code was previously doing.