### PR TITLE
Add the BOINC alarms config to Makefile.am

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -91,6 +91,7 @@ dist_healthconfig_DATA = \
     health.d/bcache.conf \
     health.d/beanstalkd.conf \
     health.d/bind_rndc.conf \
+    health.d/boinc.conf \
     health.d/btrfs.conf \
     health.d/ceph.conf \
     health.d/cpu.conf \


### PR DESCRIPTION
@ktsaou Sorry this got missed during the PR for the BOINC module.  I'm still not quite used to working with the autotools build system.  Not technically critical, but would be nice to have merged in the near future.