### PR TITLE
kickstart-static64.sh set UID when it is missing; 

### DIFF
--- a/kickstart-static64.sh
+++ b/kickstart-static64.sh
@@ -3,6 +3,9 @@
 
 umask 022
 
+# make sure UID is set
+[ -z "${UID}" ] && export UID="$(id -u)"
+
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from installer/functions.sh
 


### PR DESCRIPTION
fixes #3840