### PR TITLE
nginx_plus: use upstream server IP:port in dimension IDs, not the transient ID

### DIFF
--- a/python.d/nginx_plus.chart.py
+++ b/python.d/nginx_plus.chart.py
@@ -178,7 +178,7 @@ def web_upstream_charts(wu):
         ]
     }
     for peer in wu:
-        charts['web_upstream_{0}_{1}_responses'.format(wu.name, peer.id)] = {
+        charts['web_upstream_{0}_{1}_responses'.format(wu.name, peer.server)] = {
             'options': [None, 'Peer "{0}" Responses'.format(peer.real_server), 'responses/s', family,
                         'nginx_plus.web_upstream_peer_responses', 'stacked'],
             'lines': [
@@ -210,7 +210,7 @@ def web_upstream_charts(wu):
         ]
     }
     for peer in wu:
-        charts['web_upstream_{0}_{1}_net'.format(wu.name, peer.id)] = {
+        charts['web_upstream_{0}_{1}_net'.format(wu.name, peer.server)] = {
             'options': [None, 'Peer "{0}" Traffic'.format(peer.real_server), 'kilobits/s', family,
                         'nginx_plus.web_upstream_peer_traffic', 'area'],
             'lines': [
@@ -220,7 +220,7 @@ def web_upstream_charts(wu):
         }
     # Response Time
     for peer in wu:
-        charts['web_upstream_{0}_{1}_timings'.format(wu.name, peer.id)] = {
+        charts['web_upstream_{0}_{1}_timings'.format(wu.name, peer.server)] = {
             'options': [None, 'Peer "{0}" Timings'.format(peer.real_server), 'ms', family,
                         'nginx_plus.web_upstream_peer_timings', 'line'],
             'lines': [


### PR DESCRIPTION
nginx-plus assigns an internal numeric ID to each upstream server, this ID might change for the "same" upstream server (_same_ meaning identical IP:port) when, e.g.:
- nginx is restarted
- an upstream server is removed and then re-added to upstream via the API

Using the sanitized IP:port in dimension IDs ensures that charts behave as expected.