### PR TITLE
Add `__slots__` attributes to isolated class definitions in python.d modules.

### DIFF
--- a/python.d/hddtemp.chart.py
+++ b/python.d/hddtemp.chart.py
@@ -25,6 +25,8 @@ RE = re.compile(r'\/dev\/([^|]+)\|([^|]+)\|([0-9]+|SLP|UNK)\|')
 
 
 class Disk:
+    __slots__ = ('id', 'name', 'temp')
+
     def __init__(self, id_, name, temp):
         self.id = id_.split('/')[-1]
         self.name = name.replace(' ', '_')

--- a/python.d/icecast.chart.py
+++ b/python.d/icecast.chart.py
@@ -24,6 +24,8 @@ CHARTS = {
 
 
 class Source:
+    __slots__ = ('name', 'is_active', 'listeners')
+
     def __init__(self, idx, data):
         self.name = 'source_{0}'.format(idx)
         self.is_active = data.get('stream_start') and data.get('server_name')

--- a/python.d/isc_dhcpd.chart.py
+++ b/python.d/isc_dhcpd.chart.py
@@ -45,6 +45,8 @@ CHARTS = {
 
 
 class DhcpdLeasesFile:
+    __slots__ = ('path', 'mod_time', 'size')
+
     def __init__(self, path):
         self.path = path
         self.mod_time = 0
@@ -81,6 +83,8 @@ class DhcpdLeasesFile:
 
 
 class Pool:
+    __slots__ = ('id', 'name', 'network')
+
     def __init__(self, name, network):
         self.id = re.sub(r'[:/.-]+', '_', name)
         self.name = name
@@ -94,6 +98,8 @@ class Pool:
 
 
 class Lease:
+    __slots__ = ('address', 'ends', 'state')
+
     def __init__(self, address, ends, state):
         self.address = ipaddress.ip_address(address=u'%s' % address)
         self.ends = ends

--- a/python.d/mdstat.chart.py
+++ b/python.d/mdstat.chart.py
@@ -84,6 +84,8 @@ def md_charts(name):
 
 
 class MD:
+    __slots__ = ('d', 'name')
+
     def __init__(self, raw_data):
         self.name = raw_data["array"]
         self.d = raw_data

--- a/python.d/megacli.chart.py
+++ b/python.d/megacli.chart.py
@@ -124,6 +124,8 @@ def find_batteries(d):
 
 
 class Adapter:
+    __slots__ = ('id', 'state')
+
     def __init__(self, n, state):
         self.id = n
         self.state = int(state == 'Degraded')
@@ -135,6 +137,8 @@ class Adapter:
 
 
 class PD:
+    __slots__ = ('id', 'media_err', 'predict_fail')
+
     def __init__(self, n, media_err, predict_fail):
         self.id = n
         self.media_err = media_err
@@ -148,6 +152,8 @@ class PD:
 
 
 class Battery:
+    __slots__ = ('id', 'rel_charge', 'cycle_count')
+
     def __init__(self, adapt_id, rel_charge, cycle_count):
         self.id = adapt_id
         self.rel_charge = rel_charge
@@ -162,6 +168,8 @@ class Battery:
 
 # TODO: hardcoded sudo...
 class Megacli:
+    __slots__ = ('s', 'm', 'sudo_check', 'disk_info', 'battery_info')
+
     def __init__(self):
         self.s = find_binary('sudo')
         self.m = find_binary('megacli')

--- a/python.d/nginx_plus.chart.py
+++ b/python.d/nginx_plus.chart.py
@@ -319,6 +319,8 @@ BAD_SYMBOLS = re.compile(r'[:/.-]+')
 
 
 class Cache:
+    __slots__ = ('real_name', 'name')
+
     key = 'caches'
     charts = cache_charts
 
@@ -339,6 +341,8 @@ class Cache:
 
 
 class WebZone:
+    __slots__ = ('real_name', 'name')
+
     key = 'server_zones'
     charts = web_zone_charts
 
@@ -353,6 +357,8 @@ class WebZone:
 
 
 class WebUpstream:
+    __slots__ = ('real_name', 'name', 'peers')
+
     key = 'upstreams'
     charts = web_upstream_charts
 
@@ -408,6 +414,8 @@ class WebUpstream:
 
 
 class WebUpstreamPeer:
+    __slots__ = ('id', 'real_server', 'server', 'active')
+
     def __init__(self, idx, server):
         self.id = idx
         self.real_server = server

--- a/python.d/ntpd.chart.py
+++ b/python.d/ntpd.chart.py
@@ -163,6 +163,8 @@ PEER_CHARTS = {
 
 
 class Base:
+    # No need for __slots__, no instance variables.
+
     regex = re.compile(r'([a-z_]+)=((?:-)?[0-9]+(?:\.[0-9]+)?)')
 
     @staticmethod
@@ -190,6 +192,8 @@ class Base:
 
 
 class System(Base):
+    __slots__ = ('request')
+
     def __init__(self):
         self.request = self.get_header()
 
@@ -204,6 +208,8 @@ class System(Base):
 
 
 class Peer(Base):
+    __slots__ = ('id', 'real_name', 'name', 'request')
+
     def __init__(self, idx, name):
         self.id = idx
         self.real_name = name

--- a/python.d/smartd_log.chart.py
+++ b/python.d/smartd_log.chart.py
@@ -130,6 +130,8 @@ def handle_os_error(method):
 
 
 class SmartAttribute(object):
+    __slots__ = ('id', 'normalized', '_raw')
+
     def __init__(self, idx, normalized, raw):
         self.id = idx
         self.normalized = normalized
@@ -150,6 +152,8 @@ class SmartAttribute(object):
 
 
 class DiskLogFile:
+    __slots__ = ('path', 'size')
+
     def __init__(self, path):
         self.path = path
         self.size = os.path.getsize(path)
@@ -171,6 +175,8 @@ class DiskLogFile:
 
 
 class Disk:
+    __slots__ = ('log_file', 'name', 'age', 'status', 'attributes')
+
     def __init__(self, full_path, age):
         self.log_file = DiskLogFile(full_path)
         self.name = os.path.basename(full_path).split('.')[-3]

--- a/python.d/varnish.chart.py
+++ b/python.d/varnish.chart.py
@@ -133,6 +133,8 @@ CHARTS = {
 
 
 class Parser:
+    __slots__ = ('re_default', 're_backend')
+
     _backend_new = re.compile(r'VBE.([\d\w_.]+)\(.*?\).(beresp[\w_]+)\s+(\d+)')
     _backend_old = re.compile(r'VBE\.[\d\w-]+\.([\w\d_]+).(beresp[\w_]+)\s+(\d+)')
     _default = re.compile(r'([A-Z]+\.)?([\d\w_.]+)\s+(\d+)')

--- a/python.d/web_log.chart.py
+++ b/python.d/web_log.chart.py
@@ -317,6 +317,8 @@ class Service(LogService):
 
 
 class Web:
+    __slots__ = ('service', 'order', 'definitions', 'pre_filter', 'storage', 'data')
+
     def __init__(self, service):
         self.service = service
         self.order = ORDER_WEB[:]
@@ -762,6 +764,8 @@ class Web:
 
 
 class ApacheCache:
+    __slots__ = ('service', 'order', 'definitions')
+
     def __init__(self, service):
         self.service = service
         self.order = ORDER_APACHE_CACHE
@@ -788,6 +792,8 @@ class ApacheCache:
 
 
 class Squid:
+    __slots__ = ('service', 'order', 'definitions', 'pre_filter', 'storage', 'data')
+
     def __init__(self, service):
         self.service = service
         self.order = ORDER_SQUID


### PR DESCRIPTION
By default, Python stores all the instance attributes of an object in a dictionary.  THis is great for simplicity, and means you can add new attributes at runtime that were not defined by the original object.

However, in CPython (the reference implementation), dictionaries are not very memory efficient.  They consist of a series of 'slots', which consist of a pointer to the key for that slot, a pointer to the value for that key, and a handful of extra metadata. All the slots get pre-allocated, they start with 8 slots, and they expand automatically by reallocating to twice the number of slots when 2/3 of the existing slots have been used (so the expand to 16 slots when 6 have been used, 32 when 11 have been used, 64 when 22 have been used, etc).  As a result of this, objects tend to be bigger than they need to be by at least a few hundred bytes.

This is where the `__slots__` attribute comes in.  This lets you specify ahead of time an exact set of which instance attributes are usable for objects of that class, which in turn has a couple of nice benefits:

* Only slots for the attributes defined will be allocated, which means there is no overhead from unused slots.
* The number of slots never changes, which means that you never have to reallocate memory to assign an attribute, thus eliminating one source of latency found in object instantiation.
* Because the number of slots is fixed and exactly equal to the number of attribute names, there are never any hash collisions when accessing attributes, which makes attribute access more deterministic (and also marginally faster in some cases).
* Because you can't assign attributes whose name is not in `__slots__`, typos in attribute assignment for objects of that class will always result in syntax errors, instead of being potentially silent logic errors.

There are however a couple of disadvantages to using `__slots__`:

* Because of how weak references are handled in Python in general, you can't have weak references to objects whose class defines a `__slots__` attribute.  This one doesn't matter fr our usage, since we don't use weak references.
* For rather complicated reasons that even I don't entirely understand, `__slots__` doesn't work with multiple inheritance except for some very specific and not hugely useful cases.

My original plan was to adapt almost everything including the FrameworkServices and the actual module Service classes to use `__slots__` (total savings from doing this on the two systems I checked was around 16-32kB, but the systems in question don't run any of the modules likely to really benefit from this), but because of the second issue listed above, doing that does not work with the HAProxy module, so I just stuck to adding them to taxonomically isolated classes (that is, ones which are never inherited from, and either inherit from nothing, or don't inherit any instance attributes from anything).

CPython users will see a memory usage improvement of anywhere from a few dozen to a few hundred bytes per-instance of each class this touches (calculated based on CPython 3.6 source code), and a speed improvement of a few hundred CPU cycles on object instantiation and attribute access (calculated based on a combination of CPython 3.6 source code and compiled code for 64-bit x86).  Gutsy people who are running Netdata on PyPy will see no improvement, because it already does all the optimizations this triggers.

----
### TL;DR

This provides (really) small runtime memory usage and performance improvements for the python.d modules it touches, with minimal maintenance overhead.  Exact improvements are dependent on the particular Python implementation being used.

The changes for the ntpd, web_log, isc_dhcp, and hddtemp modules have been tested on actual production instances of what they monitor.  The icecast, mdstat, smartd_log, and varnish changes have been tested on trivial testing instances without any actual production data.  The nginx_plus and megacli modules have not been tested simply because I don't own the required hardware and don't' have a license respectively.  All testing was done on both CPython 2.7 and CPython 3.6.

There is a trivial one-line merge conflict between this and #4025.