### PR TITLE
Add fleep.io notification support.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -448,6 +448,28 @@ DEFAULT_RECIPIENT_PD=""
 
 
 #------------------------------------------------------------------------------
+# fleep notification options
+#
+# To send fleep.io notifications, you will need a webhook for the
+# conversation you want to send to.
+
+# Fleep recipients are specified as the last part of the webhook URL.
+# So, for a webhook URL of: https://fleep.io/hook/IJONmBuuSlWlkb_ttqyXJg, the
+# recipient name would be: 'IJONmBuuSlWlkb_ttqyXJg'.
+
+# enable/disable sending fleep notifications
+SEND_FLEEP="YES"
+
+# if a role's recipients are not configured, a notification will not be sent.
+# (empty = do not send a notification for unconfigured roles):
+DEFAULT_RECIPIENT_FLEEP=""
+
+# The user name to label the messages with.  If this is unset,
+# the hostname of the system the notification is for will be used.
+FLEEP_SENDER=""
+
+
+#------------------------------------------------------------------------------
 # irc notification options
 #
 # irc notifications require only the nc utility to be installed. 
@@ -636,6 +658,8 @@ role_recipients_kavenegar[sysadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_fleep[sysadmin]="${DEFAULT_RECIPIENT_FLEEP}"
+
 role_recipients_irc[sysadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[sysadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
@@ -670,6 +694,8 @@ role_recipients_messagebird[domainadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 role_recipients_kavenegar[domainadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_fleep[domainadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 
 role_recipients_irc[domainadmin]="${DEFAULT_RECIPIENT_IRC}"
 
@@ -707,6 +733,8 @@ role_recipients_kavenegar[dba]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_fleep[dba]="${DEFAULT_RECIPIENT_FLEEP}"
+
 role_recipients_irc[dba]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[dba]="${DEFAULT_RECIPIENT_SYSLOG}"
@@ -742,6 +770,8 @@ role_recipients_messagebird[webmaster]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 role_recipients_kavenegar[webmaster]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_fleep[webmaster]="${DEFAULT_RECIPIENT_FLEEP}"
 
 role_recipients_irc[webmaster]="${DEFAULT_RECIPIENT_IRC}"
 
@@ -779,6 +809,8 @@ role_recipients_kavenegar[proxyadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"
 
+role_recipients_fleep[proxyadmin]="${DEFAULT_RECIPIENT_FLEEP}"
+
 role_recipients_irc[proxyadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[proxyadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
@@ -814,6 +846,8 @@ role_recipients_messagebird[sitemgr]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 role_recipients_kavenegar[sitemgr]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
 role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
+
+role_recipients_fleep[sitemgr]="${DEFAULT_RECIPIENT_FLEEP}"
 
 role_recipients_syslog[sitemgr]="${DEFAULT_RECIPIENT_SYSLOG}"
 


### PR DESCRIPTION
This adds support for sending alarm notifications to fleep.io conversations via webhooks.  It uses the JSON interface to POST a simple message containing information about the alarm, and by default uses the host that raised the alarm as the sender name.

Recipients are specified via the last component of the webhook URL (the only part that's different for each webhook).

I have not tested this myself beyond verifying that it does not break existing notifications, as I don't use Fleep.

Fixes: #3792