### PR TITLE
Fix LGTM complaints in monit module.

### DIFF
--- a/python.d/monit.chart.py
+++ b/python.d/monit.chart.py
@@ -128,7 +128,7 @@ class Service(UrlService):
                 if service_category == 'process':
                     for subnode in ('uptime', 'threads', 'children'):
                         subnode_value = service_node.find(subnode)
-                        if subnode_value == None:
+                        if subnode_value is None:
                             continue
                         if subnode == 'uptime' and int(subnode_value.text) < 0:
                             self.debug('Skipping bugged metrics with negative uptime (monit before v5.16')
@@ -140,7 +140,7 @@ class Service(UrlService):
 
                 if service_category == 'host':
                     subnode_value = service_node.find('./icmp/responsetime')
-                    if subnode_value == None:
+                    if subnode_value is None:
                         continue
                     dimension_key = 'host_latency_{0}'.format(service_name)
                     if dimension_key not in self.charts['host_latency']:


### PR DESCRIPTION
LGTM (correctly) complains about usage of the equality operator for checking if a value is None.  This commit updates the two remaining instances of this in our Python code to instead use the identity operator, thus removing two 'errors' reported by LGTM.

This changes no actual functionality of the monit module.