### PR TITLE
Add basic apcupsd alarm templates

### DIFF
--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -88,6 +88,7 @@ healthconfigdir=$(configdir)/health.d
 
 dist_healthconfig_DATA = \
     health.d/apache.conf \
+    health.d/apcupsd.conf \
     health.d/backend.conf \
     health.d/bcache.conf \
     health.d/beanstalkd.conf \

--- a/conf.d/health.d/apcupsd.conf
+++ b/conf.d/health.d/apcupsd.conf
@@ -13,6 +13,8 @@ template: 10min_ups_load
     info: average UPS load for the last 10 minutes
       to: sitemgr
 
+# Discussion in https://github.com/firehol/netdata/pull/3928:
+# Fire the alarm as soon as it's going on battery (99% charge) and clear only when full.
 template: ups_charge
       on: apcupsd.charge
       os: *
@@ -20,7 +22,7 @@ template: ups_charge
   lookup: average -60s unaligned of charge
    units: %
    every: 60s
-    warn: $this < (($status >= $WARNING)  ? (90) : (98))
+    warn: $this < 100
     crit: $this < (($status == $CRITICAL) ? (60) : (50))
    delay: down 10m multiplier 1.5 max 1h
     info: current UPS charge, averaged over the last 60 seconds to reduce measurement errors

--- a/conf.d/health.d/apcupsd.conf
+++ b/conf.d/health.d/apcupsd.conf
@@ -1,0 +1,38 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+template: 10min_ups_load
+      on: apcupsd.load
+      os: *
+   hosts: *
+  lookup: average -10m unaligned of percentage
+   units: %
+   every: 1m
+    warn: $this > (($status >= $WARNING)  ? (70) : (80))
+    crit: $this > (($status == $CRITICAL) ? (85) : (95))
+   delay: down 10m multiplier 1.5 max 1h
+    info: average UPS load for the last 10 minutes
+      to: sitemgr
+
+template: ups_charge
+      on: apcupsd.charge
+      os: *
+   hosts: *
+  lookup: average -60s unaligned of charge
+   units: %
+   every: 60s
+    warn: $this < (($status >= $WARNING)  ? (90) : (95))
+    crit: $this < (($status == $CRITICAL) ? (20) : (15))
+   delay: down 10m multiplier 1.5 max 1h
+    info: current UPS charge, averaged over the last 60 seconds to reduce measurement errors
+      to: sitemgr
+
+template: apcupsd_last_collected_secs
+      on: apcupsd.load
+    calc: $now - $last_collected_t
+   every: 10s
+   units: seconds ago
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 2 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (10 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: sitemgr

--- a/conf.d/health.d/apcupsd.conf
+++ b/conf.d/health.d/apcupsd.conf
@@ -20,8 +20,8 @@ template: ups_charge
   lookup: average -60s unaligned of charge
    units: %
    every: 60s
-    warn: $this < (($status >= $WARNING)  ? (90) : (95))
-    crit: $this < (($status == $CRITICAL) ? (20) : (15))
+    warn: $this < (($status >= $WARNING)  ? (90) : (98))
+    crit: $this < (($status == $CRITICAL) ? (60) : (50))
    delay: down 10m multiplier 1.5 max 1h
     info: current UPS charge, averaged over the last 60 seconds to reduce measurement errors
       to: sitemgr
@@ -31,8 +31,8 @@ template: apcupsd_last_collected_secs
     calc: $now - $last_collected_t
    every: 10s
    units: seconds ago
-    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 2 * $update_every))
-    crit: $this > (($status == $CRITICAL) ? ($update_every) : (10 * $update_every))
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
    delay: down 5m multiplier 1.5 max 1h
     info: number of seconds since the last successful data collection
       to: sitemgr


### PR DESCRIPTION
I finally took the time and configure the APC UPS correctly. Had one over a year, but it was just in "dumb battery until it runs out" mode.

Anyway, added some alarms. Only the missing collection and charge warnings were actually tested though...

* Warning / Critical when Load is over 80 / 85 % (average over last 10 min)
* Warning / Critical when Charge is under 95 / 15 % (average over last 60 secs, enables fast alarms)
* Warning / Critical when Last collection time is higher than 2 times collection interval (enables fast alarms, with possible false positives)

The reason why I put the charge warning at 95 is, that because normally the charge is 100%. As soon as it goes to battery mode, this will give ppl time to react, if they haven't configured automatic shutdown or other rescue scripts. Those values are all, of course, configurable.

The "last collected" alarm should get triggered, if there wasn't a bug with the apcupsd plugin (#3927)