### PR TITLE
Added -NoLog parameter for megacli calls

### DIFF
--- a/python.d/megacli.chart.py
+++ b/python.d/megacli.chart.py
@@ -166,8 +166,8 @@ class Megacli:
         self.s = find_binary('sudo')
         self.m = find_binary('megacli')
         self.sudo_check = [self.s, '-n', '-v']
-        self.disk_info = [self.s, '-n', self.m, '-LDPDInfo', '-aAll']
-        self.battery_info = [self.s, '-n', self.m, '-AdpBbuCmd', '-a0']
+        self.disk_info = [self.s, '-n', self.m, '-LDPDInfo', '-aAll', '-NoLog']
+        self.battery_info = [self.s, '-n', self.m, '-AdpBbuCmd', '-a0', '-NoLog']
 
     def __bool__(self):
         return bool(self.s and self.m)


### PR DESCRIPTION
Running `megacli` without the `-NoLog` parameter leads to generating a `MegaSAS.log` file in the current working directory (for me it is `/etc/netdata/MegaSAS.log`). The file is growing really fast because it is appended after every `megacli `call.