### PR TITLE
relaxed network alarms

### DIFF
--- a/conf.d/health.d/tcp_listen.conf
+++ b/conf.d/health.d/tcp_listen.conf
@@ -20,8 +20,9 @@
   lookup: sum -60s unaligned absolute of ListenDrops
    units: drops
    every: 10s
-    crit: $this > 0
+    warn: $this > 0
+    crit: $this > (($status == $CRITICAL) ? (0) : (60))
    delay: up 0 down 5m multiplier 1.5 max 1h
-    info: the number of TCP listen socket drops during the last minute
+    info: the number of TCP listen socket drops during the last minute (includes bogus packets received)
       to: sysadmin
 

--- a/conf.d/health.d/udp_errors.conf
+++ b/conf.d/health.d/udp_errors.conf
@@ -27,7 +27,7 @@
    units: errors
    every: 10s
     warn: $this > 0
-    crit: $this > 100
+    crit: $this > (($status == $CRITICAL) ? (0) : (100))
     info: number of UDP receive buffer errors during the last minute
    delay: up 0 down 60m multiplier 1.2 max 2h
       to: sysadmin
@@ -43,7 +43,7 @@
    units: errors
    every: 10s
     warn: $this > 0
-    crit: $this > 100
+    crit: $this > (($status == $CRITICAL) ? (0) : (100))
     info: number of UDP send buffer errors during the last minute
    delay: up 0 down 60m multiplier 1.2 max 2h
       to: sysadmin


### PR DESCRIPTION
an attempt to make network alarms more reasonable:

1. `1m_ipv4_tcp_listen_drops` is now warning for up to 60 packets
2. `1m_ipv4_udp_receive_buffer_errors` and `1m_ipv4_udp_send_buffer_errors` are now leaving the critical state when the alarm zeros (to avoid flip-flop of critical state when the alarms fluctuate around 100.

Fixes: #3826