### PR TITLE
rate limiting streaming requests

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,7 @@ void web_server_threading_selection(void) {
 void web_server_config_options(void) {
     web_client_timeout = (int) config_get_number(CONFIG_SECTION_WEB, "disconnect idle clients after seconds", web_client_timeout);
     web_client_first_request_timeout = (int) config_get_number(CONFIG_SECTION_WEB, "timeout for first request", web_client_first_request_timeout);
+    web_client_streaming_rate_t = config_get_number(CONFIG_SECTION_WEB, "accept a streaming request every seconds", web_client_streaming_rate_t);
 
     respect_web_browser_do_not_track_policy = config_get_boolean(CONFIG_SECTION_WEB, "respect do not track policy", respect_web_browser_do_not_track_policy);
     web_x_frame_options = config_get(CONFIG_SECTION_WEB, "x-frame-options response header", "");

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -1122,15 +1122,17 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
     {
         static netdata_mutex_t stream_rate_mutex = NETDATA_MUTEX_INITIALIZER;
         static volatile time_t last_stream_accepted_t = 0;
-        time_t now = now_realtime_sec();
 
         netdata_mutex_lock(&stream_rate_mutex);
+        time_t now = now_realtime_sec();
+        time_t rate_t = 10;
+
         if(unlikely(last_stream_accepted_t == 0))
             last_stream_accepted_t = now;
 
-        if(last_stream_accepted_t + 30 < now) {
+        if(now - last_stream_accepted_t < rate_t) {
             netdata_mutex_unlock(&stream_rate_mutex);
-            error("STREAM [receive from [%s]:%s]: too busy to accept new streaming request. Try again in %ld secs.", w->client_ip, w->client_port, (long)(last_stream_accepted_t + 30 - now));
+            error("STREAM [receive from [%s]:%s]: too busy to accept new streaming request. Try again in %ld secs.", w->client_ip, w->client_port, (long)(rate_t - (now - last_stream_accepted_t)));
             return rrdpush_receiver_too_busy_now(w);
         }
 

--- a/src/web_server.c
+++ b/src/web_server.c
@@ -409,6 +409,7 @@ static struct web_client *web_client_create_on_listenfd(int listener) {
 
 int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
 int web_client_first_request_timeout = DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST;
+long web_client_streaming_rate_t = 0L;
 
 static void multi_threaded_web_client_worker_main_cleanup(void *ptr) {
     struct web_client *w = ptr;

--- a/src/web_server.h
+++ b/src/web_server.h
@@ -43,5 +43,6 @@ extern int api_listen_sockets_setup(void);
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
 extern int web_client_timeout;
 extern int web_client_first_request_timeout;
+extern long web_client_streaming_rate_t;
 
 #endif /* NETDATA_WEB_SERVER_H */


### PR DESCRIPTION
## The problem

When streaming many hosts to a central netdata, the initialization procedure all the charts adds significant pressure on the central server disks, when `memory mode = map`.

## This PR

This PR adds a netdata.conf option:

```
[web]
  accept a streaming request every seconds = 0
```

The default is zero, so this  PR does nothing.
If you set it to a positive value, the internal netdata web server will allow one streaming request every that many seconds.

So, if you set it to 1, the server will accept 1 streaming request per second. If you set it to 10, it will accept one streaming request every 10 seconds.

---

`memory mode = map` is problematic. It puts quite some pressure on disk, so we need to provide a better solution.
