### PR TITLE
[cleanup crusade] remove autogen.sh script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,6 @@ EXTRA_DIST = \
     m4/ax_c_mallopt.m4 \
     m4/tcmalloc.m4 \
     m4/ax_c__generic.m4 \
-	autogen.sh \
 	README.md \
 	CONTRIBUTORS.md \
 	LICENSE \
@@ -55,7 +54,6 @@ EXTRA_DIST = \
 	LICENSES/Python-2.0 \
 	LICENSES/WTFPL \
 	REDISTRIBUTED.md \
-	autogen.sh \
 	$(NULL)
 
 SUBDIRS = \

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-autoreconf -ivf

--- a/contrib/rhel/build-netdata-rpm.sh
+++ b/contrib/rhel/build-netdata-rpm.sh
@@ -8,7 +8,7 @@ source "installer/functions.sh" || exit 1
 
 set -e
 
-run ./autogen.sh
+run autoreconf -ivf
 run ./configure --enable-maintainer-mode
 run make dist
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -479,7 +479,7 @@ progress "Run autotools to configure the build environment"
 
 if [ "$have_autotools" ]
 then
-    run ./autogen.sh || exit 1
+    run autoreconf -ivf || exit 1
 fi
 
 run ./configure \

--- a/packaging/git-build
+++ b/packaging/git-build
@@ -47,7 +47,7 @@ then
 fi
 
 set -e
-./autogen.sh
+autoreconf -ivf
 ./configure --enable-maintainer-mode 
 set +e
 make dist

--- a/packaging/git-build
+++ b/packaging/git-build
@@ -4,7 +4,7 @@
 # When run from the top-level repository, performs a complete clean
 # and maintainer-mode rebuild of the FireHOL package.
 
-if [ ! -f .gitignore -o ! -f configure.ac -o ! -x autogen.sh ]
+if [ ! -f .gitignore -o ! -f configure.ac ]
 then
   echo "Run as ./packaging/git-build from an autotools git repository"
   exit 1


### PR DESCRIPTION
I am on cleanup crusade.

This PR removes a script which have only ONE command in it and replaces every `autogen.sh` script execution with said command.