### PR TITLE
Disable IPFS Pin API

### DIFF
--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -39,10 +39,6 @@
 # This feature is disabled by default.
 # autodetection_retry: 0
 
-# Disable/Enable IPFS pin api
-# Currently defaults to disabled due to IPFS Bug(https://github.com/ipfs/go-ipfs/issues/3874) resulting in very high CPU Usage
-# pinapi: False
-
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)
 #
@@ -68,11 +64,16 @@
 # Additionally to the above, ipfs also supports the following:
 #
 #     url: 'URL'       # URL to the IPFS API
+#     pinapi: False    # Set status of IPFS pinned object polling
+#                      # Currently defaults to disabled due to IPFS Bug
+#                      # https://github.com/ipfs/go-ipfs/issues/3874
+#                      # resulting in very high CPU Usage
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 # only one of them will run (they have the same name)
 
 localhost:
-  name : 'local'
-  url  : 'http://localhost:5001'
+  name   : 'local'
+  url    : 'http://localhost:5001'
+  pinapi : False

--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -40,7 +40,7 @@
 # autodetection_retry: 0
 
 # Disable/Enable IPFS pin api
-# Currently defaults to disabled due to IPFS Bug resulting in very high CPU Usage
+# Currently defaults to disabled due to IPFS Bug(https://github.com/ipfs/go-ipfs/issues/3874) resulting in very high CPU Usage
 # pinapi: 0
 
 # ----------------------------------------------------------------------

--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -39,6 +39,10 @@
 # This feature is disabled by default.
 # autodetection_retry: 0
 
+# Disable/Enable IPFS pin api
+# Currently defaults to disabled due to IPFS Bug resulting in very high CPU Usage
+# pinapi: 0
+
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)
 #

--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -41,7 +41,7 @@
 
 # Disable/Enable IPFS pin api
 # Currently defaults to disabled due to IPFS Bug(https://github.com/ipfs/go-ipfs/issues/3874) resulting in very high CPU Usage
-# pinapi: True
+# pinapi: False
 
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)

--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -41,7 +41,7 @@
 
 # Disable/Enable IPFS pin api
 # Currently defaults to disabled due to IPFS Bug(https://github.com/ipfs/go-ipfs/issues/3874) resulting in very high CPU Usage
-# pinapi: 0
+# pinapi: True
 
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)

--- a/conf.d/python.d/ipfs.conf
+++ b/conf.d/python.d/ipfs.conf
@@ -64,7 +64,7 @@
 # Additionally to the above, ipfs also supports the following:
 #
 #     url: 'URL'       # URL to the IPFS API
-#     pinapi: False    # Set status of IPFS pinned object polling
+#     pinapi: no       # Set status of IPFS pinned object polling
 #                      # Currently defaults to disabled due to IPFS Bug
 #                      # https://github.com/ipfs/go-ipfs/issues/3874
 #                      # resulting in very high CPU Usage
@@ -76,4 +76,4 @@
 localhost:
   name   : 'local'
   url    : 'http://localhost:5001'
-  pinapi : False
+  pinapi : no

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -11,7 +11,6 @@ from bases.FrameworkServices.UrlService import UrlService
 # update_every = 2
 priority = 60000
 retries = 60
-pinapi = False
 
 # default job configuration (overridden by python.d.plugin)
 # config = {'local': {
@@ -113,7 +112,7 @@ class Service(UrlService):
             '/api/v0/stats/repo':
                 [('size', 'RepoSize', int), ('objects', 'NumObjects', int), ('avail', 'StorageMax', self._storagemax)],
         }
-        if pinapi:
+        if self.do_pinapi:
                 cfg.update({
                     '/api/v0/pin/ls':
                         [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -110,8 +110,8 @@ class Service(UrlService):
                 [('peers', 'Peers', len)],
             '/api/v0/stats/repo':
                 [('size', 'RepoSize', int), ('objects', 'NumObjects', int), ('avail', 'StorageMax', self._storagemax)],
-            '/api/v0/pin/ls':
-                [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]
+#            '/api/v0/pin/ls':
+#                [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]
         }
         r = dict()
         for suburl in cfg:

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -11,7 +11,7 @@ from bases.FrameworkServices.UrlService import UrlService
 # update_every = 2
 priority = 60000
 retries = 60
-pinapi = 0
+pinapi = False
 
 # default job configuration (overridden by python.d.plugin)
 # config = {'local': {
@@ -62,6 +62,7 @@ class Service(UrlService):
         self.order = ORDER
         self.definitions = CHARTS
         self.__storage_max = None
+        self.do_pinapi = self.configuration.get('pinapi')
 
     def _get_json(self, sub_url):
         """
@@ -112,7 +113,7 @@ class Service(UrlService):
             '/api/v0/stats/repo':
                 [('size', 'RepoSize', int), ('objects', 'NumObjects', int), ('avail', 'StorageMax', self._storagemax)],
         }
-        if pinapi == 1:
+        if pinapi:
                 cfg.update({
                     '/api/v0/pin/ls':
                         [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -11,6 +11,7 @@ from bases.FrameworkServices.UrlService import UrlService
 # update_every = 2
 priority = 60000
 retries = 60
+pinapi = 0
 
 # default job configuration (overridden by python.d.plugin)
 # config = {'local': {
@@ -110,9 +111,12 @@ class Service(UrlService):
                 [('peers', 'Peers', len)],
             '/api/v0/stats/repo':
                 [('size', 'RepoSize', int), ('objects', 'NumObjects', int), ('avail', 'StorageMax', self._storagemax)],
-#            '/api/v0/pin/ls':
-#                [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]
         }
+        if pinapi == 1:
+                cfg.update({
+                    '/api/v0/pin/ls':
+                        [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]
+                })
         r = dict()
         for suburl in cfg:
             in_json = self._get_json(suburl)


### PR DESCRIPTION
Disabling pin api due to ipfs performance issues with larger object Storage.
Propable fix for #3156 while ipfs has not solved this issue (go-ipfs issue [#3874](https://github.com/ipfs/go-ipfs/issues/3874))