### PR TITLE
Split bash expression for not using && in simple brackets

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -460,7 +460,7 @@ issystemd() {
         ns="$(readlink /proc/${p}/ns/pid 2>/dev/null)"
 
         # if pid of systemd is in our namespace, it is systemd
-        [ ! -z "${myns}" && "${myns}" = "${ns}" ] && return 0
+        [ ! -z "${myns}" ] && [ "${myns}" = "${ns}" ] && return 0
     done
 
     # else, it is not systemd


### PR DESCRIPTION
I was trying to install netdata on an Ubuntu 14, when I saw that it installed the Sys v init script instead of the systemd `.service` file.

Checking for what could cause this, I observed that the current "issystemd" function used by the installer was not behaving quite correctly on certain bash versions.

I extracted the function and used this script to test :

```SHELL
#!/bin/bash

issystemd() {
    local pids p myns ns systemctl

    # if the directory /etc/systemd/system does not exit, it is not systemd
    [ ! -d /etc/systemd/system ] && return 1

    # if there is no systemctl command, it is not systemd
    systemctl=$(which systemctl 2>/dev/null || command -v systemctl 2>/dev/null)
    [ -z "${systemctl}" -o ! -x "${systemctl}" ] && return 1

    # if pid 1 is systemd, it is systemd
    [ "$(basename $(readlink /proc/1/exe) 2>/dev/null)" = "systemd" ] && return 0

    # if systemd is not running, it is not systemd
    pids=$(pidof systemd 2>/dev/null)
    [ -z "${pids}" ] && return 1

    # check if the running systemd processes are not in our namespace
    myns="$(readlink /proc/self/ns/pid 2>/dev/null)"
    for p in ${pids}
    do
        ns="$(readlink /proc/${p}/ns/pid 2>/dev/null)"

        # if pid of systemd is in our namespace, it is systemd
        [ ! -z "${myns}" && "${myns}" = "${ns}" ] && return 0
    done

    # else, it is not systemd
    return 1
}

issystemd
RC=$?
[[ "$RC" == "0" ]] && echo "systemd present" || echo "systemd absent"
```

On my test machine :

```
root@lab-u14:~# lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.5 LTS
Release:        14.04
Codename:       trusty
root@lab-u14:~# bash --version
GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

This scripts errors out :

```
root@lab-u14:~# bash issystemd.sh 
issystemd.sh: line 27: [: missing `]'
systemd absent
```

The problem lies on this line :

```
[ ! -z "${myns}" && "${myns}" = "${ns}" ] && return 0
```

You can't use `&&` inside simple brackets test, you should either :

###### split the expression :

```
[ ! -z "${myns}" ] && [ "${myns}" = "${ns}" ] && return 0
```

###### use the -a flag (deprecated see reference) :

```
[ ! -z "${myns}" -a "${myns}" = "${ns}" ] && return 0
```

###### use double brackets :

```
[[ ! -z "${myns}" && "${myns}" = "${ns}" ]] && return 0
```

I've chosen the first for this pull request since it's the more portable (I think ?), and even tested it on multiple OSes :

```
lab-c6:   "systemd  absent"
lab-c7:   "systemd  present"
lab-d7:   "systemd  absent"
lab-d8:   "systemd  present"
lab-d9:   "systemd  present"
lab-u14:  "systemd  present"
lab-u16:  "systemd  present"
lab-u18:  "systemd  present"
```

I would generally advice to stop using `[` in favor of `[[`, but I suppose there is a compatibility reason somewhere ?

Reference
---------

[BashFAQ](http://mywiki.wooledge.org/BashFAQ/031#np2)
