### PR TITLE
Fix config path

### DIFF
--- a/plugins.d/python.d.plugin
+++ b/plugins.d/python.d.plugin
@@ -18,7 +18,7 @@ from time import sleep
 
 
 PY_VERSION = version_info[:2]
-PLUGIN_CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', os.path.dirname(__file__) + '/../../../../etc/netdata') + '/'
+PLUGIN_CONFIG_DIR = os.getenv('NETDATA_CONFIG_DIR', '/etc/netdata') + '/'
 CHARTS_PY_DIR = os.path.abspath(os.getenv('NETDATA_PLUGINS_DIR', os.path.dirname(__file__)) + '/../python.d') + '/'
 CHARTS_PY_CONFIG_DIR = PLUGIN_CONFIG_DIR + 'python.d/'
 PYTHON_MODULES_DIR = CHARTS_PY_DIR + 'python_modules'


### PR DESCRIPTION
Since the config is expected to be located in  /etc/netdata it is kind 
of silly to use ../../../../ to get to the right path. Moreover it 
breaks netdata on Debian.