### PR TITLE
netdata.service is now installed in /lib/systemd/system; 

### DIFF
--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -449,9 +449,10 @@ issystemd() {
     # if pid 1 is systemd, it is systemd
     [ "$(basename $(readlink /proc/1/exe) 2>/dev/null)" = "systemd" ] && return 0
 
-    # if systemd is not running, it is not systemd
-    pids=$(pidof systemd 2>/dev/null)
-    [ -z "${pids}" ] && return 1
+    # -- ubuntu runs systemd as init ---
+    ## if systemd is not running, it is not systemd
+    #pids=$(pidof systemd 2>/dev/null)
+    #[ -z "${pids}" ] && return 1
 
     # check if the running systemd processes are not in our namespace
     myns="$(readlink /proc/self/ns/pid 2>/dev/null)"

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -439,8 +439,8 @@ iscontainer() {
 issystemd() {
     local pids p myns ns systemctl
 
-    # if the directory /etc/systemd/system does not exit, it is not systemd
-    [ ! -d /etc/systemd/system ] && return 1
+    # if the directory /lib/systemd/system does not exit, it is not systemd
+    [ ! -d /lib/systemd/system ] && return 1
 
     # if there is no systemctl command, it is not systemd
     systemctl=$(which systemctl 2>/dev/null || command -v systemctl 2>/dev/null)
@@ -560,16 +560,15 @@ install_netdata_service() {
             NETDATA_START_CMD="systemctl start netdata"
             NETDATA_STOP_CMD="systemctl stop netdata"
 
-            if [ ! -f /etc/systemd/system/netdata.service ]
+            if [ -d "/lib/systemd/system" ]
             then
                 echo >&2 "Installing systemd service..."
-                run cp system/netdata.service /etc/systemd/system/netdata.service && \
+                run cp system/netdata.service /lib/systemd/system/netdata.service && \
                     run systemctl daemon-reload && \
                     run systemctl enable netdata && \
                     return 0
             else
-                echo >&2 "file '/etc/systemd/system/netdata.service' already exists."
-                return 0
+                echo >&2 "no '/lib/systemd/system' directory; cannot install netdata.service"
             fi
         else
             install_non_systemd_init

--- a/makeself/makeself-help-header.txt
+++ b/makeself/makeself-help-header.txt
@@ -26,7 +26,7 @@
   # SYSTEM INIT
   This file will be installed if this system runs with systemd:
 
-   - /etc/systemd/system/netdata.service 
+   - /lib/systemd/system/netdata.service
 
    or, for older Centos, Debian/Ubuntu or OpenRC Gentoo:
 

--- a/makeself/makeself-license.txt
+++ b/makeself/makeself-license.txt
@@ -26,7 +26,7 @@
   # SYSTEM INIT
   This file will be installed if this system runs with systemd:
 
-   - /etc/systemd/system/netdata.service 
+   - /lib/systemd/system/netdata.service
 
    or, for older Centos, Debian/Ubuntu or OpenRC Gentoo:
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1069,6 +1069,12 @@ if [ -f /etc/systemd/system/netdata.service ]
     run rm -i /etc/systemd/system/netdata.service
 fi
 
+if [ -f /lib/systemd/system/netdata.service ]
+    then
+    echo "Deleting /lib/systemd/system/netdata.service ..."
+    run rm -i /lib/systemd/system/netdata.service
+fi
+
 if [ -f /etc/init.d/netdata ]
     then
     echo "Deleting /etc/init.d/netdata ..."


### PR DESCRIPTION
We were installing `netdata.service` in `/etc/systemd/system`.
This PR installs `netdata.service` in `/lib/systemd/system`.

https://github.com/firehol/netdata/issues/4087#issuecomment-419747983