### PR TITLE
Fix missing comma in couchdb module.

### DIFF
--- a/python.d/couchdb.chart.py
+++ b/python.d/couchdb.chart.py
@@ -25,7 +25,7 @@ METHODS = namedtuple('METHODS', ['get_data', 'url', 'stats'])
 OVERVIEW_STATS = [
     'couchdb.database_reads.value',
     'couchdb.database_writes.value',
-    'couchdb.httpd.view_reads.value'
+    'couchdb.httpd.view_reads.value',
     'couchdb.httpd_request_methods.COPY.value',
     'couchdb.httpd_request_methods.DELETE.value',
     'couchdb.httpd_request_methods.GET.value',


### PR DESCRIPTION
Originally found by LGTM checks.

WHile I can't test this myself, it seems pretty obvious to me that this is indeed an error and not a case of intentional implicit string concatenation.