### PR TITLE
/proc/net/snmp minimum line length for IcmpMsg is 2 words, not 3

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -3,13 +3,13 @@
 cpus=$(grep ^processor </proc/cpuinfo| wc -l)
 [ -z "${cpus}" ] && cpus=1
 
-token=
-[ -f .coverity-token ] && token="$(<.coverity-token)"
+token="${COVERITY_SCAN_TOKEN}"
+[ -z "${token}" -a -f .coverity-token ] && token="$(<.coverity-token)"
 [ -z "${token}" ] && \
-	echo >&2 "Save the coverity token to .coverity-token" && \
+	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN." && \
 	exit 1
 
-echo >&2 "Coverity token: ${token}"
+# echo >&2 "Coverity token: ${token}"
 
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 [ -z "${covbuild}" -a -f .coverity-build ] && covbuild="$(<.coverity-build)"

--- a/src/proc_net_snmp.c
+++ b/src/proc_net_snmp.c
@@ -526,8 +526,8 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
             }
 
             words = procfile_linewords(ff, l);
-            if(words < 3) {
-                error("Cannot read /proc/net/snmp IcmpMsg line. Expected 3+ params, read %zu.", words);
+            if(words < 2) {
+                error("Cannot read /proc/net/snmp IcmpMsg line. Expected 2+ params, read %zu.", words);
                 continue;
             }
 


### PR DESCRIPTION
also, coverity-scan.sh should also accept token from environment variable, to allow retrieving it via travis secure variables.