### PR TITLE
[cleanup crusade] disable linters on installer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       script: docker run --rm -v $(pwd)/web:/code eeacms/csslint sh -c "csslint /code/*.css" || echo "OK"
     - name: "bash"
       install: skip
-      script: docker run --rm --volume "$(pwd)":/project:ro --entrypoint sh koalaman/shellcheck-alpine:v0.4.7 -c 'for file in $(find /project/ -type f -name "*.sh"); do if ! shellcheck --format=gcc $file; then export FAILED=true; fi; done; if [ "$FAILED" != "" ]; then exit 1; fi' || echo "OK"
+      script: docker run --rm --volume "$(pwd)":/project:ro --entrypoint sh koalaman/shellcheck-alpine:v0.5.0 -c 'for file in $(find /project/ -type f -name "*.sh" ! -path "*/makeself/*" ); do if ! shellcheck --format=gcc $file; then export FAILED=true; fi; done; if [ "$FAILED" != "" ]; then exit 1; fi' || echo "OK"
     - stage: "test"
       name: "C"
       install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev

--- a/installer/functions.sh
+++ b/installer/functions.sh
@@ -1,5 +1,6 @@
 # no shebang necessary - this is a library to be sourced
 # SPDX-License-Identifier: GPL-3.0+
+# shellcheck disable=SC1091,SC1117,SC2002,SC2004,SC2034,SC2046,SC2059,SC2086,SC2129,SC2148,SC2154,SC2155,SC2162,SC2166,SC2181,SC2193
 
 # make sure we have a UID
 [ -z "${UID}" ] && UID="$(id -u)"

--- a/kickstart-static64.sh
+++ b/kickstart-static64.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-3.0+
+# shellcheck disable=SC1117,SC2016,SC2034,SC2039,SC2059,SC2086,SC2119,SC2120,SC2129,SC2162,SC2166,SC2181
 
 umask 022
 

--- a/kickstart.sh
+++ b/kickstart.sh
@@ -24,6 +24,8 @@
 #
 # 3. install netdata
 
+# shellcheck disable=SC1117,SC2016,SC2034,SC2039,SC2059,SC2086,SC2119,SC2120,SC2129,SC2162,SC2166,SC2181
+
 umask 022
 
 [ -z "${UID}" ] && UID="$(id -u)"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
+# shellcheck disable=SC1090,SC1091,SC1117,SC2002,SC2034,SC2044,SC2046,SC2086,SC2129,SC2162,SC2166,SC2181
 
 export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 uniquepath() {


### PR DESCRIPTION
- files located in `makeself` are not linted
- `netdata-installer.sh`, `installer/functions.sh`, `kickstart.sh`, and `kickstart-static64.sh`  are linted but most checks are disabled
- shellcheck version is bumped to 0.5.0 

Closes #4165 #4161 as those will be obsolete