### PR TITLE
fixed typo in prometheus_all_hosts output

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -38,7 +38,7 @@ make clean || exit 1
 echo >&2 "Compressing data..."
 tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 
-echo >&2 "Sending analysis..."
+echo >&2 "Sending analysis for version ${version} ..."
 curl --progress-bar --form token="${token}" \
   --form email=costa@tsaousis.gr \
   --form file=@netdata-coverity-analysis.tgz \

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -335,12 +335,26 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
 
         case ALLMETRICS_PROMETHEUS:
             w->response.data->contenttype = CT_PROMETHEUS;
-            rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_backend_options, prometheus_output_options);
+            rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(
+                    host
+                    , w->response.data
+                    , prometheus_server
+                    , prometheus_prefix
+                    , prometheus_backend_options
+                    , prometheus_output_options
+                    );
             return 200;
 
         case ALLMETRICS_PROMETHEUS_ALL_HOSTS:
             w->response.data->contenttype = CT_PROMETHEUS;
-            rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(host, w->response.data, prometheus_server, prometheus_prefix, prometheus_backend_options, prometheus_backend_options);
+            rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(
+                    host
+                    , w->response.data
+                    , prometheus_server
+                    , prometheus_prefix
+                    , prometheus_backend_options
+                    , prometheus_output_options
+                    );
             return 200;
 
         default:


### PR DESCRIPTION
This little typo, probably messed a bit the output options for `prometheus_all_hosts`.

Identified by coverity scan.