### PR TITLE
do not clear the database when it refers to the future

### DIFF
--- a/src/rrdset.c
+++ b/src/rrdset.c
@@ -588,8 +588,8 @@ RRDSET *rrdset_create_custom(
                     memset(st, 0, size);
                 }
                 else if(st->last_updated.tv_sec > now + update_every) {
-                    error("File %s refers to the future. Clearing it.", fullfilename);
-                    memset(st, 0, size);
+                    error("File %s refers to the future by %zd secs. Resetting it to now.", fullfilename, (ssize_t)(st->last_updated.tv_sec - now));
+                    st->last_updated.tv_sec = now;
                 }
 
                 // make sure the database is aligned


### PR DESCRIPTION
There was a rare case that during a netdata restart, it decided to clear the database. The reason was that systemd-timesyncd had just synced the system clock in the past by several seconds.

This PR changes the behavior of netdata, so that instead of clearing the database, it shifts the just loaded database to the current time.
