### PR TITLE
sync the time between slave and master

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -235,6 +235,7 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_HETEROGENEOUS    = 1 << 8, // if set, the chart is not homogeneous (dimensions in it have multiple algorithms, multipliers or dividers)
     RRDSET_FLAG_HOMEGENEOUS_CHECK= 1 << 9, // if set, the chart should be checked to determine if the dimensions as homogeneous
     RRDSET_FLAG_HIDDEN           = 1 << 10, // if set, do not show this chart on the dashboard, but use it for backends
+    RRDSET_FLAG_SYNC_CLOCK       = 1 << 11, // if set, microseconds on next data collection will be ignored (the chart will be synced to now)
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -247,6 +247,7 @@ typedef enum rrdset_flags {
 #define rrdset_flag_set(st, flag)   (st)->flags |= (flag)
 #define rrdset_flag_clear(st, flag) (st)->flags &= ~(flag)
 #endif
+#define rrdset_flag_check_noatomic(st, flag) ((st)->flags & (flag))
 
 struct rrdset {
     // ------------------------------------------------------------------------

--- a/src/rrddim.c
+++ b/src/rrddim.c
@@ -48,6 +48,7 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
     rd->hash_name = simple_hash(rd->name);
     rrddimvar_rename_all(rd);
     rd->exposed = 0;
+    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
     return 1;
 }
 
@@ -59,6 +60,7 @@ inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm)
     rd->algorithm = algorithm;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
+    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
     return 1;
 }
 
@@ -70,6 +72,7 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multip
     rd->multiplier = multiplier;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
+    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
     return 1;
 }
 
@@ -81,6 +84,7 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     rd->divisor = divisor;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
+    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
     return 1;
 }
 
@@ -89,6 +93,9 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
 
 RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm, RRD_MEMORY_MODE memory_mode) {
     rrdset_wrlock(st);
+
+    rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
 
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(rd)) {

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -153,7 +153,7 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
 // sends the current chart dimensions
 static inline void rrdpush_send_chart_metrics_nolock(RRDSET *st) {
     RRDHOST *host = st->rrdhost;
-    buffer_sprintf(host->rrdpush_sender_buffer, "BEGIN \"%s\" %llu\n", st->id, (st->upstream_resync_time > st->last_collected_time.tv_sec)?st->usec_since_last_update:0);
+    buffer_sprintf(host->rrdpush_sender_buffer, "BEGIN \"%s\" %llu\n", st->id, (st->last_collected_time.tv_sec > st->upstream_resync_time)?st->usec_since_last_update:0);
 
     RRDDIM *rd;
     rrddim_foreach_read(rd, st) {

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -76,9 +76,14 @@ static inline int need_to_send_chart_definition(RRDSET *st) {
         return 1;
 
     RRDDIM *rd;
-    rrddim_foreach_read(rd, st)
-        if(unlikely(!rd->exposed))
+    rrddim_foreach_read(rd, st) {
+        if(unlikely(!rd->exposed)) {
+            #ifdef NETDATA_INTERNAL_CHECKS
+            info("host '%s', chart '%s', dimension '%s' flag 'exposed' triggered chart refresh to upstream", st->rrdhost->hostname, st->id, rd->id);
+            #endif
             return 1;
+        }
+    }
 
     return 0;
 }

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -718,7 +718,7 @@ RRDSET *rrdset_create_custom(
 // RRDSET - data collection iteration control
 
 inline void rrdset_next_usec_unfiltered(RRDSET *st, usec_t microseconds) {
-    if(unlikely(!st->last_collected_time.tv_sec || !microseconds)) {
+    if(unlikely(!st->last_collected_time.tv_sec || !microseconds || (rrdset_flag_check_noatomic(st, RRDSET_FLAG_SYNC_CLOCK)))) {
         // call the full next_usec() function
         rrdset_next_usec(st, microseconds);
         return;
@@ -736,7 +736,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
     usec_t discarded = microseconds;
     #endif
 
-    if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_SYNC_CLOCK))) {
+    if(unlikely(rrdset_flag_check_noatomic(st, RRDSET_FLAG_SYNC_CLOCK))) {
         // the chart needs to be re-synced to current time
         rrdset_flag_clear(st, RRDSET_FLAG_SYNC_CLOCK);
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -477,7 +477,11 @@ RRDSET *rrdset_create_custom(
     snprintfz(fullid, RRD_ID_LENGTH_MAX, "%s.%s", type, id);
 
     RRDSET *st = rrdset_find_on_create(host, fullid);
-    if(st) return st;
+    if(st) {
+        rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+        rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+        return st;
+    }
 
     rrdhost_wrlock(host);
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -727,7 +727,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
     now_realtime_timeval(&now);
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    char *discard_reason = "UNDEFINED";
+    char *discard_reason = NULL;
     usec_t discarded = microseconds;
     #endif
 
@@ -739,7 +739,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
         microseconds = 0;
 
         #ifdef NETDATA_INTERNAL_CHECKS
-        discard_reason = "SYNC CLOCK FLAG";
+        if(!discard_reason) discard_reason = "SYNC CLOCK FLAG";
         #endif
     }
 
@@ -747,14 +747,14 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
         // the first entry
         microseconds = st->update_every * USEC_PER_SEC;
         #ifdef NETDATA_INTERNAL_CHECKS
-        discard_reason = "FIRST DATA COLLECTION";
+        if(!discard_reason) discard_reason = "FIRST DATA COLLECTION";
         #endif
     }
     else if(unlikely(!microseconds)) {
         // no dt given by the plugin
         microseconds = dt_usec(&now, &st->last_collected_time);
         #ifdef NETDATA_INTERNAL_CHECKS
-        discard_reason = "NO USEC GIVEN BY COLLECTOR";
+        if(!discard_reason) discard_reason = "NO USEC GIVEN BY COLLECTOR";
         #endif
     }
     else {
@@ -775,7 +775,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
 
             microseconds    = st->update_every * USEC_PER_SEC;
             #ifdef NETDATA_INTERNAL_CHECKS
-            discard_reason = "COLLECTION TIME IN FUTURE";
+            if(!discard_reason) discard_reason = "COLLECTION TIME IN FUTURE";
             #endif
         }
         else if(unlikely((usec_t)since_last_usec > (usec_t)(st->update_every * 5 * USEC_PER_SEC))) {
@@ -784,7 +784,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
 
             microseconds = (usec_t)since_last_usec;
             #ifdef NETDATA_INTERNAL_CHECKS
-            discard_reason = "COLLECTION TIME TOO FAR IN THE PAST";
+            if(!discard_reason) discard_reason = "COLLECTION TIME TOO FAR IN THE PAST";
             #endif
         }
 
@@ -818,7 +818,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
     rrdset_debug(st, "NEXT: %llu microseconds", microseconds);
 
     if(discarded && discarded != microseconds)
-        info("host '%s', chart '%s': discarded data collection time of %llu usec, replaced with %llu usec, reason: '%s'", st->rrdhost->hostname, st->id, discarded, microseconds, discard_reason);
+        info("host '%s', chart '%s': discarded data collection time of %llu usec, replaced with %llu usec, reason: '%s'", st->rrdhost->hostname, st->id, discarded, microseconds, discard_reason?discard_reason:"UNDEFINED");
 
     #endif
 

--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -485,6 +485,7 @@ RRDSET *rrdset_create_custom(
     if(st) {
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+        rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
         return st;
     }
 


### PR DESCRIPTION
There were 2 issues:

1. The slave was expected to send a data collection duration = zero, for 1 minute after connected to the master and then push the real data collection duration. This was buggy. A `>` should be `<`, so it actually reversed the operation: it was sending the real duration for the first 60 seconds, and then sent just zeros. Fixed #3966 

2. The master should be able to detect this. But the code was incomplete. Now, new code has been added to mark each chart that is being created and use that mark to ignore the next (just 1) data collection duration.

   This improves all plugins too, since they are now not required to send the first data collection as zero. They can send anything and netdata will just ignore the first data collection duration.

   This also allows plugins to resync the clock at any time. By just pushing the chart definition to netdata, the next data collection duration will be ignored, thus the chart will be synced to the current time.
