### PR TITLE
when running under systemd, keep the process scheduling parameters set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ AX_GCC_FUNC_ATTRIBUTE([warn_unused_result])
 AC_CHECK_TYPES([struct timespec, clockid_t], [], [], [[#include <time.h>]])
 AC_SEARCH_LIBS([clock_gettime], [rt posix4])
 AC_CHECK_FUNCS([clock_gettime])
-AC_CHECK_FUNCS([sched_setscheduler sched_get_priority_min sched_get_priority_max nice])
+AC_CHECK_FUNCS([sched_setscheduler sched_getscheduler sched_getparam sched_get_priority_min sched_get_priority_max getpriority setpriority nice])
 AC_CHECK_FUNCS([recvmmsg])
 
 AC_TYPE_INT8_T

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -152,6 +152,10 @@ static void oom_score_adj(void) {
     s = config_get(CONFIG_SECTION_GLOBAL, "OOM score", s);
     if(s && *s && (isdigit(*s) || *s == '-' || *s == '+'))
         wanted_score = atoll(s);
+    else if(s && !strcmp(s, "keep")) {
+        info("Out-Of-Memory (OOM) kept as-is (running with %d)", (int) old_score);
+        return;
+    }
     else {
         info("Out-Of-Memory (OOM) score not changed due to non-numeric setting: '%s' (running with %d)", s, (int)old_score);
         return;
@@ -203,8 +207,6 @@ static void process_nice_level(void) {
 #endif // HAVE_NICE
 };
 
-#ifdef HAVE_SCHED_SETSCHEDULER
-
 #define SCHED_FLAG_NONE                      0x00
 #define SCHED_FLAG_PRIORITY_CONFIGURABLE     0x01 // the priority is user configurable
 #define SCHED_FLAG_KEEP_AS_IS                0x04 // do not attempt to set policy, priority or nice()
@@ -228,8 +230,8 @@ struct sched_def {
 #endif
 
 #ifdef SCHED_OTHER
-        { "nice",  SCHED_OTHER, 0, SCHED_FLAG_USE_NICE },
         { "other", SCHED_OTHER, 0, SCHED_FLAG_USE_NICE },
+        { "nice",  SCHED_OTHER, 0, SCHED_FLAG_USE_NICE },
 #endif
 
 #ifdef SCHED_RR
@@ -252,6 +254,55 @@ struct sched_def {
         { NULL, 0, 0, 0 }
 };
 
+
+#ifdef HAVE_SCHED_GETSCHEDULER
+static void sched_getscheduler_report(void) {
+    int sched = sched_getscheduler(0);
+    if(sched == -1) {
+        error("Cannot get my current process scheduling policy.");
+        return;
+    }
+    else {
+        int i;
+        for(i = 0 ; scheduler_defaults[i].name ; i++) {
+            if(scheduler_defaults[i].policy == sched) {
+                if(scheduler_defaults[i].flags & SCHED_FLAG_PRIORITY_CONFIGURABLE) {
+                    struct sched_param param;
+                    if(sched_getparam(0, &param) == -1) {
+                        error("Cannot get the process scheduling priority for my policy '%s'", scheduler_defaults[i].name);
+                        return;
+                    }
+                    else {
+                        info("Running with process scheduling policy '%s', priority %d", scheduler_defaults[i].name, param.sched_priority);
+                    }
+                }
+                else if(scheduler_defaults[i].flags & SCHED_FLAG_USE_NICE) {
+                    #ifdef HAVE_GETPRIORITY
+                    int n = getpriority(PRIO_PROCESS, 0);
+                    info("Running with process scheduling policy '%s', nice level %d", scheduler_defaults[i].name, n);
+                    #else // !HAVE_GETPRIORITY
+                    info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
+                    #endif // !HAVE_GETPRIORITY
+                }
+                else {
+                    info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
+                }
+
+                return;
+            }
+        }
+    }
+}
+#else // !HAVE_SCHED_GETSCHEDULER
+static void sched_getscheduler_report(void) {
+#ifdef HAVE_GETPRIORITY
+    info("Running with priority %d", getpriority(PRIO_PROCESS, 0));
+#endif // HAVE_GETPRIORITY
+}
+#endif // !HAVE_SCHED_GETSCHEDULER
+
+#ifdef HAVE_SCHED_SETSCHEDULER
+
 static void sched_setscheduler_set(void) {
 
     if(scheduler_defaults[0].name) {
@@ -271,7 +322,7 @@ static void sched_setscheduler_set(void) {
                 flags = scheduler_defaults[i].flags;
 
                 if(flags & SCHED_FLAG_KEEP_AS_IS)
-                    return;
+                    goto report;
 
                 if(flags & SCHED_FLAG_PRIORITY_CONFIGURABLE)
                     priority = (int)config_get_number(CONFIG_SECTION_GLOBAL, "process scheduling priority", priority);
@@ -311,18 +362,21 @@ static void sched_setscheduler_set(void) {
         else {
             info("Adjusted netdata scheduling policy to %s (%d), with priority %d.", name, policy, priority);
             if(!(flags & SCHED_FLAG_USE_NICE))
-                return;
+                goto report;
         }
     }
 
 fallback:
     process_nice_level();
+
+report:
+    sched_getscheduler_report();
 }
-#else
+#else // !HAVE_SCHED_SETSCHEDULER
 static void sched_setscheduler_set(void) {
     process_nice_level();
 }
-#endif
+#endif // !HAVE_SCHED_SETSCHEDULER
 
 int become_daemon(int dont_fork, const char *user)
 {

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -9,7 +9,7 @@ User=netdata
 Group=netdata
 RuntimeDirectory=netdata
 RuntimeDirectoryMode=0775
-ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D
+ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D -W set global 'process scheduling policy' 'keep' -W set global 'OOM score' 'keep'
 ExecStartPre=/bin/mkdir -p @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/cache/netdata
 PermissionsStartOnly=true
@@ -25,20 +25,16 @@ RestartSec=30
 # netdata (via [global].OOM score in netdata.conf) can only increase the value set here.
 # To decrease it, set the minimum here and set the same or a higher value in netdata.conf.
 # Valid values: -1000 (never kill netdata) to 1000 (always kill netdata).
-#OOMScoreAdjust=0
+OOMScoreAdjust=1000
 
-# By default netdata switches to scheduling policy idle, which makes it use CPU, only
-# when there is spare available.
 # Valid policies: other (the system default) | batch | idle | fifo | rr
-#CPUSchedulingPolicy=other
+CPUSchedulingPolicy=idle
 
-# This sets the maximum scheduling priority netdata can set (for policies: rr and fifo).
-# netdata (via [global].process scheduling priority in netdata.conf) can only lower this value.
+# This sets the scheduling priority (for policies: rr and fifo).
 # Priority gets values 1 (lowest) to 99 (highest).
 #CPUSchedulingPriority=1
 
-# For scheduling policy 'other' and 'batch', this sets the lowest niceness of netdata.
-# netdata (via [global].process nice level in netdata.conf) can only increase the value set here.
+# For scheduling policy 'other' and 'batch', this sets the lowest niceness of netdata (-20 highest to 19 lowest).
 #Nice=0
 
 [Install]

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -28,6 +28,7 @@ RestartSec=30
 OOMScoreAdjust=1000
 
 # Valid policies: other (the system default) | batch | idle | fifo | rr
+# To give netdata the max priority, set CPUSchedulingPolicy=rr and CPUSchedulingPriority=99
 CPUSchedulingPolicy=idle
 
 # This sets the scheduling priority (for policies: rr and fifo).


### PR DESCRIPTION
This PR makes it easier to control netdata process scheduling policy and priority when run under systemd.

`netdata.service` now runs netdata with defaults to prevent it from altering the process scheduling priority set by systemd, and also sets the defaults in `netdata.service`.

fixes #4087 