### PR TITLE
send host variables to prometheus

### DIFF
--- a/conf.d/health.d/ipc.conf
+++ b/conf.d/health.d/ipc.conf
@@ -5,7 +5,7 @@
       on: system.ipc_semaphores
       os: linux
    hosts: *
-    calc: $semaphores * 100 / $ipc.semaphores.max
+    calc: $semaphores * 100 / $ipc_semaphores_max
    units: %
    every: 10s
     warn: $this > (($status >= $WARNING)  ? (70) : (80))
@@ -18,7 +18,7 @@
       on: system.ipc_semaphore_arrays
       os: linux
    hosts: *
-    calc: $arrays * 100 / $ipc.semaphores.arrays.max
+    calc: $arrays * 100 / $ipc_semaphores_arrays_max
    units: %
    every: 10s
     warn: $this > (($status >= $WARNING)  ? (70) : (80))

--- a/conf.d/health.d/load.conf
+++ b/conf.d/health.d/load.conf
@@ -8,7 +8,7 @@
       on: system.load
       os: linux
    hosts: *
-    calc: ($system.cpu.processors <= 2) ? ( 2 ) : ( $system.cpu.processors )
+    calc: ($active_processors == nan or $active_processors == inf or $active_processors < 2) ? ( 2 ) : ( $active_processors )
    units: cpus
    every: 1m
     info: trigger point for load average alarms

--- a/conf.d/health.d/netfilter.conf
+++ b/conf.d/health.d/netfilter.conf
@@ -19,7 +19,7 @@
       os: linux
    hosts: *
   lookup: max -10s unaligned of connections
-    calc: $this * 100 / $netfilter.conntrack.max
+    calc: $this * 100 / $netfilter_conntrack_max
    units: %
    every: 10s
     warn: $this > (($status >= $WARNING)  ? (70) : (80))

--- a/src/adaptive_resortable_list.c
+++ b/src/adaptive_resortable_list.c
@@ -21,6 +21,15 @@ inline void arl_callback_str2kernel_uint_t(const char *name, uint32_t hash, cons
     // fprintf(stderr, "name '%s' with hash %u and value '%s' is %llu\n", name, hash, value, (unsigned long long)*d);
 }
 
+inline void arl_callback_ssize_t(const char *name, uint32_t hash, const char *value, void *dst) {
+    (void)name;
+    (void)hash;
+
+    register ssize_t *d = dst;
+    *d = (ssize_t)str2ll(value, NULL);
+    // fprintf(stderr, "name '%s' with hash %u and value '%s' is %zd\n", name, hash, value, *d);
+}
+
 // create a new ARL
 ARL_BASE *arl_create(const char *name, void (*processor)(const char *, uint32_t, const char *, void *), size_t rechecks) {
     ARL_BASE *base = callocz(1, sizeof(ARL_BASE));

--- a/src/adaptive_resortable_list.h
+++ b/src/adaptive_resortable_list.h
@@ -117,6 +117,7 @@ extern void arl_begin(ARL_BASE *base);
 
 extern void arl_callback_str2ull(const char *name, uint32_t hash, const char *value, void *dst);
 extern void arl_callback_str2kernel_uint_t(const char *name, uint32_t hash, const char *value, void *dst);
+extern void arl_callback_ssize_t(const char *name, uint32_t hash, const char *value, void *dst);
 
 // check a keyword against the ARL
 // this is to be called for each keyword read from source data

--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -238,7 +238,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER 
         struct host_variables_callback_options opts = {
                 .host = host,
                 .wb = wb,
-                .labels = labels,
+                .labels = (labels[0] == ',')?&labels[1]:labels,
                 .timestamps = timestamps,
                 .help = help,
                 .types = types,

--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -127,16 +127,16 @@ struct host_variables_callback_options {
 static int print_host_variables(RRDVAR *rv, void *data) {
     struct host_variables_callback_options *opts = data;
 
-    if(rv->type == RRDVAR_TYPE_CALCULATED_ALLOCATED) {
+    if(rv->options & (RRDVAR_OPTION_CUSTOM_HOST_VAR|RRDVAR_OPTION_CUSTOM_CHART_VAR)) {
         if(!opts->host_header_printed) {
             opts->host_header_printed = 1;
 
             if(opts->help) {
-                buffer_sprintf(opts->wb, "\n# COMMENT global host variables\n");
+                buffer_sprintf(opts->wb, "\n# COMMENT global host and chart variables\n");
             }
         }
 
-        calculated_number value = rrdvar_custom_host_variable_get(opts->host, rv);
+        calculated_number value = rrdvar2number(rv);
         if(isnan(value) || isinf(value)) {
             if(opts->help)
                 buffer_sprintf(opts->wb, "# COMMENT variable \"%s\" is %s. Skipped.\n", rv->name, (isnan(value))?"NAN":"INF");
@@ -285,41 +285,6 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER 
                                , st->family
                                , st->units
                 );
-
-            /*
-             * FIXME
-             * WE SHOULD USE THE INDEX TO TRAVERSE THE CHART VARIABLES, LIKE THE HOST ONES
-             * SINCE THIS LINKED LIST IS SUPPOSED TO BE USED EXCLUSIVELY BY THE THREAD THAT
-             * CONTROLS THE CHART !
-            // send custom variables set for the chart
-            RRDSETVAR *rs;
-            for(rs = st->variables; rs ; rs = rs->next) {
-                if(rs->options & RRDVAR_OPTION_ALLOCATED) {
-                    if(timestamps)
-                        buffer_sprintf(wb
-                            , "%s_%s_%s{chart=\"%s\",family=\"%s\"%s} " CALCULATED_NUMBER_FORMAT " %llu\n"
-                            , prefix
-                            , context
-                            , rs->variable
-                            , chart
-                            , family
-                            , labels
-                            , rrdsetvar_custom_chart_variable_get(rs)
-                            , timeval_msec(&st->last_collected_time)
-                    );
-                    else
-                        buffer_sprintf(wb, "%s_%s_%s{chart=\"%s\",family=\"%s\"%s} " CALCULATED_NUMBER_FORMAT "\n"
-                            , prefix
-                            , context
-                            , rs->variable
-                            , chart
-                            , family
-                            , labels
-                            , rrdsetvar_custom_chart_variable_get(rs)
-                    );
-                }
-            }
-             */
 
             // for each dimension
             RRDDIM *rd;

--- a/src/backend_prometheus.c
+++ b/src/backend_prometheus.c
@@ -153,7 +153,7 @@ static int print_host_variables(RRDVAR *rv, void *data) {
 
         if(opts->output_options & PROMETHEUS_OUTPUT_TIMESTAMPS)
             buffer_sprintf(opts->wb
-                           , "%s_host_var_%s%s%s%s " CALCULATED_NUMBER_FORMAT " %llu\n"
+                           , "%s_%s%s%s%s " CALCULATED_NUMBER_FORMAT " %llu\n"
                            , opts->prefix
                            , opts->name
                            , label_pre
@@ -163,7 +163,7 @@ static int print_host_variables(RRDVAR *rv, void *data) {
                            , rv->last_updated * 1000ULL
             );
         else
-            buffer_sprintf(opts->wb, "%s_host_var_%s%s%s%s " CALCULATED_NUMBER_FORMAT "\n"
+            buffer_sprintf(opts->wb, "%s_%s%s%s%s " CALCULATED_NUMBER_FORMAT "\n"
                            , opts->prefix
                            , opts->name
                            , label_pre

--- a/src/backend_prometheus.h
+++ b/src/backend_prometheus.h
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0+
-//
-// Created by costa on 09/07/17.
-//
 
 #ifndef NETDATA_BACKEND_PROMETHEUS_H
 #define NETDATA_BACKEND_PROMETHEUS_H
 
-extern void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(RRDHOST *host, BUFFER *wb, const char *server, const char *prefix, uint32_t options, int help, int types, int names, int timestamps);
-extern void rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(RRDHOST *host, BUFFER *wb, const char *server, const char *prefix, uint32_t options, int help, int types, int names, int timestamps);
+typedef enum prometheus_output_flags {
+    PROMETHEUS_OUTPUT_NONE       = 0,
+    PROMETHEUS_OUTPUT_HELP       = (1 << 0),
+    PROMETHEUS_OUTPUT_TYPES      = (1 << 1),
+    PROMETHEUS_OUTPUT_NAMES      = (1 << 2),
+    PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 3),
+    PROMETHEUS_OUTPUT_VARIABLES  = (1 << 4)
+} PROMETHEUS_OUTPUT_OPTIONS;
+
+extern void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(RRDHOST *host, BUFFER *wb, const char *server, const char *prefix, BACKEND_OPTIONS backend_options, PROMETHEUS_OUTPUT_OPTIONS output_options);
+extern void rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(RRDHOST *host, BUFFER *wb, const char *server, const char *prefix, BACKEND_OPTIONS backend_options, PROMETHEUS_OUTPUT_OPTIONS output_options);
 
 #endif //NETDATA_BACKEND_PROMETHEUS_H

--- a/src/backends.c
+++ b/src/backends.c
@@ -23,10 +23,9 @@
 // 5. repeats the above forever.
 //
 
-const char *backend_prefix = "netdata";
-int backend_send_names = 1;
-int backend_update_every = 10;
-uint32_t backend_options = BACKEND_SOURCE_DATA_AVERAGE;
+const char *global_backend_prefix = "netdata";
+int global_backend_update_every = 10;
+BACKEND_OPTIONS global_backend_options = BACKEND_SOURCE_DATA_AVERAGE | BACKEND_OPTION_SEND_NAMES;
 
 // ----------------------------------------------------------------------------
 // helper functions for backends
@@ -53,7 +52,7 @@ inline calculated_number backend_calculate_value_from_stored_data(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
         , time_t *first_timestamp   // the first point of the database used in this response
         , time_t *last_timestamp    // the timestamp that should be reported to backend
 ) {
@@ -133,7 +132,7 @@ inline calculated_number backend_calculate_value_from_stored_data(
         return NAN;
     }
 
-    if(unlikely((options & BACKEND_SOURCE_BITS) == BACKEND_SOURCE_DATA_SUM))
+    if(unlikely(BACKEND_OPTIONS_DATA_SOURCE(backend_options) == BACKEND_SOURCE_DATA_SUM))
         return sum;
 
     return sum / (calculated_number)counter;
@@ -173,27 +172,26 @@ static inline int format_dimension_collected_graphite_plaintext(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
     (void)after;
     (void)before;
-    (void)options;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     char dimension_name[RRD_ID_LENGTH_MAX + 1];
-    backend_name_copy(chart_name, (backend_send_names && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
-    backend_name_copy(dimension_name, (backend_send_names && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(chart_name, (backend_options & BACKEND_OPTION_SEND_NAMES && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(dimension_name, (backend_options & BACKEND_OPTION_SEND_NAMES && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
 
     buffer_sprintf(
             b
-            , "%s.%s.%s.%s " COLLECTED_NUMBER_FORMAT " %u\n"
+            , "%s.%s.%s.%s " COLLECTED_NUMBER_FORMAT " %llu\n"
             , prefix
             , hostname
             , chart_name
             , dimension_name
             , rd->last_collected_value
-            , (uint32_t)rd->last_collected_time.tv_sec
+            , (unsigned long long)rd->last_collected_time.tv_sec
     );
 
     return 1;
@@ -208,29 +206,29 @@ static inline int format_dimension_stored_graphite_plaintext(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     char dimension_name[RRD_ID_LENGTH_MAX + 1];
-    backend_name_copy(chart_name, (backend_send_names && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
-    backend_name_copy(dimension_name, (backend_send_names && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(chart_name, (backend_options & BACKEND_OPTION_SEND_NAMES && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(dimension_name, (backend_options & BACKEND_OPTION_SEND_NAMES && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
 
     time_t first_t = after, last_t = before;
-    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options, &first_t, &last_t);
+    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, backend_options, &first_t, &last_t);
 
     if(!isnan(value)) {
 
         buffer_sprintf(
                 b
-                , "%s.%s.%s.%s " CALCULATED_NUMBER_FORMAT " %u\n"
+                , "%s.%s.%s.%s " CALCULATED_NUMBER_FORMAT " %llu\n"
                 , prefix
                 , hostname
                 , chart_name
                 , dimension_name
                 , value
-                , (uint32_t) last_t
+                , (unsigned long long) last_t
         );
 
         return 1;
@@ -255,25 +253,24 @@ static inline int format_dimension_collected_opentsdb_telnet(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
     (void)after;
     (void)before;
-    (void)options;
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     char dimension_name[RRD_ID_LENGTH_MAX + 1];
-    backend_name_copy(chart_name, (backend_send_names && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
-    backend_name_copy(dimension_name, (backend_send_names && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(chart_name, (backend_options & BACKEND_OPTION_SEND_NAMES && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(dimension_name, (backend_options & BACKEND_OPTION_SEND_NAMES && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
 
     buffer_sprintf(
             b
-            , "put %s.%s.%s %u " COLLECTED_NUMBER_FORMAT " host=%s%s%s\n"
+            , "put %s.%s.%s %llu " COLLECTED_NUMBER_FORMAT " host=%s%s%s\n"
             , prefix
             , chart_name
             , dimension_name
-            , (uint32_t)rd->last_collected_time.tv_sec
+            , (unsigned long long)rd->last_collected_time.tv_sec
             , rd->last_collected_value
             , hostname
             , (host->tags)?" ":""
@@ -292,27 +289,27 @@ static inline int format_dimension_stored_opentsdb_telnet(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
 
     time_t first_t = after, last_t = before;
-    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options, &first_t, &last_t);
+    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, backend_options, &first_t, &last_t);
 
     char chart_name[RRD_ID_LENGTH_MAX + 1];
     char dimension_name[RRD_ID_LENGTH_MAX + 1];
-    backend_name_copy(chart_name, (backend_send_names && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
-    backend_name_copy(dimension_name, (backend_send_names && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(chart_name, (backend_options & BACKEND_OPTION_SEND_NAMES && st->name)?st->name:st->id, RRD_ID_LENGTH_MAX);
+    backend_name_copy(dimension_name, (backend_options & BACKEND_OPTION_SEND_NAMES && rd->name)?rd->name:rd->id, RRD_ID_LENGTH_MAX);
 
     if(!isnan(value)) {
 
         buffer_sprintf(
                 b
-                , "put %s.%s.%s %u " CALCULATED_NUMBER_FORMAT " host=%s%s%s\n"
+                , "put %s.%s.%s %llu " CALCULATED_NUMBER_FORMAT " host=%s%s%s\n"
                 , prefix
                 , chart_name
                 , dimension_name
-                , (uint32_t) last_t
+                , (unsigned long long) last_t
                 , value
                 , hostname
                 , (host->tags)?" ":""
@@ -341,12 +338,12 @@ static inline int format_dimension_collected_json_plaintext(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
     (void)after;
     (void)before;
-    (void)options;
+    (void)backend_options;
 
     const char *tags_pre = "", *tags_post = "", *tags = host->tags;
     if(!tags) tags = "";
@@ -378,7 +375,7 @@ static inline int format_dimension_collected_json_plaintext(
         "\"name\":\"%s\","
         "\"value\":" COLLECTED_NUMBER_FORMAT ","
 
-        "\"timestamp\": %u}\n",
+        "\"timestamp\": %llu}\n",
             prefix,
             hostname,
             tags_pre, tags, tags_post,
@@ -394,7 +391,7 @@ static inline int format_dimension_collected_json_plaintext(
             rd->name,
             rd->last_collected_value,
 
-            (uint32_t)rd->last_collected_time.tv_sec
+            (unsigned long long) rd->last_collected_time.tv_sec
     );
 
     return 1;
@@ -409,12 +406,12 @@ static inline int format_dimension_stored_json_plaintext(
         , RRDDIM *rd                // the dimension
         , time_t after              // the start timestamp
         , time_t before             // the end timestamp
-        , uint32_t options          // BACKEND_SOURCE_* bitmap
+        , BACKEND_OPTIONS backend_options // BACKEND_SOURCE_* bitmap
 ) {
     (void)host;
 
     time_t first_t = after, last_t = before;
-    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, options, &first_t, &last_t);
+    calculated_number value = backend_calculate_value_from_stored_data(st, rd, after, before, backend_options, &first_t, &last_t);
 
     if(!isnan(value)) {
         const char *tags_pre = "", *tags_post = "", *tags = host->tags;
@@ -447,7 +444,7 @@ static inline int format_dimension_stored_json_plaintext(
             "\"name\":\"%s\","
             "\"value\":" CALCULATED_NUMBER_FORMAT ","
 
-            "\"timestamp\": %u}\n", 
+            "\"timestamp\": %llu}\n",
                 prefix,
                 hostname,
                 tags_pre, tags, tags_post,
@@ -461,9 +458,9 @@ static inline int format_dimension_stored_json_plaintext(
 
                 rd->id,
                 rd->name,
-                value, 
-                
-                (uint32_t) last_t
+                value,
+
+                (unsigned long long) last_t
         );
         
         return 1;
@@ -482,7 +479,7 @@ static inline int process_json_response(BUFFER *b) {
 static SIMPLE_PATTERN *charts_pattern = NULL;
 static SIMPLE_PATTERN *hosts_pattern = NULL;
 
-inline int backends_can_send_rrdset(uint32_t options, RRDSET *st) {
+inline int backends_can_send_rrdset(BACKEND_OPTIONS backend_options, RRDSET *st) {
     RRDHOST *host = st->rrdhost;
 
     if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_BACKEND_IGNORE)))
@@ -504,7 +501,7 @@ inline int backends_can_send_rrdset(uint32_t options, RRDSET *st) {
         return 0;
     }
 
-    if(unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE && !((options & BACKEND_SOURCE_BITS) == BACKEND_SOURCE_DATA_AS_COLLECTED))) {
+    if(unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE && !(BACKEND_OPTIONS_DATA_SOURCE(backend_options) == BACKEND_SOURCE_DATA_AS_COLLECTED))) {
         debug(D_BACKEND, "BACKEND: not sending chart '%s' of host '%s' because its memory mode is '%s' and the backend requires database access.", st->id, host->hostname, rrd_memory_mode_name(host->rrd_memory_mode));
         return 0;
     }
@@ -512,24 +509,24 @@ inline int backends_can_send_rrdset(uint32_t options, RRDSET *st) {
     return 1;
 }
 
-inline uint32_t backend_parse_data_source(const char *source, uint32_t mode) {
+inline BACKEND_OPTIONS backend_parse_data_source(const char *source, BACKEND_OPTIONS backend_options) {
     if(!strcmp(source, "raw") || !strcmp(source, "as collected") || !strcmp(source, "as-collected") || !strcmp(source, "as_collected") || !strcmp(source, "ascollected")) {
-        mode |= BACKEND_SOURCE_DATA_AS_COLLECTED;
-        mode &= ~(BACKEND_SOURCE_BITS ^ BACKEND_SOURCE_DATA_AS_COLLECTED);
+        backend_options |= BACKEND_SOURCE_DATA_AS_COLLECTED;
+        backend_options &= ~(BACKEND_OPTIONS_SOURCE_BITS ^ BACKEND_SOURCE_DATA_AS_COLLECTED);
     }
     else if(!strcmp(source, "average")) {
-        mode |= BACKEND_SOURCE_DATA_AVERAGE;
-        mode &= ~(BACKEND_SOURCE_BITS ^ BACKEND_SOURCE_DATA_AVERAGE);
+        backend_options |= BACKEND_SOURCE_DATA_AVERAGE;
+        backend_options &= ~(BACKEND_OPTIONS_SOURCE_BITS ^ BACKEND_SOURCE_DATA_AVERAGE);
     }
     else if(!strcmp(source, "sum") || !strcmp(source, "volume")) {
-        mode |= BACKEND_SOURCE_DATA_SUM;
-        mode &= ~(BACKEND_SOURCE_BITS ^ BACKEND_SOURCE_DATA_SUM);
+        backend_options |= BACKEND_SOURCE_DATA_SUM;
+        backend_options &= ~(BACKEND_OPTIONS_SOURCE_BITS ^ BACKEND_SOURCE_DATA_SUM);
     }
     else {
         error("BACKEND: invalid data source method '%s'.", source);
     }
 
-    return mode;
+    return backend_options;
 }
 
 static void backends_main_cleanup(void *ptr) {
@@ -547,7 +544,7 @@ void *backends_main(void *ptr) {
     int default_port = 0;
     int sock = -1;
     BUFFER *b = buffer_create(1), *response = buffer_create(1);
-    int (*backend_request_formatter)(BUFFER *, const char *, RRDHOST *, const char *, RRDSET *, RRDDIM *, time_t, time_t, uint32_t) = NULL;
+    int (*backend_request_formatter)(BUFFER *, const char *, RRDHOST *, const char *, RRDSET *, RRDDIM *, time_t, time_t, BACKEND_OPTIONS) = NULL;
     int (*backend_response_checker)(BUFFER *) = NULL;
 
     // ------------------------------------------------------------------------
@@ -557,35 +554,39 @@ void *backends_main(void *ptr) {
             .tv_sec = 0,
             .tv_usec = 0
     };
-    int enabled             = config_get_boolean(CONFIG_SECTION_BACKEND, "enabled", 0);
-    const char *source      = config_get(CONFIG_SECTION_BACKEND, "data source", "average");
-    const char *type        = config_get(CONFIG_SECTION_BACKEND, "type", "graphite");
-    const char *destination = config_get(CONFIG_SECTION_BACKEND, "destination", "localhost");
-    backend_prefix          = config_get(CONFIG_SECTION_BACKEND, "prefix", "netdata");
-    const char *hostname    = config_get(CONFIG_SECTION_BACKEND, "hostname", localhost->hostname);
-    backend_update_every    = (int)config_get_number(CONFIG_SECTION_BACKEND, "update every", backend_update_every);
-    int buffer_on_failures  = (int)config_get_number(CONFIG_SECTION_BACKEND, "buffer on failures", 10);
-    long timeoutms          = config_get_number(CONFIG_SECTION_BACKEND, "timeout ms", backend_update_every * 2 * 1000);
-    backend_send_names      = config_get_boolean(CONFIG_SECTION_BACKEND, "send names instead of ids", backend_send_names);
+    int enabled                 = config_get_boolean(CONFIG_SECTION_BACKEND, "enabled", 0);
+    const char *source          = config_get(CONFIG_SECTION_BACKEND, "data source", "average");
+    const char *type            = config_get(CONFIG_SECTION_BACKEND, "type", "graphite");
+    const char *destination     = config_get(CONFIG_SECTION_BACKEND, "destination", "localhost");
+    global_backend_prefix       = config_get(CONFIG_SECTION_BACKEND, "prefix", "netdata");
+    const char *hostname        = config_get(CONFIG_SECTION_BACKEND, "hostname", localhost->hostname);
+    global_backend_update_every = (int)config_get_number(CONFIG_SECTION_BACKEND, "update every", global_backend_update_every);
+    int buffer_on_failures      = (int)config_get_number(CONFIG_SECTION_BACKEND, "buffer on failures", 10);
+    long timeoutms              = config_get_number(CONFIG_SECTION_BACKEND, "timeout ms", global_backend_update_every * 2 * 1000);
+
+    if(config_get_boolean(CONFIG_SECTION_BACKEND, "send names instead of ids", (global_backend_options & BACKEND_OPTION_SEND_NAMES)))
+        global_backend_options |= BACKEND_OPTION_SEND_NAMES;
+    else
+        global_backend_options &= ~BACKEND_OPTION_SEND_NAMES;
 
     charts_pattern = simple_pattern_create(config_get(CONFIG_SECTION_BACKEND, "send charts matching", "*"), NULL, SIMPLE_PATTERN_EXACT);
-    hosts_pattern = simple_pattern_create(config_get(CONFIG_SECTION_BACKEND, "send hosts matching", "localhost *"), NULL, SIMPLE_PATTERN_EXACT);
+    hosts_pattern  = simple_pattern_create(config_get(CONFIG_SECTION_BACKEND, "send hosts matching", "localhost *"), NULL, SIMPLE_PATTERN_EXACT);
 
 
     // ------------------------------------------------------------------------
     // validate configuration options
     // and prepare for sending data to our backend
 
-    backend_options = backend_parse_data_source(source, backend_options);
+    global_backend_options = backend_parse_data_source(source, global_backend_options);
 
     if(timeoutms < 1) {
-        error("BACKEND: invalid timeout %ld ms given. Assuming %d ms.", timeoutms, backend_update_every * 2 * 1000);
-        timeoutms = backend_update_every * 2 * 1000;
+        error("BACKEND: invalid timeout %ld ms given. Assuming %d ms.", timeoutms, global_backend_update_every * 2 * 1000);
+        timeoutms = global_backend_update_every * 2 * 1000;
     }
     timeout.tv_sec  = (timeoutms * 1000) / 1000000;
     timeout.tv_usec = (timeoutms * 1000) % 1000000;
 
-    if(!enabled || backend_update_every < 1)
+    if(!enabled || global_backend_update_every < 1)
         goto cleanup;
 
     // ------------------------------------------------------------------------
@@ -596,7 +597,7 @@ void *backends_main(void *ptr) {
         default_port = 2003;
         backend_response_checker = process_graphite_response;
 
-        if((backend_options & BACKEND_SOURCE_BITS) == BACKEND_SOURCE_DATA_AS_COLLECTED)
+        if(BACKEND_OPTIONS_DATA_SOURCE(global_backend_options) == BACKEND_SOURCE_DATA_AS_COLLECTED)
             backend_request_formatter = format_dimension_collected_graphite_plaintext;
         else
             backend_request_formatter = format_dimension_stored_graphite_plaintext;
@@ -607,7 +608,7 @@ void *backends_main(void *ptr) {
         default_port = 4242;
         backend_response_checker = process_opentsdb_response;
 
-        if((backend_options & BACKEND_SOURCE_BITS) == BACKEND_SOURCE_DATA_AS_COLLECTED)
+        if(BACKEND_OPTIONS_DATA_SOURCE(global_backend_options) == BACKEND_SOURCE_DATA_AS_COLLECTED)
             backend_request_formatter = format_dimension_collected_opentsdb_telnet;
         else
             backend_request_formatter = format_dimension_stored_opentsdb_telnet;
@@ -618,7 +619,7 @@ void *backends_main(void *ptr) {
         default_port = 5448;
         backend_response_checker = process_json_response;
 
-        if ((backend_options & BACKEND_SOURCE_BITS) == BACKEND_SOURCE_DATA_AS_COLLECTED)
+        if (BACKEND_OPTIONS_DATA_SOURCE(global_backend_options) == BACKEND_SOURCE_DATA_AS_COLLECTED)
             backend_request_formatter = format_dimension_collected_json_plaintext;
         else
             backend_request_formatter = format_dimension_stored_json_plaintext;
@@ -655,18 +656,18 @@ void *backends_main(void *ptr) {
             chart_backend_reconnects = 0,
             chart_backend_latency = 0;
 
-    RRDSET *chart_metrics = rrdset_create_localhost("netdata", "backend_metrics", NULL, "backend", NULL, "Netdata Buffered Metrics", "metrics", "backends", NULL, 130600, backend_update_every, RRDSET_TYPE_LINE);
+    RRDSET *chart_metrics = rrdset_create_localhost("netdata", "backend_metrics", NULL, "backend", NULL, "Netdata Buffered Metrics", "metrics", "backends", NULL, 130600, global_backend_update_every, RRDSET_TYPE_LINE);
     rrddim_add(chart_metrics, "buffered", NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_metrics, "lost",     NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_metrics, "sent",     NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
 
-    RRDSET *chart_bytes = rrdset_create_localhost("netdata", "backend_bytes", NULL, "backend", NULL, "Netdata Backend Data Size", "KB", "backends", NULL, 130610, backend_update_every, RRDSET_TYPE_AREA);
+    RRDSET *chart_bytes = rrdset_create_localhost("netdata", "backend_bytes", NULL, "backend", NULL, "Netdata Backend Data Size", "KB", "backends", NULL, 130610, global_backend_update_every, RRDSET_TYPE_AREA);
     rrddim_add(chart_bytes, "buffered", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_bytes, "lost",     NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_bytes, "sent",     NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_bytes, "received", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
 
-    RRDSET *chart_ops = rrdset_create_localhost("netdata", "backend_ops", NULL, "backend", NULL, "Netdata Backend Operations", "operations", "backends", NULL, 130630, backend_update_every, RRDSET_TYPE_LINE);
+    RRDSET *chart_ops = rrdset_create_localhost("netdata", "backend_ops", NULL, "backend", NULL, "Netdata Backend Operations", "operations", "backends", NULL, 130630, global_backend_update_every, RRDSET_TYPE_LINE);
     rrddim_add(chart_ops, "write",     NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_ops, "discard",   NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     rrddim_add(chart_ops, "reconnect", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
@@ -680,11 +681,11 @@ void *backends_main(void *ptr) {
      *
      * issue #1432 and https://www.softlab.ntua.gr/facilities/documentation/unix/unix-socket-faq/unix-socket-faq-2.html
      *
-    RRDSET *chart_latency = rrdset_create_localhost("netdata", "backend_latency", NULL, "backend", NULL, "Netdata Backend Latency", "ms", "backends", NULL, 130620, backend_update_every, RRDSET_TYPE_AREA);
+    RRDSET *chart_latency = rrdset_create_localhost("netdata", "backend_latency", NULL, "backend", NULL, "Netdata Backend Latency", "ms", "backends", NULL, 130620, global_backend_update_every, RRDSET_TYPE_AREA);
     rrddim_add(chart_latency, "latency",   NULL,  1, 1000, RRD_ALGORITHM_ABSOLUTE);
     */
 
-    RRDSET *chart_rusage = rrdset_create_localhost("netdata", "backend_thread_cpu", NULL, "backend", NULL, "NetData Backend Thread CPU usage", "milliseconds/s", "backends", NULL, 130630, backend_update_every, RRDSET_TYPE_STACKED);
+    RRDSET *chart_rusage = rrdset_create_localhost("netdata", "backend_thread_cpu", NULL, "backend", NULL, "NetData Backend Thread CPU usage", "milliseconds/s", "backends", NULL, 130630, global_backend_update_every, RRDSET_TYPE_STACKED);
     rrddim_add(chart_rusage, "user",   NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
     rrddim_add(chart_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
 
@@ -692,9 +693,9 @@ void *backends_main(void *ptr) {
     // ------------------------------------------------------------------------
     // prepare the backend main loop
 
-    info("BACKEND: configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, backend_update_every, hostname, backend_prefix);
+    info("BACKEND: configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, global_backend_update_every, hostname, global_backend_prefix);
 
-    usec_t step_ut = backend_update_every * USEC_PER_SEC;
+    usec_t step_ut = global_backend_update_every * USEC_PER_SEC;
     time_t after = now_realtime_sec();
     int failures = 0;
     heartbeat_t hb;
@@ -747,7 +748,7 @@ void *backends_main(void *ptr) {
 
             RRDSET *st;
             rrdset_foreach_read(st, host) {
-                if(likely(backends_can_send_rrdset(backend_options, st))) {
+                if(likely(backends_can_send_rrdset(global_backend_options, st))) {
                     rrdset_rdlock(st);
 
                     count_charts++;
@@ -755,7 +756,7 @@ void *backends_main(void *ptr) {
                     RRDDIM *rd;
                     rrddim_foreach_read(rd, st) {
                         if (likely(rd->last_collected_time.tv_sec >= after)) {
-                            chart_buffered_metrics += backend_request_formatter(b, backend_prefix, host, __hostname, st, rd, after, before, backend_options);
+                            chart_buffered_metrics += backend_request_formatter(b, global_backend_prefix, host, __hostname, st, rd, after, before, global_backend_options);
                             count_dims++;
                         }
                         else {

--- a/src/backends.h
+++ b/src/backends.h
@@ -2,21 +2,27 @@
 #ifndef NETDATA_BACKENDS_H
 #define NETDATA_BACKENDS_H 1
 
-#define BACKEND_SOURCE_DATA_AS_COLLECTED 0x00000001
-#define BACKEND_SOURCE_DATA_AVERAGE      0x00000002
-#define BACKEND_SOURCE_DATA_SUM          0x00000004
+typedef enum backend_options {
+    BACKEND_OPTION_NONE              = 0,
 
-#define BACKEND_SOURCE_BITS (BACKEND_SOURCE_DATA_AS_COLLECTED|BACKEND_SOURCE_DATA_AVERAGE|BACKEND_SOURCE_DATA_SUM)
+    BACKEND_SOURCE_DATA_AS_COLLECTED = (1 << 0),
+    BACKEND_SOURCE_DATA_AVERAGE      = (1 << 1),
+    BACKEND_SOURCE_DATA_SUM          = (1 << 2),
 
-extern int backend_send_names;
-extern int backend_update_every;
-extern uint32_t backend_options;
-extern const char *backend_prefix;
+    BACKEND_OPTION_SEND_NAMES        = (1 << 16)
+} BACKEND_OPTIONS;
+
+#define BACKEND_OPTIONS_SOURCE_BITS (BACKEND_SOURCE_DATA_AS_COLLECTED|BACKEND_SOURCE_DATA_AVERAGE|BACKEND_SOURCE_DATA_SUM)
+#define BACKEND_OPTIONS_DATA_SOURCE(backend_options) (backend_options & BACKEND_OPTIONS_SOURCE_BITS)
+
+extern int global_backend_update_every;
+extern BACKEND_OPTIONS global_backend_options;
+extern const char *global_backend_prefix;
 
 extern void *backends_main(void *ptr);
 
-extern int backends_can_send_rrdset(uint32_t options, RRDSET *st);
-extern uint32_t backend_parse_data_source(const char *source, uint32_t mode);
+extern int backends_can_send_rrdset(BACKEND_OPTIONS options, RRDSET *st);
+extern BACKEND_OPTIONS backend_parse_data_source(const char *source, BACKEND_OPTIONS mode);
 
 extern calculated_number backend_calculate_value_from_stored_data(
         RRDSET *st                  // the chart

--- a/src/health.c
+++ b/src/health.c
@@ -522,6 +522,11 @@ void *health_main(void *ptr) {
                         );
 
                         rc->value = rc->calculation->result;
+
+                        if(rc->local) rc->local->last_updated = now;
+                        if(rc->family) rc->family->last_updated = now;
+                        if(rc->hostid) rc->hostid->last_updated = now;
+                        if(rc->hostname) rc->hostname->last_updated = now;
                     }
                 }
             }

--- a/src/health.h
+++ b/src/health.h
@@ -15,10 +15,14 @@ typedef enum rrdvar_type {
 } RRDVAR_TYPE;
 
 typedef enum rrdvar_options {
-    RRDVAR_OPTION_DEFAULT          = 0,
-    RRDVAR_OPTION_ALLOCATED        = (1 << 0), // the value ptr is allocated (not a reference)
-    RRDVAR_OPTION_CUSTOM_HOST_VAR  = (1 << 1), // this is a custom host variable, not associated with a dimension
-    RRDVAR_OPTION_CUSTOM_CHART_VAR = (1 << 2)  // this is a custom chart variable, not associated with a dimension
+    RRDVAR_OPTION_DEFAULT                    = 0,
+    RRDVAR_OPTION_ALLOCATED                  = (1 << 0), // the value ptr is allocated (not a reference)
+    RRDVAR_OPTION_CUSTOM_HOST_VAR            = (1 << 1), // this is a custom host variable, not associated with a dimension
+    RRDVAR_OPTION_CUSTOM_CHART_VAR           = (1 << 2), // this is a custom chart variable, not associated with a dimension
+    RRDVAR_OPTION_RRDCALC_LOCAL_VAR          = (1 << 3), // this is a an alarm variable, attached to a chart
+    RRDVAR_OPTION_RRDCALC_FAMILY_VAR         = (1 << 4), // this is a an alarm variable, attached to a family
+    RRDVAR_OPTION_RRDCALC_HOST_CHARTID_VAR   = (1 << 5), // this is a an alarm variable, attached to the host, using the chart id
+    RRDVAR_OPTION_RRDCALC_HOST_CHARTNAME_VAR = (1 << 6), // this is a an alarm variable, attached to the host, using the chart name
 } RRDVAR_OPTIONS;
 
 // the variables as stored in the variables indexes

--- a/src/health.h
+++ b/src/health.h
@@ -369,9 +369,12 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);
 
 extern RRDVAR *rrdvar_custom_host_variable_create(RRDHOST *host, const char *name);
 extern void rrdvar_custom_host_variable_set(RRDHOST *host, RRDVAR *rv, calculated_number value);
+extern calculated_number rrdvar_custom_host_variable_get(RRDHOST *host, RRDVAR *rv);
+extern int foreach_host_variable_callback(RRDHOST *host, int (*callback)(RRDVAR *rv, void *data), void *data);
 
 extern RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name);
 extern void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rv, calculated_number value);
+extern calculated_number rrdsetvar_custom_chart_variable_get(RRDSETVAR *rv);
 
 extern void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock);
 

--- a/src/health.h
+++ b/src/health.h
@@ -15,10 +15,10 @@ typedef enum rrdvar_type {
 } RRDVAR_TYPE;
 
 typedef enum rrdvar_options {
-    RRDVAR_OPTION_DEFAULT          = (0 << 0),
+    RRDVAR_OPTION_DEFAULT          = 0,
     RRDVAR_OPTION_ALLOCATED        = (1 << 0), // the value ptr is allocated (not a reference)
-    RRDVAR_OPTION_CUSTOM_HOST_VAR  = (2 << 0), // this is a custom host variable, not associated with a dimension
-    RRDVAR_OPTION_CUSTOM_CHART_VAR = (3 << 0)  // this is a custom chart variable, not associated with a dimension
+    RRDVAR_OPTION_CUSTOM_HOST_VAR  = (1 << 1), // this is a custom host variable, not associated with a dimension
+    RRDVAR_OPTION_CUSTOM_CHART_VAR = (1 << 2)  // this is a custom chart variable, not associated with a dimension
 } RRDVAR_OPTIONS;
 
 // the variables as stored in the variables indexes

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -167,7 +167,7 @@ int do_ipc(int update_every, usec_t dt) {
     static int initialized = 0, read_limits_next = -1;
     static struct ipc_limits limits;
     static struct ipc_status status;
-    static RRDSETVAR *arrays_max = NULL, *semaphores_max = NULL;
+    static RRDVAR *arrays_max = NULL, *semaphores_max = NULL;
     static RRDSET *st_semaphores = NULL, *st_arrays = NULL;
     static RRDDIM *rd_semaphores = NULL, *rd_arrays = NULL;
 
@@ -224,8 +224,8 @@ int do_ipc(int update_every, usec_t dt) {
         }
 
         // variables
-        semaphores_max = rrdsetvar_custom_chart_variable_create(st_semaphores, "ipc.semaphores.max");
-        arrays_max     = rrdsetvar_custom_chart_variable_create(st_arrays, "ipc.semaphores.arrays.max");
+        semaphores_max = rrdvar_custom_host_variable_create(localhost, "ipc_semaphores_max");
+        arrays_max     = rrdvar_custom_host_variable_create(localhost, "ipc_semaphores_arrays_max");
     }
 
     if(unlikely(read_limits_next < 0)) {
@@ -233,8 +233,8 @@ int do_ipc(int update_every, usec_t dt) {
             error("Unable to fetch semaphore limits.");
         }
         else {
-            if(semaphores_max) rrdsetvar_custom_chart_variable_set(semaphores_max, limits.semmns);
-            if(arrays_max)     rrdsetvar_custom_chart_variable_set(arrays_max,     limits.semmni);
+            if(semaphores_max) rrdvar_custom_host_variable_set(localhost, semaphores_max, limits.semmns);
+            if(arrays_max)     rrdvar_custom_host_variable_set(localhost, arrays_max,     limits.semmni);
 
             st_arrays->red = limits.semmni;
             st_semaphores->red = limits.semmns;

--- a/src/proc_net_snmp.c
+++ b/src/proc_net_snmp.c
@@ -103,7 +103,6 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
              *arl_udplite = NULL;
 
     static RRDVAR *tcp_max_connections_var = NULL;
-    static ssize_t last_max_connections = 0;
 
     if(unlikely(!arl_ip)) {
         do_ip_packets       = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp", "ipv4 packets", CONFIG_BOOLEAN_AUTO);
@@ -182,7 +181,7 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
         // arl_expect(arl_tcp, "RtoAlgorithm", &snmp_root.tcp_RtoAlgorithm);
         // arl_expect(arl_tcp, "RtoMin", &snmp_root.tcp_RtoMin);
         // arl_expect(arl_tcp, "RtoMax", &snmp_root.tcp_RtoMax);
-        arl_expect(arl_tcp, "MaxConn", &snmp_root.tcp_MaxConn);
+        arl_expect_custom(arl_tcp, "MaxConn", arl_callback_ssize_t, &snmp_root.tcp_MaxConn);
         arl_expect(arl_tcp, "ActiveOpens", &snmp_root.tcp_ActiveOpens);
         arl_expect(arl_tcp, "PassiveOpens", &snmp_root.tcp_PassiveOpens);
         arl_expect(arl_tcp, "AttemptFails", &snmp_root.tcp_AttemptFails);
@@ -670,10 +669,8 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(snmp_root.tcp_MaxConn != last_max_connections) {
-                last_max_connections = snmp_root.tcp_MaxConn;
-                rrdvar_custom_host_variable_set(localhost, tcp_max_connections_var, last_max_connections);
-            }
+            // this is smart enough to update it, only when it is changed
+            rrdvar_custom_host_variable_set(localhost, tcp_max_connections_var, snmp_root.tcp_MaxConn);
 
             // --------------------------------------------------------------------
 

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -122,7 +122,7 @@ int do_proc_stat(int update_every, usec_t dt) {
     static int do_cpu = -1, do_cpu_cores = -1, do_interrupts = -1, do_context = -1, do_forks = -1, do_processes = -1, do_core_throttle_count = -1, do_package_throttle_count = -1, do_scaling_cur_freq = -1;
     static uint32_t hash_intr, hash_ctxt, hash_processes, hash_procs_running, hash_procs_blocked;
     static char *core_throttle_count_filename = NULL, *package_throttle_count_filename = NULL, *scaling_cur_freq_filename = NULL;
-    static RRDSETVAR *cpus_var = NULL;
+    static RRDVAR *cpus_var = NULL;
     size_t cores_found = (size_t)processors;
 
     if(unlikely(do_cpu == -1)) {
@@ -314,7 +314,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                     rrddim_hide(cpu_chart->st, "idle");
 
                     if(unlikely(core == 0 && cpus_var == NULL))
-                        cpus_var = rrdsetvar_custom_chart_variable_create(cpu_chart->st, "processors");
+                        cpus_var = rrdvar_custom_host_variable_create(localhost, "active_processors");
                 }
                 else rrdset_next(cpu_chart->st);
 
@@ -561,7 +561,7 @@ int do_proc_stat(int update_every, usec_t dt) {
     }
 
     if(cpus_var)
-        rrdsetvar_custom_chart_variable_set(cpus_var, cores_found);
+        rrdvar_custom_host_variable_set(localhost, cpus_var, cores_found);
 
     return 0;
 }

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -104,8 +104,8 @@ typedef struct rrdfamily RRDFAMILY;
 
 typedef enum rrddim_flags {
     RRDDIM_FLAG_NONE                            = 0,
-    RRDDIM_FLAG_HIDDEN                          = 1 << 0,  // this dimension will not be offered to callers
-    RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS = 1 << 1   // do not offer RESET or OVERFLOW info to callers
+    RRDDIM_FLAG_HIDDEN                          = (1 << 0),  // this dimension will not be offered to callers
+    RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS = (1 << 1)   // do not offer RESET or OVERFLOW info to callers
 } RRDDIM_FLAGS;
 
 #ifdef HAVE_C___ATOMIC

--- a/src/rrdcalc.c
+++ b/src/rrdcalc.c
@@ -65,15 +65,18 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
         st->red = rc->red;
     }
 
-    rc->local  = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
-    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
+    rc->local  = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_RRDCALC_LOCAL_VAR, &rc->value);
+    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_RRDCALC_FAMILY_VAR, &rc->value);
 
     char fullname[RRDVAR_MAX_LENGTH + 1];
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->id, rc->name);
-    rc->hostid   = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
+    rc->hostid   = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_RRDCALC_HOST_CHARTID_VAR, &rc->value);
 
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->name, rc->name);
-    rc->hostname = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
+    rc->hostname = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_RRDCALC_HOST_CHARTNAME_VAR, &rc->value);
+
+    if(rc->hostid && !rc->hostname)
+        rc->hostid->options |= RRDVAR_OPTION_RRDCALC_HOST_CHARTNAME_VAR;
 
     if(!rc->units) rc->units = strdupz(st->units);
 

--- a/src/rrdcalc.c
+++ b/src/rrdcalc.c
@@ -65,15 +65,15 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
         st->red = rc->red;
     }
 
-    rc->local  = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
-    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->local  = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
+    rc->family = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rc->name, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
 
     char fullname[RRDVAR_MAX_LENGTH + 1];
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->id, rc->name);
-    rc->hostid   = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->hostid   = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
 
     snprintfz(fullname, RRDVAR_MAX_LENGTH, "%s.%s", st->name, rc->name);
-    rc->hostname = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, &rc->value);
+    rc->hostname = rrdvar_create_and_index("host", &host->rrdvar_root_index, fullname, RRDVAR_TYPE_CALCULATED, RRDVAR_OPTION_DEFAULT, &rc->value);
 
     if(!rc->units) rc->units = strdupz(st->units);
 

--- a/src/rrddimvar.c
+++ b/src/rrddimvar.c
@@ -118,8 +118,8 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $id
     // - $name
 
-    rs->var_local_id           = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_id, rs->type, rs->value);
-    rs->var_local_name         = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_name, rs->type, rs->value);
+    rs->var_local_id           = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_id, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_local_name         = rrdvar_create_and_index("local", &st->rrdvar_root_index, rs->key_name, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
 
     // FAMILY VARIABLES FOR THIS DIMENSION
     // -----------------------------------
@@ -130,10 +130,10 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $chart-context.id
     // - $chart-context.name
 
-    rs->var_family_id          = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_id, rs->type, rs->value);
-    rs->var_family_name        = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_name, rs->type, rs->value);
-    rs->var_family_contextid   = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextid, rs->type, rs->value);
-    rs->var_family_contextname = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextname, rs->type, rs->value);
+    rs->var_family_id          = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_id, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_family_name        = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_name, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_family_contextid   = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextid, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_family_contextname = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_contextname, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
 
     // HOST VARIABLES FOR THIS DIMENSION
     // -----------------------------------
@@ -144,10 +144,10 @@ static inline void rrddimvar_create_variables(RRDDIMVAR *rs) {
     // - $chart-name.id
     // - $chart-name.name
 
-    rs->var_host_chartidid      = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullidid, rs->type, rs->value);
-    rs->var_host_chartidname    = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullidname, rs->type, rs->value);
-    rs->var_host_chartnameid    = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullnameid, rs->type, rs->value);
-    rs->var_host_chartnamename  = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullnamename, rs->type, rs->value);
+    rs->var_host_chartidid      = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullidid, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_host_chartidname    = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullidname, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_host_chartnameid    = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullnameid, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
+    rs->var_host_chartnamename  = rrdvar_create_and_index("host", &host->rrdvar_root_index, rs->key_fullnamename, rs->type, RRDVAR_OPTION_DEFAULT, rs->value);
 }
 
 RRDDIMVAR *rrddimvar_create(RRDDIM *rd, RRDVAR_TYPE type, const char *prefix, const char *suffix, void *value, RRDVAR_OPTIONS options) {

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -245,7 +245,7 @@ static int rrdpush_sender_thread_custom_host_variables_callback(void *rrdvar_ptr
     RRDVAR *rv = (RRDVAR *)rrdvar_ptr;
     RRDHOST *host = (RRDHOST *)host_ptr;
 
-    if(unlikely(rv->options & RRDVAR_OPTION_CUSTOM_HOST_VAR)) {
+    if(unlikely(rv->options & RRDVAR_OPTION_CUSTOM_HOST_VAR && rv->type == RRDVAR_TYPE_CALCULATED)) {
         rrdpush_sender_add_host_variable_to_buffer_nolock(host, rv);
 
         // return 1, so that the traversal will return the number of variables sent

--- a/src/rrdpush.c
+++ b/src/rrdpush.c
@@ -135,7 +135,7 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
     // send the chart local custom variables
     RRDSETVAR *rs;
     for(rs = st->variables; rs ;rs = rs->next) {
-        if(unlikely(rs->options && RRDVAR_OPTION_ALLOCATED)) {
+        if(unlikely(rs->type == RRDVAR_TYPE_CALCULATED && rs->options & RRDVAR_OPTION_CUSTOM_CHART_VAR)) {
             calculated_number *value = (calculated_number *) rs->value;
 
             buffer_sprintf(
@@ -245,7 +245,7 @@ static int rrdpush_sender_thread_custom_host_variables_callback(void *rrdvar_ptr
     RRDVAR *rv = (RRDVAR *)rrdvar_ptr;
     RRDHOST *host = (RRDHOST *)host_ptr;
 
-    if(unlikely(rv->type == RRDVAR_TYPE_CALCULATED_ALLOCATED)) {
+    if(unlikely(rv->options & RRDVAR_OPTION_CUSTOM_HOST_VAR)) {
         rrdpush_sender_add_host_variable_to_buffer_nolock(host, rv);
 
         // return 1, so that the traversal will return the number of variables sent

--- a/src/rrdsetvar.c
+++ b/src/rrdsetvar.c
@@ -182,3 +182,15 @@ void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rs, calculated_number value)
         }
     }
 }
+
+calculated_number rrdsetvar_custom_chart_variable_get(RRDSETVAR *rs) {
+    if(unlikely(!(rs->options & RRDVAR_OPTION_ALLOCATED))) {
+        error("RRDSETVAR: requested to get variable '%s' of chart '%s' on host '%s' but the variable is not a custom one.", rs->variable, rs->rrdset->id, rs->rrdset->rrdhost->hostname);
+    }
+    else {
+        calculated_number *v = rs->value;
+        return *v;
+    }
+
+    return NAN;
+}

--- a/src/rrdsetvar.c
+++ b/src/rrdsetvar.c
@@ -44,6 +44,10 @@ static inline void rrdsetvar_create_variables(RRDSETVAR *rs) {
     RRDSET *st = rs->rrdset;
     RRDHOST *host = st->rrdhost;
 
+    RRDVAR_OPTIONS options = rs->options;
+    if(rs->options & RRDVAR_OPTION_ALLOCATED)
+        options &= ~ RRDVAR_OPTION_ALLOCATED;
+
     // ------------------------------------------------------------------------
     // free the old ones (if any)
 
@@ -61,17 +65,17 @@ static inline void rrdsetvar_create_variables(RRDSETVAR *rs) {
 
     // ------------------------------------------------------------------------
     // CHART
-    rs->var_local       = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rs->variable, rs->type, rs->value);
+    rs->var_local       = rrdvar_create_and_index("local",  &st->rrdvar_root_index, rs->variable, rs->type, options, rs->value);
 
     // ------------------------------------------------------------------------
     // FAMILY
-    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullid,   rs->type, rs->value);
-    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullname, rs->type, rs->value);
+    rs->var_family      = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullid,   rs->type, options, rs->value);
+    rs->var_family_name = rrdvar_create_and_index("family", &st->rrdfamily->rrdvar_root_index, rs->key_fullname, rs->type, options, rs->value);
 
     // ------------------------------------------------------------------------
     // HOST
-    rs->var_host        = rrdvar_create_and_index("host",   &host->rrdvar_root_index, rs->key_fullid,   rs->type, rs->value);
-    rs->var_host_name   = rrdvar_create_and_index("host",   &host->rrdvar_root_index, rs->key_fullname, rs->type, rs->value);
+    rs->var_host        = rrdvar_create_and_index("host",   &host->rrdvar_root_index, rs->key_fullid,   rs->type, options, rs->value);
+    rs->var_host_name   = rrdvar_create_and_index("host",   &host->rrdvar_root_index, rs->key_fullname, rs->type, options, rs->value);
 }
 
 RRDSETVAR *rrdsetvar_create(RRDSET *st, const char *variable, RRDVAR_TYPE type, void *value, RRDVAR_OPTIONS options) {
@@ -144,7 +148,7 @@ RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name) 
     for(rs = st->variables; rs ; rs = rs->next) {
         if(hash == rs->hash && strcmp(n, rs->variable) == 0) {
             rrdset_unlock(st);
-            if(rs->options & RRDVAR_OPTION_ALLOCATED) {
+            if(rs->options & RRDVAR_OPTION_CUSTOM_CHART_VAR) {
                 free(n);
                 return rs;
             }
@@ -161,7 +165,7 @@ RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name) 
     calculated_number *v = mallocz(sizeof(calculated_number));
     *v = NAN;
 
-    rs = rrdsetvar_create(st, n, RRDVAR_TYPE_CALCULATED, v, RRDVAR_OPTION_ALLOCATED);
+    rs = rrdsetvar_create(st, n, RRDVAR_TYPE_CALCULATED, v, RRDVAR_OPTION_ALLOCATED|RRDVAR_OPTION_CUSTOM_CHART_VAR);
     rrdset_unlock(st);
 
     free(n);
@@ -169,8 +173,8 @@ RRDSETVAR *rrdsetvar_custom_chart_variable_create(RRDSET *st, const char *name) 
 }
 
 void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rs, calculated_number value) {
-    if(unlikely(!(rs->options & RRDVAR_OPTION_ALLOCATED))) {
-        error("RRDSETVAR: requested to set variable '%s' of chart '%s' on host '%s' to value " CALCULATED_NUMBER_FORMAT " but the variable is not a custom one.", rs->variable, rs->rrdset->id, rs->rrdset->rrdhost->hostname, value);
+    if(rs->type != RRDVAR_TYPE_CALCULATED || !(rs->options & RRDVAR_OPTION_CUSTOM_CHART_VAR) || !(rs->options & RRDVAR_OPTION_ALLOCATED)) {
+        error("RRDSETVAR: requested to set variable '%s' of chart '%s' on host '%s' to value " CALCULATED_NUMBER_FORMAT " but the variable is not a custom chart one.", rs->variable, rs->rrdset->id, rs->rrdset->rrdhost->hostname, value);
     }
     else {
         calculated_number *v = rs->value;
@@ -181,16 +185,4 @@ void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rs, calculated_number value)
             rrdset_flag_clear(rs->rrdset, RRDSET_FLAG_EXPOSED_UPSTREAM);
         }
     }
-}
-
-calculated_number rrdsetvar_custom_chart_variable_get(RRDSETVAR *rs) {
-    if(unlikely(!(rs->options & RRDVAR_OPTION_ALLOCATED))) {
-        error("RRDSETVAR: requested to get variable '%s' of chart '%s' on host '%s' but the variable is not a custom one.", rs->variable, rs->rrdset->id, rs->rrdset->rrdhost->hostname);
-    }
-    else {
-        calculated_number *v = rs->value;
-        return *v;
-    }
-
-    return NAN;
 }

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -261,7 +261,7 @@ struct prometheus_output_options {
         { "types",      PROMETHEUS_OUTPUT_TYPES      },
         { "names",      PROMETHEUS_OUTPUT_NAMES      },
         { "timestamps", PROMETHEUS_OUTPUT_TIMESTAMPS },
-        { "variables",  PROMETHEUS_OUTPUT_VARIABLES   },
+        { "variables",  PROMETHEUS_OUTPUT_VARIABLES  },
 
         // terminator
         { NULL, PROMETHEUS_OUTPUT_NONE },

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -253,12 +253,26 @@ inline int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w,
     return 200;
 }
 
+struct prometheus_output_options {
+    char *name;
+    PROMETHEUS_OUTPUT_OPTIONS flag;
+} prometheus_output_flags_root[] = {
+        { "help",       PROMETHEUS_OUTPUT_HELP       },
+        { "types",      PROMETHEUS_OUTPUT_TYPES      },
+        { "names",      PROMETHEUS_OUTPUT_NAMES      },
+        { "timestamps", PROMETHEUS_OUTPUT_TIMESTAMPS },
+        { "variables",  PROMETHEUS_OUTPUT_VARIABLES   },
+
+        // terminator
+        { NULL, PROMETHEUS_OUTPUT_NONE },
+};
+
 inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url) {
     int format = ALLMETRICS_SHELL;
-    int help = 0, types = 0, timestamps = 1, names = backend_send_names; // prometheus options
     const char *prometheus_server = w->client_ip;
-    uint32_t prometheus_options = backend_options;
-    const char *prometheus_prefix = backend_prefix;
+    uint32_t prometheus_backend_options = global_backend_options;
+    PROMETHEUS_OUTPUT_OPTIONS prometheus_output_options = PROMETHEUS_OUTPUT_TIMESTAMPS | ((global_backend_options & BACKEND_OPTION_SEND_NAMES)?PROMETHEUS_OUTPUT_NAMES:0);
+    const char *prometheus_prefix = global_backend_prefix;
 
     while(url) {
         char *value = mystrsep(&url, "?&");
@@ -280,30 +294,6 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
             else
                 format = 0;
         }
-        else if(!strcmp(name, "help")) {
-            if(!strcmp(value, "yes"))
-                help = 1;
-            else
-                help = 0;
-        }
-        else if(!strcmp(name, "types")) {
-            if(!strcmp(value, "yes"))
-                types = 1;
-            else
-                types = 0;
-        }
-        else if(!strcmp(name, "names")) {
-            if(!strcmp(value, "yes"))
-                names = 1;
-            else
-                names = 0;
-        }
-        else if(!strcmp(name, "timestamps")) {
-            if(!strcmp(value, "yes"))
-                timestamps = 1;
-            else
-                timestamps = 0;
-        }
         else if(!strcmp(name, "server")) {
             prometheus_server = value;
         }
@@ -311,7 +301,20 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
             prometheus_prefix = value;
         }
         else if(!strcmp(name, "data") || !strcmp(name, "source") || !strcmp(name, "data source") || !strcmp(name, "data-source") || !strcmp(name, "data_source") || !strcmp(name, "datasource")) {
-            prometheus_options = backend_parse_data_source(value, prometheus_options);
+            prometheus_backend_options = backend_parse_data_source(value, prometheus_backend_options);
+        }
+        else {
+            int i;
+            for(i = 0; prometheus_output_flags_root[i].name ; i++) {
+                if(!strcmp(name, prometheus_output_flags_root[i].name)) {
+                    if(!strcmp(value, "yes") || !strcmp(value, "1") || !strcmp(value, "true"))
+                        prometheus_output_options |= prometheus_output_flags_root[i].flag;
+                    else
+                        prometheus_output_options &= ~prometheus_output_flags_root[i].flag;
+
+                    break;
+                }
+            }
         }
     }
 
@@ -331,12 +334,12 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
 
         case ALLMETRICS_PROMETHEUS:
             w->response.data->contenttype = CT_PROMETHEUS;
-            rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_options, help, types, names, timestamps);
+            rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_backend_options, prometheus_output_options);
             return 200;
 
         case ALLMETRICS_PROMETHEUS_ALL_HOSTS:
             w->response.data->contenttype = CT_PROMETHEUS;
-            rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_options, help, types, names, timestamps);
+            rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_backend_options, prometheus_backend_options);
             return 200;
 
         default:


### PR DESCRIPTION
fixes #4035

This PR will send netdata global host variables to prometheus, like this:

```
# COMMENT global host and chart variables
netdata_active_processors 8.0000000 1537055890000
netdata_ipc_semaphores_arrays_max 32000.0000000 1537055892000
netdata_tcp_mem_high 2615664.0000000 1537055891000
netdata_tcp_max_connections -1.0000000 1537055891000
netdata_ipc_semaphores_max 1024000000.0000000 1537055892000
netdata_netfilter_conntrack_max 262144.0000000 1537055891000
netdata_tcp_max_orphans 131072.0000000 1537055891000
netdata_tcp_mem_pressure 1743788.0000000 1537055891000
netdata_tcp_mem_low 1307832.0000000 1537055891000
```

netdata now maintains the timestamp of the last time these variables were changed (not the timestamp they were just refreshed with the same value). This is the timestamp sent to prometheus.

Keep in mind netdata maintains chart variables too. We don't send them to prometheus. This PR converted all internal chart variables to host variables.
@l2isbad could you please check if you send any chart variables?

This PR also unifies a bit host variables naming. Prior to this PR a few variables had `.` in them and others had `_`. Now all have `_`. Updated the alarms too. @l2isbad could you please check the names of the variables you send.

This PR fixes 2 bugs:

1. The logic the set `tcp_max_connections` was faulty. This variable was never set.
2. The logic that parsed `tcp_max_connections` was parsing it as unsigned, but it is signed (the kernel sets it to `-1` to indicate there is no limit).
