### PR TITLE
Add support for float values for time_multiplier in web_log

### DIFF
--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -629,7 +629,7 @@ class Web:
 
         resp_time_func = self.configuration.get('custom_log_format', dict()).get('time_multiplier') or 0
 
-        if not isinstance(resp_time_func, int):
+        if not isinstance(resp_time_func, (int, float)):
             return find_regex_return(msg='Custom log: "time_multiplier" is not an integer')
 
         try:


### PR DESCRIPTION
It fixes #4003. 

After merging this PR, response times in nanoseconds will be supported as well. You just need to set `time_multiplier` to `0.001`.