### PR TITLE
Add some extra error logging to the spigotmc module.

### DIFF
--- a/python.d/spigotmc.chart.py
+++ b/python.d/spigotmc.chart.py
@@ -52,7 +52,9 @@ class Service(SimpleService):
             return False
         try:
             self.connect()
-        except (mcrcon.MCRconException, socket.error):
+        except (mcrcon.MCRconException, socket.error) as err:
+            self.error('Error connecting.')
+            self.error(repr(err))
             return False
         return True
 
@@ -67,7 +69,9 @@ class Service(SimpleService):
                 pass
             self.console.connect(self.host, self.port, self.password)
             self.alive = True
-        except (mcrcon.MCRconException, socket.error):
+        except (mcrcon.MCRconException, socket.error) as err:
+            self.error('Error connecting.')
+            self.error(repr(err))
             return False
         return True
 

--- a/python.d/spigotmc.chart.py
+++ b/python.d/spigotmc.chart.py
@@ -100,6 +100,8 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
+        except (TypeError, LookupError):
+            self.error('Unable to process TPS values.')
         try:
             raw = self.console.command('list')
             # The above command returns a string that looks like this:
@@ -112,4 +114,6 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
+        except (TypeError, LookupError):
+            self.error('Unable to process user counts.')
         return data


### PR DESCRIPTION
This should hopeffully make it easier to debug things when it fails to connect to the configured system.

This ideally should have been in the original PR, but I didn't think about it then.