### PR TITLE
Monitor active users and sessions via logind.

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -51,6 +51,7 @@ dist_pythonconfig_DATA = \
     python.d/ipfs.conf \
     python.d/isc_dhcpd.conf \
     python.d/litespeed.conf \
+    python.d/logind.conf \
     python.d/mdstat.conf \
     python.d/memcached.conf \
     python.d/mongodb.conf \

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -51,7 +51,7 @@ go_expvar: no
 # ipfs: yes
 # isc_dhcpd: yes
 # litespeed: yes
-# logind: yes
+logind: no
 # mdstat: yes
 # memcached: yes
 # mongodb: yes

--- a/conf.d/python.d.conf
+++ b/conf.d/python.d.conf
@@ -51,6 +51,7 @@ go_expvar: no
 # ipfs: yes
 # isc_dhcpd: yes
 # litespeed: yes
+# logind: yes
 # mdstat: yes
 # memcached: yes
 # mongodb: yes

--- a/conf.d/python.d/logind.conf
+++ b/conf.d/python.d/logind.conf
@@ -1,0 +1,62 @@
+# netdata python.d.plugin configuration for logind
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 60
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     retries: 60             # the JOB's number of restoration attempts
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds

--- a/python.d/Makefile.am
+++ b/python.d/Makefile.am
@@ -39,6 +39,7 @@ dist_python_DATA = \
     ipfs.chart.py \
     isc_dhcpd.chart.py \
     litespeed.chart.py \
+    logind.chart.py \
     mdstat.chart.py \
     memcached.chart.py \
     mongodb.chart.py \

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -1095,7 +1095,7 @@ command: '/path/to/other/command'
 
 ### notes
 
-* This module's ability to trakck logins is dependent on what PAM services
+* This module's ability to track logins is dependent on what PAM services
 are configured to register sessions with logind.  In particular, for
 most systems, it will only track TTY logins, local desktop logins,
 and logins through remote shell connections.

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -1059,6 +1059,57 @@ If no configuration is given, module will use "/tmp/lshttpd/".
 
 ---
 
+# logind
+
+THis module monitors active sessions, users, and seats tracked by systemd-logind or elogind.
+
+It provides the following charts:
+
+1. **Sessions** Tracks the total number of sessions.
+  * Graphical: Local graphical sessions (running X11, or Wayland, or something else).
+  * Console: Local console sessions.
+  * Remote: Remote sessions.
+
+2. **Users** Tracks total number of unique user logins of each type.
+  * Graphical
+  * Console
+  * Remote
+
+3. **Seats** Total number of seats in use.
+  * Seats
+
+### configuration
+
+This module needs no configuration.  Just make sure the netdata user
+can run the `loginctl` command and get a session list without having to
+specify a path.
+
+This will work with any command that can output data in the _exact_
+same format as `loginctl list-sessions --no-legend`.  If you have some
+other command you want to use that outputs data in this format, you can
+specify it using the `command` key like so:
+
+```yaml
+command: '/path/to/other/command'
+```
+
+### notes
+
+* This module's ability to trakck logins is dependent on what PAM services
+are configured to register sessions with logind.  In particular, for
+most systems, it will only track TTY logins, local desktop logins,
+and logins through remote shell connections.
+
+* The users chart counts _usernames_ not UID's.  This is potentially
+important in configurations where multiple users have the same UID.
+
+* The users chart counts any given user name up to once for _each_ type
+of login.  So if the same user has a graphical and a console login on a
+system, they will show up once in the graphical count, and once in the
+console count.
+
+---
+
 # mdstat
 
 Module monitor /proc/mdstat

--- a/python.d/README.md
+++ b/python.d/README.md
@@ -1108,6 +1108,10 @@ of login.  So if the same user has a graphical and a console login on a
 system, they will show up once in the graphical count, and once in the
 console count.
 
+* Because the data collection process is rather expensive, this plugin
+is currently disabled by default, and needs to be explicitly enabled in
+`/etc/netdata/python.d.conf` before it will run.
+
 ---
 
 # mdstat

--- a/python.d/logind.chart.py
+++ b/python.d/logind.chart.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Description: logind netdata python.d module
+# Author: Austin S. Hemmelgarn (Ferroin)
+# SPDX-License-Identifier: GPL-3.0+
+
+import os
+import sys
+
+from bases.FrameworkServices.ExecutableService import ExecutableService
+
+PRIORITY = 40000
+
+ORDER = ['sessions', 'users', 'seats']
+
+CHARTS = {
+    'sessions': {
+        'options': [None, 'Logind Sessions', 'sessions', 'sessions', 'logind.sessions', 'stacked'],
+        'lines': [
+            ['sessions_graphical', 'Graphical', 'absolute', 1, 1],
+            ['sessions_console', 'Console', 'absolute', 1, 1],
+            ['sessions_remote', 'Remote', 'absolute', 1, 1]
+        ]
+    },
+    'users': {
+        'options': [None, 'Logind Users', 'users', 'users', 'logind.users', 'stacked'],
+        'lines': [
+            ['users_graphical', 'Graphical', 'absolute', 1, 1],
+            ['users_console', 'Console', 'absolute', 1, 1],
+            ['users_remote', 'Remote', 'absolute', 1, 1]
+        ]
+    },
+    'seats': {
+        'options': [None, 'Logind Seats', 'seats', 'seats', 'logind.seats', 'line'],
+        'lines': [
+            ['seats', 'Active Seats', 'absolute', 1, 1]
+        ]
+    }
+}
+
+
+class Service(ExecutableService):
+    def __init__(self, configuration=None, name=None):
+        ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.command = 'loginctl list-sessions --no-legend'
+        self.order = ORDER
+        self.definitions = CHARTS
+
+    def _get_data(self):
+        ret = {
+            'sessions_graphical': 0,
+            'sessions_console': 0,
+            'sessions_remote': 0,
+        }
+        users = {
+            'graphical': list(),
+            'console': list(),
+            'remote': list()
+        }
+        seats = list()
+        data = self._get_raw_data()
+
+        for item in data:
+            fields = item.split()
+            if len(fields) == 3:
+                users['remote'].append(fields[2])
+                ret['sessions_remote'] += 1
+            elif len(fields) == 4:
+                users['graphical'].append(fields[2])
+                ret['sessions_graphical'] += 1
+                seats.append(fields[3])
+            elif len(fields) == 5:
+                users['console'].append(fields[2])
+                ret['sessions_console'] += 1
+                seats.append(fields[3])
+
+        ret['users_graphical'] = len(set(users['graphical']))
+        ret['users_console'] = len(set(users['console']))
+        ret['users_remote'] = len(set(users['remote']))
+        ret['seats'] = len(set(seats))
+
+        return ret

--- a/python.d/logind.chart.py
+++ b/python.d/logind.chart.py
@@ -5,7 +5,7 @@
 
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
-PRIORITY = 40000
+prioirty = 59999
 
 ORDER = ['sessions', 'users', 'seats']
 

--- a/python.d/logind.chart.py
+++ b/python.d/logind.chart.py
@@ -3,9 +3,6 @@
 # Author: Austin S. Hemmelgarn (Ferroin)
 # SPDX-License-Identifier: GPL-3.0+
 
-import os
-import sys
-
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
 PRIORITY = 40000

--- a/python.d/logind.chart.py
+++ b/python.d/logind.chart.py
@@ -6,6 +6,7 @@
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
 prioirty = 59999
+disabled_by_default = True
 
 ORDER = ['sessions', 'users', 'seats']
 

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -390,6 +390,12 @@ netdataDashboard.menu = {
         title: '1-Wire Sensors',
         icon: '<i class="fas fa-thermometer-half"></i>',
         info: 'Data derived from <a href="https://en.wikipedia.org/wiki/1-Wire">1-Wire</a> sensors.  Currently temperature sensors are automatically detected.'
+    },
+
+    'logind': {
+        title: 'Logind'
+        icon: '<i class="fas fa-user"></i>',
+        info: undefined
     }
 };
 
@@ -2152,6 +2158,18 @@ netdataDashboard.context = {
 
     'w1sensor.temp': {
         info: 'Temperature derived from 1-Wire temperature sensors.'
+    },
+
+    'logind.sessions': {
+        info: 'Shows the number of active sessions of each type tracked by logind.'
+    },
+
+    'logind.users': {
+        info: 'Shows the number of active users of each type tracked by logind.'
+    },
+
+    'logind.seats': {
+        info: 'Shows the number of active seats tracked by logind.  Each seat corresponds to a combination of a display device and input device providing a physical presence for the system.'
     }
 
     // ------------------------------------------------------------------------

--- a/web/dashboard_info.js
+++ b/web/dashboard_info.js
@@ -393,7 +393,7 @@ netdataDashboard.menu = {
     },
 
     'logind': {
-        title: 'Logind'
+        title: 'Logind',
         icon: '<i class="fas fa-user"></i>',
         info: undefined
     }


### PR DESCRIPTION
'logind' is a daemon used for tracking active users and sessions on a system.  By querying this, we can easily get counts of users and sessions on the system, and additionally differentiate by session type (graphical, console, or remote).

This module uses the `loginctl` command to query the the service, and does some dead simple text processing on the output to extract the required information.  In theory, we could query the DBus methods directly, but that would get us very little in terms of performance, so it's not worth the significantly higher complexity.

This module requires zero configuration.  The only thing that is required is for the user netdata is running as to be able to call `loginctl list-sessions --no-legend` and get reasonable output back.  However, it will work with any command that provides output in the same format as the above mentioned command, and the user can override the command the same way they normally do for `ExecutableService` derived modules.

`logind` itself is originally a systemd service, but Gentoo provides an independent fork of it (called `elogind`) that does not require systemd.

Example output without an icon or descriptions:

![screenshot](https://user-images.githubusercontent.com/905151/41300131-02aeda02-6e33-11e8-900f-2dc729ea45f1.png)

Tested on both python 2 and 3 on multiple systems.  Average runtime on the test systems was approximately 8ms, with peak runtime being just over 20ms (though it appears to only rarely go above about 14ms).