### PR TITLE
proc_interrupts/softirqs parser fix

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -104,3 +104,4 @@ username|name|email (optional)
 @rda0|Sven Mäder|maeder@phys.ethz.ch
 @alibo|Ali Borhani|aliborhani1@gmail.com
 @Nani-o|Sofiane Medjkoune|sofiane@medjkoune.fr
+@abalabahaha|abalabahaha|hi@abal.moe

--- a/src/proc_interrupts.c
+++ b/src/proc_interrupts.c
@@ -61,7 +61,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/interrupts");
-        ff = procfile_open(config_get("plugin:proc:/proc/interrupts", "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
+        ff = procfile_open(config_get("plugin:proc:/proc/interrupts", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
     }
     if(unlikely(!ff))
         return 1;

--- a/src/proc_softirqs.c
+++ b/src/proc_softirqs.c
@@ -60,7 +60,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/softirqs");
-        ff = procfile_open(config_get("plugin:proc:/proc/softirqs", "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
+        ff = procfile_open(config_get("plugin:proc:/proc/softirqs", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) return 1;
     }
 


### PR DESCRIPTION
For a system with insanely high interrupts/softirqs, netdata appears to parse tokens like `IPI0:1145401553` as a single word, inadvertently creating new dimensions every time the file is parsed.

It looks like a couple other `/proc/*` separators were changed to include the colon (`" \t:"`), but `/proc/interrupts` and `/proc/softirqs` monitors do not (`" \t"`).

Fixes #4051