### PR TITLE
heartbeat now reports durations in realtime

### DIFF
--- a/src/clocks.h
+++ b/src/clocks.h
@@ -18,7 +18,10 @@ typedef unsigned long long msec_t;
 typedef unsigned long long usec_t;
 typedef long long susec_t;
 
-typedef usec_t heartbeat_t;
+typedef struct heartbeat {
+    usec_t monotonic;
+    usec_t realtime;
+} heartbeat_t;
 
 /* Linux value is as good as any other */
 #ifndef CLOCK_REALTIME
@@ -120,6 +123,6 @@ extern void heartbeat_init(heartbeat_t *hb);
 extern usec_t heartbeat_next(heartbeat_t *hb, usec_t tick);
 
 /* Returns elapsed time in microseconds since last heartbeat */
-extern usec_t heartbeat_dt_usec(heartbeat_t *hb);
+extern usec_t heartbeat_monotonic_dt_to_now_usec(heartbeat_t *hb);
 
 #endif /* NETDATA_CLOCKS_H */

--- a/src/plugin_freebsd.c
+++ b/src/plugin_freebsd.c
@@ -114,7 +114,7 @@ void *freebsd_main(void *ptr) {
             debug(D_PROCNETDEV_LOOP, "FREEBSD calling %s.", pm->name);
 
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
-            pm->duration = heartbeat_dt_usec(&hb) - duration;
+            pm->duration = heartbeat_monotonic_dt_to_now_usec(&hb) - duration;
             duration += pm->duration;
 
             if(unlikely(netdata_exit)) break;

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -789,7 +789,6 @@ void *nfacct_main(void *ptr) {
     heartbeat_t hb;
     heartbeat_init(&hb);
     for(;;) {
-        heartbeat_dt_usec(&hb);
         heartbeat_next(&hb, step);
 
         if(unlikely(netdata_exit)) break;

--- a/src/plugin_proc.c
+++ b/src/plugin_proc.c
@@ -109,7 +109,7 @@ void *proc_main(void *ptr) {
             debug(D_PROCNETDEV_LOOP, "PROC calling %s.", pm->name);
 
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
-            pm->duration = heartbeat_dt_usec(&hb) - duration;
+            pm->duration = heartbeat_monotonic_dt_to_now_usec(&hb) - duration;
             duration += pm->duration;
 
             if(unlikely(netdata_exit)) break;

--- a/src/plugin_proc_diskspace.c
+++ b/src/plugin_proc_diskspace.c
@@ -360,7 +360,7 @@ void *proc_diskspace_main(void *ptr) {
     heartbeat_t hb;
     heartbeat_init(&hb);
     while(!netdata_exit) {
-        duration = heartbeat_dt_usec(&hb);
+        duration = heartbeat_monotonic_dt_to_now_usec(&hb);
         /* usec_t hb_dt = */ heartbeat_next(&hb, step);
 
         if(unlikely(netdata_exit)) break;


### PR DESCRIPTION
This PR should fix the issue of apps.plugin reporting data collection durations using monotonic clocks.
The durations are now reported using the realtime clock, although the sleep time is calculated using the monotonic clock.

related to #3752 