### PR TITLE
Add Amazon SNS notification support.

### DIFF
--- a/conf.d/health_alarm_notify.conf
+++ b/conf.d/health_alarm_notify.conf
@@ -14,6 +14,7 @@
 # - sms messages to your cell phone or any sms enabled device (twilio.com)
 # - sms messages to your cell phone or any sms enabled device (messagebird.com)
 # - notifications to users on pagerduty.com
+# - notifications to Amazon SNS topics (aws.amazon.com)
 # - messages to your irc channel on your selected network
 # - messages to a local or remote syslog daemon
 # - message to Microsoft Team (thru webhook)
@@ -84,6 +85,11 @@ nc=""
 # If empty, the system $PATH will be searched for it.
 # If not found, syslog notifications will be silently disabled.
 logger=""
+
+# The full path of the aws command.
+# If empty, the system $PATH will be searched for it.
+# If not found, Amazon SNS notifications will be silently disabled.
+aws=""
 
 #------------------------------------------------------------------------------
 # extra options for external commands
@@ -619,6 +625,28 @@ SYSLOG_FACILITY=''
 DEFAULT_RECIPIENT_SYSLOG="netdata"
 
 #------------------------------------------------------------------------------
+# Amazon SNS notifications
+#
+# This method requires potentially complex manual configuration.  See the
+# netdata wiki for information on what is needed.
+
+# enable/disable sending Amazon SNS notifications
+SEND_AWSSNS="YES"
+
+# Specify a template for the Amazon SNS notifications.  This supports
+# the same set of variables that are usable in the `custom_sender()`
+# function in the custom notification configuration below.
+#
+AWSSNS_MESSAGE_FORMAT="${status} on ${host} at ${date}: ${chart} ${value_string}"
+
+# If a role's recipients are not configured, use the following.
+# (empty = do not send a notification for unconfigured roles)
+#
+# Recipients for AWS SNS notifications are specified as topic ARN's.
+#
+DEFAULT_RECIPIENT_AWSSNS=""
+
+#------------------------------------------------------------------------------
 # custom notifications
 #
 
@@ -719,6 +747,8 @@ role_recipients_irc[sysadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[sysadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_awssns[sysadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
+
 role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
 role_recipients_msteam[sysadmin]="${DEFAULT_RECIPIENT_MSTEAM}"
@@ -757,6 +787,8 @@ role_recipients_fleep[domainadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 role_recipients_irc[domainadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[domainadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_awssns[domainadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[domainadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
@@ -798,6 +830,8 @@ role_recipients_irc[dba]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[dba]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_awssns[dba]="${DEFAULT_RECIPIENT_AWSSNS}"
+
 role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
 
 role_recipients_msteam[dba]="${DEFAULT_RECIPIENT_MSTEAM}"
@@ -837,6 +871,8 @@ role_recipients_fleep[webmaster]="${DEFAULT_RECIPIENT_FLEEP}"
 role_recipients_irc[webmaster]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[webmaster]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_awssns[webmaster]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[webmaster]="${DEFAULT_RECIPIENT_CUSTOM}"
 
@@ -878,6 +914,8 @@ role_recipients_irc[proxyadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[proxyadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_awssns[porxyadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
+
 role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
 role_recipients_msteam[proxyadmin]="${DEFAULT_RECIPIENT_MSTEAM}"
@@ -915,6 +953,8 @@ role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
 role_recipients_fleep[sitemgr]="${DEFAULT_RECIPIENT_FLEEP}"
 
 role_recipients_syslog[sitemgr]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_awssns[sitemgr]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[sitemgr]="${DEFAULT_RECIPIENT_CUSTOM}"
 

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -604,9 +604,9 @@ do
         [ "${r}" != "disabled" ] && filter_recipient_by_criticality irc "${r}" && arr_irc[${r/|*/}]="1"
     done
 
-    # awssns
+    # amazon sns
     a="${role_recipients_awssns[${x}]}"
-    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_awssns}"
+    [ -z "${a}" ] && a="${DEFAULT_RECIPIENT_AWSSNS}"
     for r in ${a//,/ }
     do
         [ "${r}" != "disabled" ] && filter_recipient_by_criticality awssns "${r}" && arr_awssns[${r/|*/}]="1"

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1830,7 +1830,7 @@ send_awssns() {
     for target in ${targets} ; do
         # Extract the region from the target ARN.  We need to explicitly specify the region so that it matches up correctly.
         region="$(echo ${target} | cut -f 4 -d ':')"
-        ${aws} --region "${region}" --subject "${host} ${status_message} - ${name//_/ } - ${chart}" --message "${message}" --target-arn ${target} &>/dev/null
+        ${aws} sns publish --region "${region}" --subject "${host} ${status_message} - ${name//_/ } - ${chart}" --message "${message}" --target-arn ${target} &>/dev/null
         if [ $? = 0 ]; then
             info "sent Amazon SNS notification for: ${host} ${chart}.${name} is ${status} to '${target}'"
             sent=$((sent + 1))

--- a/plugins.d/alarm-notify.sh
+++ b/plugins.d/alarm-notify.sh
@@ -1833,7 +1833,7 @@ send_awssns() {
         ${aws} --region "${region}" --subject "${host} ${status_message} - ${name//_/ } - ${chart}" --message "${message}" --target-arn ${target} &>/dev/null
         if [ $? = 0 ]; then
             info "sent Amazon SNS notification for: ${host} ${chart}.${name} is ${status} to '${target}'"
-            sent=$((${sent} + 1))
+            sent=$((sent + 1))
         else
             error "failed to send Amazon SNS notification for: ${host} ${chart}.${name} is ${status} to '${target}'" 
         fi


### PR DESCRIPTION
The Simple Notification Service (SNS) is a reasonably simple message broker service provided by Amazon as part of it's AWS offerings.

SNS utilizes the concept of 'topics' (similar to Netdata's concept of 'roles' for notifications) to control message routing.  Any given topic may have any number of subscribers of any of the following types..

* Email addresses.
* Phone numbers for SMS.
* HTTP or HTTPS web hooks.
* AWS Lambda endpoints.
* AWS SQS endpoints.
* Mobile applications (via various native push notification services).

Topics are represented by Amazon Resource Names (ARN), which are a special type of URI.

Unfortunately, properly signing requests to AWS endpoints is a serious pain in the arse, so we pretty much have to use the CLI interface. Because of the inflexibility of this tool, setup is somewhat painful.

This uses topic ARN's directly as recipients.  SNS does not support delivery to multiple topics in bulk, so a separate call is required for each topic ARN.  Users are provided with the ability to customize the message format used for the notifications.

------

As mentioned above, setup for this is somewhat complicated (not hard per-se, mostly just tedious).  The AWS CLI assumes that you have your configuration in '~/.aws`, and has no way to change or override this securely (you can provide configuration options as environment variables, but that is a bad idea given that the only two configuration options needed for this are security credentials).  I plan to write up a page on the Wiki going over how to set up a system to send notifications via SNS once this gets merged.

I have not yet done any significant testing of this code.  I plan to do so over the weekend, and will report back with either confirmation that it's working, or with updates to get it working when that's done.