### PR TITLE
[cleanup crusade] remove biased cppcheck code

### DIFF
--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -5,9 +5,6 @@
 cppcheck=$(which cppcheck 2>/dev/null || command -v cppcheck 2>/dev/null)
 [ -z "${cppcheck}" ] && echo >&2 "install cppcheck." && exit 1
 
-[ -x "/home/costa/src/cppcheck.git/cppcheck" ] && \
-	cppcheck="/home/costa/src/cppcheck.git/cppcheck"
-
 processors=$(grep -c ^processor /proc/cpuinfo)
 [ $(( processors )) -lt 1 ] && processors=1
 

--- a/netdata.cppcheck
+++ b/netdata.cppcheck
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="1">
-    <root name="/home/costa/src/netdata-ktsaou.git/src"/>
     <builddir>cppcheck-build</builddir>
     <includedir>
         <dir name=".."/>


### PR DESCRIPTION
Code cleanup crusade part 2.

This removes @ktsaou environment setup assumption. Maybe move it to your bash env setup?

Can we also move this file to `tests` directory instead of TLD?